### PR TITLE
TDG identity: split Edgar verification email to admin Apps Script

### DIFF
--- a/SCHEMA.md
+++ b/SCHEMA.md
@@ -249,6 +249,8 @@ See [`python_scripts/schema_validation/README.md`](./python_scripts/schema_valid
 | Q | External API call status | String | Status of external API calls |
 | R | External API call response | String | Response from external API |
 
+**Note (DApp / Edgar ingest):** For `POST /dao/submit_contribution`, column **P** is populated by Edgar as `success` / `failed` / `no_signature_format` / `error` (and similar). Downstream processors (for example Agroverse QR generation) treat `success` (case-insensitive) as cryptographically verified at ingest. Email onboarding events (`[EMAIL REGISTERED EVENT]`, `[EMAIL VERIFICATION EVENT]`) follow the same ingest path and column **P** semantics.
+
 **Used by:**
 - [`tdg_expenses_processing.gs`](https://github.com/TrueSightDAO/tokenomics/blob/main/google_app_scripts/tdg_asset_management/tdg_expenses_processing.gs) - Processes expense submissions
 - [`process_sales_telegram_logs.gs`](https://github.com/TrueSightDAO/tokenomics/blob/main/google_app_scripts/tdg_inventory_management/process_sales_telegram_logs.gs) - Processes sales from Telegram
@@ -641,15 +643,23 @@ See [`python_scripts/schema_validation/README.md`](./python_scripts/schema_valid
 | A | Contributor Name | String | Full name of contributor |
 | B | Created \nTime Stamp | String | Format: "YYYY-MM-DD HH:MM:SS" (note: header contains line break) |
 | C | Last Active \nTime Stamp | String | Format: "YYYYMMDD HH:MM:SS" (note: header contains line break) |
-| D | Status | String | "ACTIVE", "INACTIVE", etc. |
-| E | Digital Signature | String | Public key for authentication |
-| F | Contributor Email Address | String | Email address |
+| D | Status | String | `ACTIVE`, `INACTIVE`, `VERIFYING` (email onboarding), etc. |
+| E | Digital Signature | String | Public key for authentication (DApp base64 SPKI) |
+| F | Contributor Email Address | String | Email address (used for email-based onboarding) |
+| G | Verification Key | String | Random single-use key for browser email verification (DApp onboarding; blank for legacy rows) |
+
+**DApp email onboarding (2026-04):**
+
+1. Contributor submits a signed `[EMAIL REGISTERED EVENT]` payload to Edgar (`POST /dao/submit_contribution`). After cryptographic verification succeeds, Edgar appends a **`VERIFYING`** row here (columns **E–G** populated) and triggers a Google Apps Script web app to email a link containing `em` + `vk` query parameters.
+2. Contributor opens the link on the **same browser** that holds the private key and submits a signed `[EMAIL VERIFICATION EVENT]` payload referencing the **`Verification Key`**. Edgar then flips **D** from **`VERIFYING`** → **`ACTIVE`** when the key matches.
 
 **Used by:**
 - [`tdg_expenses_processing.gs`](https://github.com/TrueSightDAO/tokenomics/blob/main/google_app_scripts/tdg_asset_management/tdg_expenses_processing.gs) - Authenticates expense submitters via signature
 - [`process_qr_code_generation_telegram_logs.gs`](https://github.com/TrueSightDAO/tokenomics/blob/main/google_app_scripts/tdg_inventory_management/process_qr_code_generation_telegram_logs.gs) - Authenticates QR generation requests
-- [`register_member_digital_signatures_telegram.gs`](https://github.com/TrueSightDAO/tokenomics/blob/main/google_app_scripts/tdg_proposal/register_member_digital_signatures_telegram.gs) - Registers new signatures from Telegram
-- [`register_member_digital_signatures_email.gs`](https://github.com/TrueSightDAO/tokenomics/blob/main/google_app_scripts/tdg_proposal/register_member_digital_signatures_email.gs) - Registers new signatures from email
+- [`register_member_digital_signatures_telegram.gs`](https://github.com/TrueSightDAO/tokenomics/blob/main/google_app_scripts/tdg_identity_management/register_member_digital_signatures_telegram.gs) - Registers new signatures from Telegram (`processDigitalSignatureEvents` web app)
+- [`register_member_digital_signatures_email.gs`](https://github.com/TrueSightDAO/tokenomics/blob/main/google_app_scripts/tdg_identity_management/register_member_digital_signatures_email.gs) - Registers new signatures from Gmail
+- [`edgar_send_email_verification.gs`](https://github.com/TrueSightDAO/tokenomics/blob/main/google_app_scripts/tdg_identity_management/edgar_send_email_verification.gs) - Web app invoked by **Edgar** to send DApp verification email (script `1m8IZ…`; deploy as admin sender)
+- **Edgar (`sentiment_importer`)** — `DaoEmailRegistrationService` + `Gdrive::ContributorsDigitalSignatures` maintain `VERIFYING` / `ACTIVE` for the DApp `create_signature.html` flow; see `email_verification_from_edgar.gs` for wiring notes.
 
 ---
 
@@ -764,7 +774,7 @@ See [`python_scripts/schema_validation/README.md`](./python_scripts/schema_valid
 | F | state | String | State/region |
 | G | country | String | Country |
 | H | Year | String | Year |
-| I | Currency | String | Product type/currency |
+| I | Currency | String | Canonical inventory / **`Currency`** label; **must match** a row in tab **`Currencies` column A** (same workbook). The sheet often pulls this via **cross-sheet reference** / **`IMPORTRANGE`** so **I** displays the exact **`Currencies`!A** string (required for sales validation and ledger lookups—not arbitrary free text). |
 | J | QR code creation date (YYYYMMDD) | String | Creation date |
 | K | QR code location | String | Storage location URL |
 | L | Owner Email | String | Owner email |

--- a/google_app_scripts/tdg_identity_management/README.md
+++ b/google_app_scripts/tdg_identity_management/README.md
@@ -38,6 +38,10 @@ This folder contains scripts for managing digital identities within TrueSight DA
    - Updated Digital Signatures registry (Google Sheet)
    - Telegram notifications
 
+### [`edgar_send_email_verification.gs`](./edgar_send_email_verification.gs)
+
+**Purpose**: Standalone web app for **Edgar → contributor** verification email after DApp `[EMAIL REGISTERED EVENT]` (GET `sendEmailVerification` + POST JSON). Deployed under **admin@truesight.me** so `GmailApp.sendEmail` sends from that account. Separate Apps Script project from the Telegram log processor above.
+
 ## Reference Files
 
 The system interacts with these key Google Sheets:

--- a/google_app_scripts/tdg_identity_management/edgar_send_email_verification.gs
+++ b/google_app_scripts/tdg_identity_management/edgar_send_email_verification.gs
@@ -1,0 +1,106 @@
+/**
+ * File: google_app_scripts/tdg_identity_management/edgar_send_email_verification.gs
+ * Repository: https://github.com/TrueSightDAO/tokenomics
+ *
+ * Summary:
+ * - Standalone web app invoked by Edgar (`sentiment_importer`) after a verified
+ *   `[EMAIL REGISTERED EVENT]`. Sends the contributor a DApp link with `em` + `vk`.
+ * - Deploy as **Web app**: Execute as **User (admin@truesight.me)** so `GmailApp.sendEmail`
+ *   sends from that account; Who has access: **Anyone**.
+ *
+ * ---------------------------------------------------------------------------
+ * Apps Script project (clasp mirror must stay in sync)
+ * ---------------------------------------------------------------------------
+ * - Script ID: 1m8IZPs1vFN99cuu-39kbC-OGXggRVtJtXq5rfSB0M1sCQjMdolEUDuGU
+ * - Editor URL:
+ *   https://script.google.com/u/2/home/projects/1m8IZPs1vFN99cuu-39kbC-OGXggRVtJtXq5rfSB0M1sCQjMdolEUDuGU/edit
+ * - Web app deployment URL (`/exec`; Edgar `EMAIL_VERIFICATION_GAS_WEBHOOK_URL` default in `sentiment_importer`):
+ *   https://script.google.com/macros/s/AKfycbxfngGYBYMe1ATyW0U4lLODyAlhUnSUATAsBrNgIvKH6k9ARifG3arSFkB4hjn2h2ID2A/exec
+ * - Clasp mirror: tokenomics/clasp_mirrors/1m8IZPs1vFN99cuu-39kbC-OGXggRVtJtXq5rfSB0M1sCQjMdolEUDuGU/
+ *
+ * Script property (Project Settings → Script properties):
+ * - `EMAIL_VERIFICATION_SECRET` — must match Edgar `EMAIL_VERIFICATION_GAS_SECRET` / `EMAIL_VERIFICATION_SECRET`.
+ *
+ * This project intentionally does **not** include Telegram log processing; see
+ * `register_member_digital_signatures_telegram.gs` (script `10NKp8…`) for `processDigitalSignatureEvents`.
+ */
+
+/**
+ * Edgar → GET ?action=sendEmailVerification&secret=...&email=...&verification_key=...&return_url=...
+ */
+function doGet(e) {
+  const action = e.parameter?.action;
+  if (action === 'sendEmailVerification') {
+    return handleEmailVerificationRequest_({
+      secret: e.parameter.secret,
+      email: e.parameter.email,
+      verification_key: e.parameter.verification_key,
+      return_url: e.parameter.return_url || '',
+    });
+  }
+
+  return ContentService.createTextOutput(
+    JSON.stringify({
+      ok: false,
+      error: 'No valid action (use action=sendEmailVerification on GET, or POST JSON for email verification).',
+    })
+  ).setMimeType(ContentService.MimeType.JSON);
+}
+
+/**
+ * Shared handler: GET query object or POST JSON body
+ * { secret, email, verification_key, return_url }
+ */
+function handleEmailVerificationRequest_(body) {
+  try {
+    const expected = PropertiesService.getScriptProperties().getProperty('EMAIL_VERIFICATION_SECRET');
+    if (!expected || String(body.secret || '') !== String(expected)) {
+      return ContentService.createTextOutput(JSON.stringify({ ok: false, error: 'Unauthorized' }))
+        .setMimeType(ContentService.MimeType.JSON);
+    }
+
+    const email = String(body.email || '').trim().toLowerCase();
+    const vk = String(body.verification_key || '').trim();
+    const returnUrl = String(body.return_url || 'https://truesightdao.github.io/dapp/create_signature.html').trim();
+    if (!email || !vk || !email.includes('@')) {
+      return ContentService.createTextOutput(JSON.stringify({ ok: false, error: 'Missing email or verification_key' }))
+        .setMimeType(ContentService.MimeType.JSON);
+    }
+
+    const base = returnUrl.split('#')[0];
+    const join = base.indexOf('?') >= 0 ? '&' : '?';
+    const verifyUrl = `${base}${join}em=${encodeURIComponent(email)}&vk=${encodeURIComponent(vk)}`;
+
+    const subject = 'Verify your TrueSight DAO digital signature';
+    const plain =
+      'Hello,\n\n' +
+      'Click the link below to verify this browser for your digital signature registration:\n\n' +
+      verifyUrl +
+      '\n\nIf you did not request this, you can ignore this email.\n\nTrueSight DAO';
+
+    GmailApp.sendEmail(email, subject, plain);
+
+    return ContentService.createTextOutput(JSON.stringify({ ok: true }))
+      .setMimeType(ContentService.MimeType.JSON);
+  } catch (err) {
+    Logger.log('handleEmailVerificationRequest_ failed: ' + err);
+    return ContentService.createTextOutput(
+      JSON.stringify({ ok: false, error: String(err && err.message ? err.message : err) })
+    ).setMimeType(ContentService.MimeType.JSON);
+  }
+}
+
+/**
+ * Edgar → POST JSON { secret, email, verification_key, return_url }
+ */
+function doPost(e) {
+  try {
+    const body = e.postData && e.postData.contents ? JSON.parse(e.postData.contents) : {};
+    return handleEmailVerificationRequest_(body);
+  } catch (err) {
+    Logger.log('doPost email verification failed: ' + err);
+    return ContentService.createTextOutput(
+      JSON.stringify({ ok: false, error: String(err && err.message ? err.message : err) })
+    ).setMimeType(ContentService.MimeType.JSON);
+  }
+}

--- a/google_app_scripts/tdg_identity_management/email_verification_from_edgar.gs
+++ b/google_app_scripts/tdg_identity_management/email_verification_from_edgar.gs
@@ -1,0 +1,37 @@
+/**
+ * File: google_app_scripts/tdg_identity_management/email_verification_from_edgar.gs
+ * Repository: https://github.com/TrueSightDAO/tokenomics
+ *
+ * Summary:
+ * - Edgar (`sentiment_importer`) calls a **standalone** Apps Script web app after a verified
+ *   `[EMAIL REGISTERED EVENT]`. Transport: **GET**
+ *   `?action=sendEmailVerification&secret=...&email=...&verification_key=...&return_url=...`
+ *   (`doGet`), with **POST JSON** fallback (`doPost`).
+ * - The handler emails the contributor a DApp link with `em` + `vk` query params.
+ *
+ * ---------------------------------------------------------------------------
+ * Where the code lives (Edgar default `EMAIL_VERIFICATION_GAS_WEBHOOK_URL`)
+ * ---------------------------------------------------------------------------
+ * - Source: `edgar_send_email_verification.gs`
+ * - Script ID: `1m8IZPs1vFN99cuu-39kbC-OGXggRVtJtXq5rfSB0M1sCQjMdolEUDuGU` (owned by admin@truesight.me;
+ *   deploy web app **Execute as** that user so mail sends from admin@truesight.me).
+ * - Clasp mirror: `tokenomics/clasp_mirrors/1m8IZPs1vFN99cuu-39kbC-OGXggRVtJtXq5rfSB0M1sCQjMdolEUDuGU/`
+ *
+ * ---------------------------------------------------------------------------
+ * Related projects (not used for this webhook unless you override env)
+ * ---------------------------------------------------------------------------
+ * - **Telegram log → sheet** — `register_member_digital_signatures_telegram.gs`, script `10NKp8…`,
+ *   `doGet` action `processDigitalSignatureEvents` only.
+ * - **Gmail ingestion** — `register_member_digital_signatures_email.gs`, script `1zKg…`.
+ *
+ * Script property on the **1m8IZ** project (Project Settings → Script properties):
+ * - `EMAIL_VERIFICATION_SECRET` — must match Edgar `EMAIL_VERIFICATION_GAS_SECRET` /
+ *   `EMAIL_VERIFICATION_SECRET`.
+ *
+ * Deploy (1m8IZ project):
+ * - Deploy → New deployment → Web app
+ * - Execute as: **User (admin@truesight.me)** (sender for `GmailApp.sendEmail`)
+ * - Who has access: **Anyone**
+ * - Copy the `/exec` URL into Edgar env `EMAIL_VERIFICATION_GAS_WEBHOOK_URL` (or rely on
+ *   `sentiment_importer` default in `config/application.rb` after deploy URL is stable).
+ */

--- a/google_app_scripts/tdg_identity_management/register_member_digital_signatures_email.gs
+++ b/google_app_scripts/tdg_identity_management/register_member_digital_signatures_email.gs
@@ -1,8 +1,22 @@
 /**
  * File: google_app_scripts/tdg_identity_management/register_member_digital_signatures_email.gs
  * Repository: https://github.com/TrueSightDAO/tokenomics
- * 
- * Description: Registers new contributor digital signatures submitted via email.
+ *
+ * Description: Time-based Gmail ingestion for `[DIGITAL SIGNATURE EVENT]` messages (separate
+ * pipeline from Telegram). Runs as **admin@truesight.me** in its own Apps Script project.
+ *
+ * ---------------------------------------------------------------------------
+ * Apps Script project (Gmail ingestion; not Edgar’s default verification webhook)
+ * ---------------------------------------------------------------------------
+ * - Script ID: 1zKgMwd6KJFjoWkRH6OobgFvtVzrXVuEKfxVbgixgnfcp4TZTjrsfNKq0
+ * - Editor URL (opens in the account that owns the project; `/u/N/` may vary):
+ *   https://script.google.com/u/2/home/projects/1zKgMwd6KJFjoWkRH6OobgFvtVzrXVuEKfxVbgixgnfcp4TZTjrsfNKq0/edit
+ * - Web app deployment URL (`/exec`):
+ *   https://script.google.com/macros/s/AKfycbwbtBlxkK0TzwLGnwUNQ_INfvLFvTRli-31r-b51Tnx4c-xlwMoqwT5sKFmfZv5lN6sLQ/exec
+ *
+ * Edgar (`sentiment_importer`) sends verification email via **`edgar_send_email_verification.gs`**
+ * (script `1m8IZ…`, deployment in `sentiment_importer/config/application.rb` by default).
+ * Override `EMAIL_VERIFICATION_GAS_WEBHOOK_URL` only if you point verification at another web app.
  */
 
 /**

--- a/google_app_scripts/tdg_identity_management/register_member_digital_signatures_telegram.gs
+++ b/google_app_scripts/tdg_identity_management/register_member_digital_signatures_telegram.gs
@@ -1,8 +1,27 @@
 /**
  * File: google_app_scripts/tdg_identity_management/register_member_digital_signatures_telegram.gs
  * Repository: https://github.com/TrueSightDAO/tokenomics
- * 
+ *
  * Description: Registers new contributor digital signatures submitted via Telegram.
+ * Web app `doGet` action `processDigitalSignatureEvents` scans Telegram Chat Logs and updates
+ * Contributors Digital Signatures (and Telegram notifications). Edgar DApp **verification email**
+ * is handled by a **separate** project: `edgar_send_email_verification.gs` (script `1m8IZ…`).
+ *
+ * ---------------------------------------------------------------------------
+ * Apps Script project (this file + clasp mirror below must stay in sync)
+ * ---------------------------------------------------------------------------
+ * - Script ID: 10NKp8uLMGyfgDv0ByakHVGioOYzvDV7NbHMSBigB2TCVcY7aqYXhbywv
+ * - Editor URL:
+ *   https://script.google.com/home/projects/10NKp8uLMGyfgDv0ByakHVGioOYzvDV7NbHMSBigB2TCVcY7aqYXhbywv/edit
+ * - Web app deployment URL (`/exec`; `action=processDigitalSignatureEvents` only on this project):
+ *   https://script.google.com/macros/s/AKfycbwlh2u-SktykzL6S_qamE2rQVd-G_3uSd3GhJ_8KI5b2e8oVuMYxXA5UfJ-NaigOk60/exec
+ * - Clasp mirror (push from repo): tokenomics/clasp_mirrors/10NKp8uLMGyfgDv0ByakHVGioOYzvDV7NbHMSBigB2TCVcY7aqYXhbywv/
+ *
+ * (Editor links may include `/u/0/`, `/u/1/`, … depending on which Google account is active;
+ * the script ID in the path is stable.)
+ *
+ * See also `register_member_digital_signatures_email.gs` (Gmail ingestion) and
+ * `edgar_send_email_verification.gs` (Edgar → verification email, admin-owned script).
  */
 
 /**
@@ -53,6 +72,35 @@ const CONFIG = {
   }
 };
 
+/** Spreadsheet ID from https://docs.google.com/spreadsheets/d/<ID>/... */
+function extractSpreadsheetIdFromUrl_(url) {
+  const m = String(url || '').match(/\/spreadsheets\/d\/([a-zA-Z0-9-_]+)/);
+  return m ? m[1] : '';
+}
+
+/** Tab gid from #gid= or &gid= in spreadsheet URL */
+function extractGidFromUrl_(url) {
+  const m = String(url || '').match(/(?:[#&?])gid=(\d+)/);
+  return m ? Number(m[1]) : null;
+}
+
+/**
+ * Prefer exact tab name; if getSheetByName returns null (rename, hidden copy, locale),
+ * resolve by gid from CONFIG (stable).
+ */
+function getSheetByNameOrGid_(spreadsheet, sheetName, fallbackGid) {
+  if (!spreadsheet) return null;
+  const byName = spreadsheet.getSheetByName(sheetName);
+  if (byName) return byName;
+  if (fallbackGid == null || Number.isNaN(Number(fallbackGid))) return null;
+  const want = Number(fallbackGid);
+  const sheets = spreadsheet.getSheets();
+  for (let i = 0; i < sheets.length; i++) {
+    if (sheets[i].getSheetId() === want) return sheets[i];
+  }
+  return null;
+}
+
 function doGet(e) {
   const action = e.parameter?.action;
   if (action === 'processDigitalSignatureEvents') {
@@ -66,9 +114,13 @@ function doGet(e) {
     }
   }
 
-  return ContentService.createTextOutput("ℹ️ No valid action specified");
+  return ContentService.createTextOutput(
+    JSON.stringify({
+      ok: false,
+      error: 'No valid action (use action=processDigitalSignatureEvents on GET).',
+    })
+  ).setMimeType(ContentService.MimeType.JSON);
 }
-
 
 /**
  * Main function to process digital signature events
@@ -98,14 +150,40 @@ function processDigitalSignatureEvents() {
  * Load required sheets and data
  */
 function loadSheets() {
-  const sourceSheet = SpreadsheetApp
-    .openByUrl(CONFIG.SOURCE.URL)
-    .getSheetByName(CONFIG.SOURCE.SHEET_NAME);
-    
-  const signaturesSheet = SpreadsheetApp
-    .openByUrl(CONFIG.SIGNATURES.URL)
-    .getSheetByName(CONFIG.SIGNATURES.SHEET_NAME);
-    
+  const sourceId = extractSpreadsheetIdFromUrl_(CONFIG.SOURCE.URL);
+  const sigId = extractSpreadsheetIdFromUrl_(CONFIG.SIGNATURES.URL);
+  if (!sourceId) throw new Error('CONFIG.SOURCE.URL is missing a spreadsheet id.');
+  if (!sigId) throw new Error('CONFIG.SIGNATURES.URL is missing a spreadsheet id.');
+
+  const sourceSs = SpreadsheetApp.openById(sourceId);
+  const sourceSheet = getSheetByNameOrGid_(
+    sourceSs,
+    CONFIG.SOURCE.SHEET_NAME,
+    extractGidFromUrl_(CONFIG.SOURCE.URL)
+  );
+  if (!sourceSheet) {
+    throw new Error('Telegram Chat Logs tab not found (name="' + CONFIG.SOURCE.SHEET_NAME + '").');
+  }
+
+  const sigSs = SpreadsheetApp.openById(sigId);
+  const signaturesSheet = getSheetByNameOrGid_(
+    sigSs,
+    CONFIG.SIGNATURES.SHEET_NAME,
+    extractGidFromUrl_(CONFIG.SIGNATURES.URL)
+  );
+  if (!signaturesSheet) {
+    const tabList = sigSs
+      .getSheets()
+      .map(s => '"' + s.getName() + '" (gid=' + s.getSheetId() + ')')
+      .join(', ');
+    throw new Error(
+      'Contributors Digital Signatures tab not found (name="' +
+        CONFIG.SIGNATURES.SHEET_NAME +
+        '"). Known tabs: ' +
+        tabList
+    );
+  }
+
   return {
     sourceData: sourceSheet.getDataRange().getValues(),
     signaturesSheet: signaturesSheet
@@ -116,8 +194,13 @@ function loadSheets() {
  * Get existing signatures from registry
  */
 function getExistingSignatures(sheet) {
-  return sheet.getDataRange()
-    .getValues()
+  if (!sheet) {
+    Logger.log('getExistingSignatures: sheet is null/undefined.');
+    return [];
+  }
+  const values = sheet.getDataRange().getValues();
+  if (!values || values.length < 2) return [];
+  return values
     .slice(1) // Skip header
     .map(row => row[CONFIG.SIGNATURES.COLUMNS.SIGNATURE])
     .filter(Boolean);


### PR DESCRIPTION
## Summary
Moves DApp **verification email** sending out of the Telegram log processor project and into a **standalone** Apps Script (`edgar_send_email_verification.gs`, script `1m8IZ…`, admin-owned) so mail sends from **admin@truesight.me**. The **10NKp8** project keeps **`processDigitalSignatureEvents`** only.

## Repo changes
- **New:** `google_app_scripts/tdg_identity_management/edgar_send_email_verification.gs` — `doGet` (`sendEmailVerification`) + `doPost` JSON; documented editor + `/exec` URL (clasp mirror files remain local; `clasp_mirrors/**/*.js` is gitignored).
- **Updated:** `register_member_digital_signatures_telegram.gs` — removed verification handlers; JSON unknown-action response for GET.
- **Updated:** `register_member_digital_signatures_email.gs`, `email_verification_from_edgar.gs`, `README.md` — cross-links and which project Edgar calls.
- **SCHEMA.md:** Contributors Digital Signatures columns **G** / `VERIFYING` onboarding; fixed links to `tdg_identity_management`; notes on Edgar + verification script.

## Related PRs
- **sentiment_importer:** default `EMAIL_VERIFICATION_GAS_WEBHOOK_URL` + Edgar service.
- **dapp:** `create_signature.html` UX.

## Ops
- Deploy **1m8IZ** web app as **Execute as** admin; set `EMAIL_VERIFICATION_SECRET` to match Edgar.
- `clasp push` from local mirrors as needed (not in this PR).

Made with [Cursor](https://cursor.com)