### PR TITLE
GAS: Sales reporter QR API, unassigned Stripe sessions, and ledger writes from sales events

### DIFF
--- a/google_app_scripts/agroverse_qr_codes/web_app.gs
+++ b/google_app_scripts/agroverse_qr_codes/web_app.gs
@@ -13,12 +13,17 @@
 // ===== Configuration =====
 var SHEET_URL = 'https://docs.google.com/spreadsheets/d/1GE7PUq-UT6x2rBN-Q2ksogbWpgyuh2SaxJyG_uEK6PU/edit?gid=472328231';
 var QR_CODE_SHEET_NAME = 'Agroverse QR codes';
+var STRIPE_CHECKOUT_SHEET_NAME = 'Stripe Social Media Checkout ID';
+/** Stripe checkout: Session ID column C, Tracking Number column N, Agroverse QR code column P */
 var QR_CODE_PARAM = 'qr_code';
 var EMAIL_ADDRESS_PARAM = 'email_address';
 var LIST_PARAM = 'list';
 var LIST_ALL_PARAM = 'list_all';
 var LIST_WITH_MEMBERS_PARAM = 'list_with_members';
 var LOOKUP_PARAM = 'lookup';
+/** GET list_unassigned_stripe_sessions=true — Stripe Session IDs (column C) where P is blank; optional for_qr_code also includes rows where P equals that QR */
+var LIST_UNASSIGNED_STRIPE_SESSIONS_PARAM = 'list_unassigned_stripe_sessions';
+var FOR_QR_CODE_PARAM = 'for_qr_code';
 var HEADER_ROW = 2;
 var DATA_START_ROW = 2;
 var DEPLOYMENT_URL = 'https://script.google.com/macros/s/AKfycbxigq4-J0izShubqIC5k6Z7fgNRyVJLakfQ34HPuENiSpxuCG-wSq0g-wOAedZzzgaL/exec';
