### PR TITLE
feat(gas): QR Code Sales columns L–O (DApp sale extract)

### DIFF
--- a/SCHEMA.md
+++ b/SCHEMA.md
@@ -9,8 +9,8 @@
 ### Sales reporter ↔ Stripe ↔ Agroverse QR linking
 
 - **`Stripe Social Media Checkout ID`**: **Column P — `Agroverse QR code`** (NEW in operations; link Stripe checkout Session ID row to the serialized bag QR). Code treats **C** = Stripe Session ID, **N** = Tracking Number, **P** = Agroverse QR code.
-- **DApp Sales Reporter** (`report_sales.html`) and **`agroverse_qr_codes` web app** (`list_unassigned_stripe_sessions`, `lookup`, etc.) use column **P** to show unassigned sessions and to write **P** + **N** when a `[SALES EVENT]` is processed (`process_sales_telegram_logs.gs` → `updateStripeCheckoutMetadata`).
-- **`QR Code Sales`** tab (Telegram & Submissions spreadsheet): Column **D** is the **cash proceeds collector** for `[SALES EVENT]` submissions when “Cash proceeds collected by” differs from “Sold by”; full message (both lines) remains in column **C**.
+- **DApp Sales Reporter** (`report_sales.html`) and **`agroverse_qr_codes` web app** (`list_unassigned_stripe_sessions`, `lookup`, etc.) use column **P** to show unassigned sessions and to write **P** + **N** (+ **M** shipping provider) when a `[SALES EVENT]` is processed (`process_sales_telegram_logs.gs` → `updateStripeCheckoutMetadata`).
+- **`QR Code Sales`** tab (same workbook as Telegram logs compilation, `gid=1003674539`): Column **D** is the **cash proceeds collector** for `[SALES EVENT]` when “Cash proceeds collected by” differs from “Sold by”; full message stays in **C**. **`process_sales_telegram_logs.gs`** now also writes extracted **`[SALES EVENT]`** fields on each new row: **L** Owner email, **M** Stripe Session ID, **N** Shipping Provider, **O** Tracking Number (columns **J–K** stay empty on ingest for downstream ledger scripts). Row 1 headers **L–O** are created automatically when blank.
 
 ---
 
