### PR TITLE
Docs: Store Interaction History README — optional Email Agent drafts (GAS)

### DIFF
--- a/google_app_scripts/holistic_hit_list_store_history/README.md
+++ b/google_app_scripts/holistic_hit_list_store_history/README.md
@@ -57,3 +57,13 @@ If the browser blocks the response with a **CORS** error:
 
 - DApp page: `/Applications/dapp/store_interaction_history.html`
 - Conventions: `agentic_ai_context/DAPP_PAGE_CONVENTIONS.md`, `dapp/UX_CONVENTIONS.md`
+
+## Email Agent drafts (optional, same spreadsheet project)
+
+Add **`email_agent_drafts.gs`** to the **container-bound** Apps Script project if you want menu-driven Gmail drafts (mirrors **`market_research/scripts/suggest_*_drafts.py`**):
+
+- **AI: Warm up prospect** — intro + consignment/bulk copy + wholesale PDF (`UrlFetch` to raw GitHub or script property **`BULK_PDF_RAW_URL`**)
+- **Manager Follow-up** — no PDF
+- **Bulk Info Requested** — PDF only
+
+Save → reload the spreadsheet → **Email Agent drafts** menu. Details: **`market_research/HIT_LIST_CREDENTIALS.md`**.


### PR DESCRIPTION
## Summary
Documents the optional **Email Agent drafts** container-bound Apps Script (`email_agent_drafts.gs`) alongside the Store Interaction History API README.

- Clarifies that GAS menu actions mirror `market_research/scripts/suggest_*_drafts.py`.
- Points readers to **`market_research/HIT_LIST_CREDENTIALS.md`** for setup details.

No runtime code changes.

Made with [Cursor](https://cursor.com)