@@ -33,6 +38,29 @@ var DEPLOYMENT_EXAMPLE = 'https://script.google.com/macros/s/AKfycbxigq4-J0izShu
 function createCORSResponse(data) {
   return ContentService.createTextOutput(JSON.stringify(data))
     .setMimeType(ContentService.MimeType.JSON);
+}
+
+/** Web app query helpers — GAS may pass boolean true or string variants */
+function isTruthyQueryParam_(raw) {
+  if (raw === true) return true;
+  if (raw == null || raw === '') return false;
+  if (Object.prototype.toString.call(raw) === '[object Array]') {
+    raw = raw.length ? raw[0] : '';
+  }
+  var s = String(raw).toLowerCase().trim();
+  return s === 'true' || s === '1' || s === 'yes';
+}
+
+function getQueryParam_(e, key) {
+  if (!e) return '';
+  if (e.parameter && e.parameter[key] !== undefined && e.parameter[key] !== null && e.parameter[key] !== '') {
+    return e.parameter[key];
+  }
+  if (e.parameters && e.parameters[key]) {
+    var arr = e.parameters[key];
+    return Object.prototype.toString.call(arr) === '[object Array]' ? arr[0] : arr;
+  }
+  return '';
 }
 
 /**
@@ -54,14 +82,24 @@ function doOptions(e) {
  * - 'list=true' query parameter to return QR codes where column D is NOT 'SOLD' (includes MINTED, CONSIGNMENT, etc.).
  * - 'list_all=true' query parameter to return ALL QR codes including SOLD status.
  * - 'list_with_members=true' query parameter to return QR codes with details where column D is NOT 'SOLD'.
+ * - 'lookup=true&qr_code=...' returns ledger details plus stripe_session_id and tracking_number when a row
+ *   in 'Stripe Social Media Checkout ID' has column P equal to the QR code (Session in C, Tracking in N; newest row wins).
+ * - 'list_unassigned_stripe_sessions=true' returns { items: [{ stripe_session_id }] } for rows with Session in C
+ *   and column P blank; optional 'for_qr_code' also returns sessions already linked to that QR in P (for DApp prefill).
  *
  * @param {Object} e Event object containing parameters.
  * @return {ContentService.TextOutput} JSON response with results or error.
  */
 function doGet(e) {
   try {
-    // Open the spreadsheet and sheet
+    // Open the spreadsheet (several endpoints use multiple tabs)
     var spreadsheet = SpreadsheetApp.openByUrl(SHEET_URL);
+
+    if (isTruthyQueryParam_(getQueryParam_(e, LIST_UNASSIGNED_STRIPE_SESSIONS_PARAM))) {
+      var forQr = getQueryParam_(e, FOR_QR_CODE_PARAM);
+      return listUnassignedStripeSessions_(spreadsheet, forQr);
+    }
+
     var sheet = spreadsheet.getSheetByName(QR_CODE_SHEET_NAME);
     if (!sheet) {
       return createCORSResponse({
@@ -192,7 +230,8 @@ function doGet(e) {
           var status = dataRange[i][3] || ''; // Column D (index 3)
           var email = dataRange[i][11] || ''; // Column L (index 11)
           var managerName = dataRange[i][20] || ''; // Column U (index 20)
-          
+          var stripeInfo = lookupStripeCheckoutByQrCode_(spreadsheet, qrCode);
+
           return createCORSResponse({
             status: 'success',
             qr_code: qrCode,
@@ -200,7 +239,9 @@ function doGet(e) {
             ledger_shortcut: ledgerShortcut,
             qr_status: status,
             email: email,
-            manager_name: managerName
+            manager_name: managerName,
+            stripe_session_id: stripeInfo.stripe_session_id,
+            tracking_number: stripeInfo.tracking_number
           });
         }
       }
@@ -267,4 +308,84 @@ function doGet(e) {
       message: 'Error processing request: ' + error.message
     });
   }
+}
+
+/**
+ * Finds Stripe checkout row where column P matches the Agroverse QR code.
+ * Returns Session ID (column C) and Tracking Number (column N). If multiple rows match, the bottom-most row wins.
+ * @param {GoogleAppsScript.Spreadsheet.Spreadsheet} spreadsheet
+ * @param {string} qrCode
+ * @return {{stripe_session_id: string, tracking_number: string}}
+ */
+/**
+ * Stripe sessions where column P is unassigned, optionally including rows already tied to forQrCode (column P match).
+ * Iterates from bottom so newer sheet rows appear first; dedupes by session id.
+ * @param {GoogleAppsScript.Spreadsheet.Spreadsheet} spreadsheet
+ * @param {string=} forQrCodeRaw
+ * @return {ContentService.TextOutput}
+ */
+function listUnassignedStripeSessions_(spreadsheet, forQrCodeRaw) {
+  var stripeSheet = spreadsheet.getSheetByName(STRIPE_CHECKOUT_SHEET_NAME);
+  if (!stripeSheet) {
+    return createCORSResponse({
+      status: 'error',
+      message: 'Sheet not found: ' + STRIPE_CHECKOUT_SHEET_NAME
+    });
+  }
+
+  var lastRow = stripeSheet.getLastRow();
+  if (lastRow < DATA_START_ROW) {
+    return createCORSResponse({ status: 'success', items: [] });
+  }
+
+  var wantQr = (forQrCodeRaw || '').toString().trim();
+  var range = stripeSheet.getRange(DATA_START_ROW, 3, lastRow, 16).getValues();
+  var seen = {};
+  var items = [];
+
+  for (var r = range.length - 1; r >= 0; r--) {
+    var session = (range[r][0] || '').toString().trim();
+    if (!session) continue;
+
+    var pVal = (range[r][13] || '').toString().trim();
+    var pEmpty = !pVal;
+    var pMatches = wantQr !== '' && pVal === wantQr;
+
+    if (!pEmpty && !pMatches) continue;
+    if (seen[session]) continue;
+
+    seen[session] = true;
+    items.push({ stripe_session_id: session });
+  }
+
+  return createCORSResponse({
+    status: 'success',
+    items: items
+  });
+}
+
+function lookupStripeCheckoutByQrCode_(spreadsheet, qrCode) {
+  var empty = { stripe_session_id: '', tracking_number: '' };
+  if (!qrCode) return empty;
+
+  var sheet = spreadsheet.getSheetByName(STRIPE_CHECKOUT_SHEET_NAME);
+  if (!sheet) return empty;
+
+  var lastRow = sheet.getLastRow();
+  if (lastRow < DATA_START_ROW) return empty;
+
+  var wanted = qrCode.toString().trim();
+  // Columns C through P: C=Session, N=Tracking, P=QR code match
+  var range = sheet.getRange(DATA_START_ROW, 3, lastRow, 16).getValues();
+
+  for (var r = range.length - 1; r >= 0; r--) {
+    var pVal = (range[r][13] || '').toString().trim();
+    if (pVal === wanted) {
+      return {
+        stripe_session_id: (range[r][0] || '').toString().trim(),
+        tracking_number: (range[r][11] || '').toString().trim()
+      };
+    }
+  }
+  return empty;
 }

--- a/google_app_scripts/tdg_inventory_management/process_sales_telegram_logs.gs
+++ b/google_app_scripts/tdg_inventory_management/process_sales_telegram_logs.gs
@@ -35,6 +35,12 @@ const CONTRIBUTORS_SHEET_URL = 'https://docs.google.com/spreadsheets/d/1GE7PUq-U
 const CONTRIBUTORS_SHEET_NAME = 'Contributors contact information';
 const AGROVERSE_QR_SHEET_URL = 'https://docs.google.com/spreadsheets/d/1GE7PUq-UT6x2rBN-Q2ksogbWpgyuh2SaxJyG_uEK6PU/edit?gid=472328231#gid=472328231';
 const AGROVERSE_QR_SHEET_NAME = 'Agroverse QR codes';
+/** Main ledger tab: Session ID column C, Tracking column N, Agroverse QR column P */
+const STRIPE_CHECKOUT_SHEET_NAME = 'Stripe Social Media Checkout ID';
+const STRIPE_COL_SESSION = 3; // C
+const STRIPE_COL_TRACKING = 14; // N
+const STRIPE_COL_QR = 16; // P
+const AGROVERSE_OWNER_EMAIL_COL = 12; // L (1-based for getRange)
 const XAI_API_URL = 'https://api.x.ai/v1/chat/completions';
 
 // Column indices for source sheet
@@ -219,6 +225,82 @@ function updateAgroverseQrStatus(qrCode) {
   }
 }
 
+/** Normalize optional [SALES EVENT] lines; treat blank and "(none)" as empty */
+function normalizeSalesEventOptionalField(raw) {
+  const t = (raw || '').toString().trim();
+  if (!t || /^(\(none\)|none)$/i.test(t)) return '';
+  return t;
+}
+
+/** Update Agroverse QR codes column L (owner email) when the sale payload includes it */
+function updateAgroverseQrOwnerEmail(qrCode, email) {
+  if (!qrCode || !email) return false;
+  try {
+    const agroverseSpreadsheet = SpreadsheetApp.openByUrl(AGROVERSE_QR_SHEET_URL);
+    const agroverseSheet = agroverseSpreadsheet.getSheetByName(AGROVERSE_QR_SHEET_NAME);
+    const agroverseData = agroverseSheet.getDataRange().getValues();
+    for (let i = 1; i < agroverseData.length; i++) {
+      if (agroverseData[i][QR_CODE_COL] === qrCode) {
+        agroverseSheet.getRange(i + 1, AGROVERSE_OWNER_EMAIL_COL).setValue(email);
+        Logger.log(`Updated owner email for QR ${qrCode} in Agroverse QR codes`);
+        return true;
+      }
+    }
+    Logger.log(`QR code ${qrCode} not found for owner email update`);
+    return false;
+  } catch (e) {
+    Logger.log(`Error updating Agroverse owner email: ${e.message}`);
+    return false;
+  }
+}
+
+/** Match Stripe checkout row by Session ID (column C); set Tracking (N) and QR (P) when provided */
+function updateStripeCheckoutMetadata(sessionId, trackingNumber, qrCode) {
+  if (!sessionId) {
+    Logger.log('Stripe checkout update skipped: no Stripe Session ID in payload');
+    return false;
+  }
+  try {
+    const ss = SpreadsheetApp.openByUrl(AGROVERSE_QR_SHEET_URL);
+    const sheet = ss.getSheetByName(STRIPE_CHECKOUT_SHEET_NAME);
+    if (!sheet) {
+      Logger.log(`Sheet not found: ${STRIPE_CHECKOUT_SHEET_NAME}`);
+      return false;
+    }
+    const want = sessionId.toString().trim();
+    const lastRow = sheet.getLastRow();
+    for (let r = lastRow; r >= 2; r--) {
+      const cell = sheet.getRange(r, STRIPE_COL_SESSION).getValue();
+      if ((cell || '').toString().trim() === want) {
+        if (trackingNumber) {
+          sheet.getRange(r, STRIPE_COL_TRACKING).setValue(trackingNumber);
+        }
+        if (qrCode) {
+          sheet.getRange(r, STRIPE_COL_QR).setValue(qrCode);
+        }
+        Logger.log(`Updated Stripe checkout row ${r} for session ${want} (tracking / column P)`);
+        return true;
+      }
+    }
+    Logger.log(`No Stripe row found for session ${want}`);
+    return false;
+  } catch (e) {
+    Logger.log(`Error updating Stripe checkout sheet: ${e.message}`);
+    return false;
+  }
+}
+
+/** After a verified [SALES EVENT] row is accepted, sync optional DApp fields to the main ledger */
+function applySalesEventLedgerFields(qrCode, parseMethod, ownerEmail, stripeSessionId, trackingNumber) {
+  if (parseMethod !== 'SALES_EVENT' || !qrCode) return;
+  if (ownerEmail) {
+    updateAgroverseQrOwnerEmail(qrCode, ownerEmail);
+  }
+  if (stripeSessionId) {
+    updateStripeCheckoutMetadata(stripeSessionId, trackingNumber, qrCode);
+  }
+}
+
 // Function to parse [SALES EVENT] structured format
 function parseSalesEvent(message) {
   try {
@@ -231,17 +313,45 @@ function parseSalesEvent(message) {
     // Extract Sales price - pattern: "- Sales price: $XX" or "- Sales price: XX"
     const priceMatch = message.match(/- Sales price:\s*\$?([0-9]+\.?[0-9]*)/i);
     const salePrice = priceMatch ? parseFloat(priceMatch[1]) : '';
+
+    const ownerLine = message.match(/- Owner email:\s*([^\n]+)/i);
+    const stripeLine = message.match(/- Stripe Session ID:\s*([^\n]+)/i);
+    const trackLine = message.match(/- Tracking number:\s*([^\n]+)/i);
+    const ownerEmail = normalizeSalesEventOptionalField(ownerLine ? ownerLine[1] : '');
+    const stripeSessionId = normalizeSalesEventOptionalField(stripeLine ? stripeLine[1] : '');
+    const trackingNumber = normalizeSalesEventOptionalField(trackLine ? trackLine[1] : '');
     
     if (qrCode && salePrice) {
       Logger.log(`[SALES EVENT] parsed successfully: QR=${qrCode}, Price=${salePrice}`);
-      return { qrCode, salePrice, parseMethod: 'SALES_EVENT' };
+      return {
+        qrCode,
+        salePrice,
+        parseMethod: 'SALES_EVENT',
+        ownerEmail,
+        stripeSessionId,
+        trackingNumber
+      };
     }
     
     Logger.log('[SALES EVENT] parsing failed: missing QR code or price');
-    return { qrCode: '', salePrice: '', parseMethod: 'FAILED' };
+    return {
+      qrCode: '',
+      salePrice: '',
+      parseMethod: 'FAILED',
+      ownerEmail: '',
+      stripeSessionId: '',
+      trackingNumber: ''
+    };
   } catch (e) {
     Logger.log(`[SALES EVENT] parsing error: ${e.message}`);
-    return { qrCode: '', salePrice: '', parseMethod: 'ERROR' };
+    return {
+      qrCode: '',
+      salePrice: '',
+      parseMethod: 'ERROR',
+      ownerEmail: '',
+      stripeSessionId: '',
+      trackingNumber: ''
+    };
   }
 }
 
@@ -263,14 +373,35 @@ function parseQrCodeEvent(message) {
     
     if (qrCode && salePrice) {
       Logger.log(`[QR CODE EVENT] parsed successfully: QR=${qrCode}, Price=${salePrice}`);
-      return { qrCode, salePrice, parseMethod: 'QR_CODE_EVENT' };
+      return {
+        qrCode,
+        salePrice,
+        parseMethod: 'QR_CODE_EVENT',
+        ownerEmail: '',
+        stripeSessionId: '',
+        trackingNumber: ''
+      };
     }
     
     Logger.log('[QR CODE EVENT] parsing failed: missing QR code or price');
-    return { qrCode: '', salePrice: '', parseMethod: 'FAILED' };
+    return {
+      qrCode: '',
+      salePrice: '',
+      parseMethod: 'FAILED',
+      ownerEmail: '',
+      stripeSessionId: '',
+      trackingNumber: ''
+    };
   } catch (e) {
     Logger.log(`[QR CODE EVENT] parsing error: ${e.message}`);
-    return { qrCode: '', salePrice: '', parseMethod: 'ERROR' };
+    return {
+      qrCode: '',
+      salePrice: '',
+      parseMethod: 'ERROR',
+      ownerEmail: '',
+      stripeSessionId: '',
+      trackingNumber: ''
+    };
   }
 }
 
@@ -288,7 +419,14 @@ function parseStructuredMessage(message) {
   
   // Not a recognized structured format
   Logger.log('Message does not match any structured format');
-  return { qrCode: '', salePrice: '', parseMethod: 'NONE' };
+  return {
+    qrCode: '',
+    salePrice: '',
+    parseMethod: 'NONE',
+    ownerEmail: '',
+    stripeSessionId: '',
+    trackingNumber: ''
+  };
 }
 
 // Function to call Grok API to extract QR code and sale price (fallback for unstructured messages)
@@ -298,7 +436,14 @@ function callGrokApi(message) {
     const apiKey = PropertiesService.getScriptProperties().getProperty('XAI_API_KEY');
     if (!apiKey) {
       Logger.log('Error: XAI_API_KEY not set in Script Properties');
-      return { qrCode: '', salePrice: '', parseMethod: 'GROK_ERROR' };
+      return {
+        qrCode: '',
+        salePrice: '',
+        parseMethod: 'GROK_ERROR',
+        ownerEmail: '',
+        stripeSessionId: '',
+        trackingNumber: ''
+      };
     }
 
     const prompt = `Extract the QR code and sale price from the following message. Return a JSON object with "qr_code" and "sale_price" fields. If not found, return empty strings. 
@@ -332,11 +477,21 @@ Message: "${message}"`;
     return {
       qrCode: extractedData.qr_code || '',
       salePrice: extractedData.sale_price ? parseFloat(extractedData.sale_price.replace('$', '')) : '',
-      parseMethod: 'GROK_API'
+      parseMethod: 'GROK_API',
+      ownerEmail: '',
+      stripeSessionId: '',
+      trackingNumber: ''
     };
   } catch (e) {
     Logger.log(`Grok API error: ${e.message}`);
-    return { qrCode: '', salePrice: '', parseMethod: 'GROK_ERROR' };
+    return {
+      qrCode: '',
+      salePrice: '',
+      parseMethod: 'GROK_ERROR',
+      ownerEmail: '',
+      stripeSessionId: '',
+      trackingNumber: ''
+    };
   }
 }
 