@@ -306,6 +306,10 @@ See [`python_scripts/schema_validation/README.md`](./python_scripts/schema_valid
 | I | Currency | String | Product sold |
 | J | Status | String | "PROCESSING", "ACCOUNTED", "TOKENIZED", empty |
 | K | Ledger Lines Number | String | Comma-separated row numbers |
+| L | Owner email | String | From **`[SALES EVENT]`** when present (DApp **report_sales** / list flow); empty for legacy rows |
+| M | Stripe Session ID | String | Parsed from same message; aligns with Stripe checkout column C |
+| N | Shipping Provider | String | EasyPost USPS label text (e.g. `GroundAdvantage - USPS`) when submitted |
+| O | Tracking Number | String | Carrier tracking when submitted |
 
 **Used by:**
 - [`process_sales_telegram_logs.gs`](https://github.com/TrueSightDAO/tokenomics/blob/main/google_app_scripts/tdg_inventory_management/process_sales_telegram_logs.gs) - Parses and validates sales from Telegram

--- a/google_app_scripts/tdg_inventory_management/process_sales_telegram_logs.gs
+++ b/google_app_scripts/tdg_inventory_management/process_sales_telegram_logs.gs
@@ -56,6 +56,50 @@ const SALES_DATE_COL = 11; // Column L
 // Column D contributor cell: cash proceeds collector for [SALES EVENT] (who received payment). Column C retains full message including "Sold by:".
 const DEST_MESSAGE_ID_COL = 1; // Column B (for duplicate checking)
 const DEST_QR_CODE_COL = 4; // Column E (for QR code duplicate checking)
+// A–I: written on ingest; J–K reserved for ledger scripts (Status, Ledger lines); L–O extracted DApp fields.
+const DEST_OWNER_EMAIL_COL_INDEX = 11; // Column L (0-based row array index)
+const DEST_STRIPE_SESSION_COL_INDEX = 12; // Column M
+const DEST_SHIPPING_PROVIDER_COL_INDEX = 13; // Column N
+const DEST_TRACKING_NUM_COL_INDEX = 14; // Column O
+
+/**
+ * If row 1 columns L–O are empty, set headers for extracted [SALES EVENT] fields (report_sales / dapp).
+ * @param {GoogleAppsScript.Spreadsheet.Sheet} sheet
+ */
+function ensureQrSalesExtractedFieldsHeaders_(sheet) {
+  if (!sheet) return;
+  const rng = sheet.getRange(1, DEST_OWNER_EMAIL_COL_INDEX + 1, 1, DEST_TRACKING_NUM_COL_INDEX + 1);
+  const existing = rng.getValues()[0];
+  var allBlank = true;
+  for (var i = 0; i < existing.length; i++) {
+    if (existing[i] != null && String(existing[i]).trim() !== '') {
+      allBlank = false;
+      break;
+    }
+  }
+  if (!allBlank) return;
+  rng.setValues([[
+    'Owner email',
+    'Stripe Session ID',
+    'Shipping Provider',
+    'Tracking Number'
+  ]]);
+  rng.setFontWeight('bold');
+}
+
+/**
+ * Columns J–K empty placeholders; L–O from parsed [SALES EVENT] (empty for legacy / QR CODE EVENT).
+ */
+function buildQrSalesRowExtractedColumns_(ownerEmail, stripeSessionId, shippingProvider, trackingNumber) {
+  return [
+    '',
+    '',
+    (ownerEmail || '').toString(),
+    (stripeSessionId || '').toString(),
+    (shippingProvider || '').toString(),
+    (trackingNumber || '').toString()
+  ];
+}
 
 // Column indices for contributors sheet
 const CONTRIBUTOR_NAME_COL_CONTRIBUTORS = 0; // Column A (Reporter Name)
@@ -561,7 +605,8 @@ function parseTelegramChatLogs() {
   const destinationSpreadsheet = SpreadsheetApp.openByUrl(DESTINATION_SHEET_URL);
   const sourceSheet = sourceSpreadsheet.getSheetByName(SOURCE_SHEET_NAME);
   const destinationSheet = destinationSpreadsheet.getSheetByName(DESTINATION_SHEET_NAME);
-  
+  ensureQrSalesExtractedFieldsHeaders_(destinationSheet);
+
   // Get data from source and destination sheets
   const sourceData = sourceSheet.getDataRange().getValues();
   const destData = destinationSheet.getDataRange().getValues();
@@ -667,7 +712,7 @@ function parseTelegramChatLogs() {
         agroverseValue,
         salesDate,
         inventoryType
-      ];
+      ].concat(buildQrSalesRowExtractedColumns_(ownerEmail, stripeSessionId, shippingProvider, trackingNumber));
 
       destinationSheet.getRange(destinationSheet.getLastRow() + 1, 1, 1, rowToAppend.length).setValues([rowToAppend]);
 
@@ -695,7 +740,8 @@ function processSpecificRow(rowIndex) {
   const destinationSpreadsheet = SpreadsheetApp.openByUrl(DESTINATION_SHEET_URL);
   const sourceSheet = sourceSpreadsheet.getSheetByName(SOURCE_SHEET_NAME);
   const destinationSheet = destinationSpreadsheet.getSheetByName(DESTINATION_SHEET_NAME);
-  
+  ensureQrSalesExtractedFieldsHeaders_(destinationSheet);
+
   // Validate rowIndex
   if (rowIndex < 2) {
     Logger.log(`Invalid rowIndex: ${rowIndex}. Must be >= 2 (header row is 1).`);
@@ -808,7 +854,7 @@ function processSpecificRow(rowIndex) {
       agroverseValue,
       salesDate,
       inventoryType
-    ];
+    ].concat(buildQrSalesRowExtractedColumns_(ownerEmail, stripeSessionId, shippingProvider, trackingNumber));
 
     destinationSheet.getRange(destinationSheet.getLastRow() + 1, 1, 1, rowToAppend.length).setValues([rowToAppend]);
 


### PR DESCRIPTION
## Summary
Persists **report_sales** / `[SALES EVENT]` fields on the **QR Code Sales** tab so ops can filter without parsing column C.

## Changes
- **process_sales_telegram_logs.gs**: New rows are **A–O**; **J–K** left empty for existing AGL / offchain ledger scripts; **L–O** = Owner email, Stripe Session ID, Shipping Provider, Tracking Number. `ensureQrSalesExtractedFieldsHeaders_` writes row-1 headers **L–O** when that range is blank.
- **SCHEMA.md**: Table rows **L–O**; **Recent Changes (2026-04-10)** updated to describe ingest + column M in Stripe bullet.

## Deploy
Redeploy the **tdg_inventory_management** web app that runs `parseTelegramChatLogs` / `processSpecificRow`.

Made with [Cursor](https://cursor.com)