@@ -420,7 +575,14 @@ function parseTelegramChatLogs() {
       }
       
       // Extract QR code and sale price (structured parsing first, then Grok API fallback)
-      const { qrCode, salePrice, parseMethod } = extractQrCodeAndPrice(message);
+      const {
+        qrCode,
+        salePrice,
+        parseMethod,
+        ownerEmail,
+        stripeSessionId,
+        trackingNumber
+      } = extractQrCodeAndPrice(message);
       Logger.log(`Row ${i + 1}: Parsed using method: ${parseMethod}`);
       
       // If valid data returned, prepare row
@@ -445,6 +607,7 @@ function parseTelegramChatLogs() {
         
         // Update Agroverse QR codes sheet status to SOLD
         updateAgroverseQrStatus(qrCode);
+        applySalesEventLedgerFields(qrCode, parseMethod, ownerEmail, stripeSessionId, trackingNumber);
         
         // Get value from Agroverse QR codes sheet
         const agroverseValue = getAgroverseValue(qrCode);
@@ -489,8 +652,7 @@ function parseTelegramChatLogs() {
 }
 
 // Function to process a specific row from the source sheet
-function processSpecificRow() {
-  rowIndex = 6751;
+function processSpecificRow(rowIndex) {
   // Get source and destination spreadsheets
   const sourceSpreadsheet = SpreadsheetApp.openByUrl(SOURCE_SHEET_URL);
   const destinationSpreadsheet = SpreadsheetApp.openByUrl(DESTINATION_SHEET_URL);
@@ -558,7 +720,14 @@ function processSpecificRow() {
     }
     
     // Extract QR code and sale price (structured parsing first, then Grok API fallback)
-    const { qrCode, salePrice, parseMethod } = extractQrCodeAndPrice(message);
+    const {
+      qrCode,
+      salePrice,
+      parseMethod,
+      ownerEmail,
+      stripeSessionId,
+      trackingNumber
+    } = extractQrCodeAndPrice(message);
     Logger.log(`Row ${rowIndex}: Parsed using method: ${parseMethod}`);
     
     // If valid data returned, prepare row
@@ -583,6 +752,7 @@ function processSpecificRow() {
       
       // Update Agroverse QR codes sheet status to SOLD
       updateAgroverseQrStatus(qrCode);
+      applySalesEventLedgerFields(qrCode, parseMethod, ownerEmail, stripeSessionId, trackingNumber);
       
       // Get value from Agroverse QR codes sheet
       const agroverseValue = getAgroverseValue(qrCode);


### PR DESCRIPTION
## Summary
Reference Apps Script sources for the Sales Reporter flow: new read API for open Stripe checkout rows and richer QR lookup, plus ledger writes when Edgar-processed `[SALES EVENT]` messages include owner email and Stripe/tracking metadata.

## `google_app_scripts/agroverse_qr_codes/web_app.gs`
- **`list_unassigned_stripe_sessions=true`**: Returns Stripe Session IDs from **Stripe Social Media Checkout ID** where column **P** is empty; optional **`for_qr_code`** includes rows already linked to that QR for DApp prefill.
- **`lookup=true&qr_code=\u2026`**: Adds **`stripe_session_id`** and **`tracking_number`** (match column **P** to QR; session in **C**, tracking in **N**).
- **Query helpers**: `isTruthyQueryParam_` / `getQueryParam_` so flags are recognized when the runtime passes boolean or non-string values (avoids falling through to the email-update handler).

**Deploy note:** The public `/exec` URL used by the DApp is bound to the standalone script project mirrored as `clasp_mirrors/1y6JVYwq\u2026` (`Code.js`); after merge, copy this `.gs` to that project\u2019s `Code.js` (or equivalent) and publish a **new Web app version** so production picks up routes.

## `google_app_scripts/tdg_inventory_management/process_sales_telegram_logs.gs`
- Parse optional lines from `[SALES EVENT]`: **Owner email**, **Stripe Session ID**, **Tracking number** (ignore `(none)`).
- After marking the QR **SOLD**, apply **Agroverse QR codes** column **L** when owner email is present; when a session id is present, update **Stripe Social Media Checkout ID** row matched on column **C** with **N** (tracking) and **P** (QR).
- **`processSpecificRow(rowIndex)`**: Accept webhook `rowIndex` (remove hard-coded debug row).

## Testing
- GET `lookup` and `list_unassigned_stripe_sessions` against a test deployment.
- Run sales telegram processor against a sample log row containing the new `\u2014 Owner email` / Stripe / tracking lines and confirm sheet columns update as expected.

Made with [Cursor](https://cursor.com)