### PR TITLE
feat(agroverse-qr): migrate qr_code_web_service to admin@truesight.me, consolidate owner emails

### DIFF
--- a/clasp_mirrors/1slQVojn5P2wC7l5LdFesFT243afkZ2HQ9no9mciExl574VeOe3Wom2rW/.clasp.json
+++ b/clasp_mirrors/1slQVojn5P2wC7l5LdFesFT243afkZ2HQ9no9mciExl574VeOe3Wom2rW/.clasp.json
@@ -1,5 +1,5 @@
 {
-  "scriptId": "1slQVojn5P2wC7l5LdFesFT243afkZ2HQ9no9mciExl574VeOe3Wom2rW",
+  "scriptId": "1MnAsIQAxcSfZO_hALOtMFJ4y1k4OnqeXKMwYs6xev600rPNUYepqcXsT",
   "rootDir": "",
   "scriptExtensions": [
     ".js",

--- a/google_app_scripts/_clasp_default/Version.gs
+++ b/google_app_scripts/_clasp_default/Version.gs
@@ -13,12 +13,13 @@
  */
 
 /** ISO UTC timestamp of the last clasp push for this mirror */
-var CLASP_MIRROR_LAST_CLASP_PUSH_UTC = '2026-04-15T23:10:00Z';
+var CLASP_MIRROR_LAST_CLASP_PUSH_UTC = '2026-04-17T00:00:00Z';
 
 /**
  * Newest first. Keep lines short; link PRs/commits in git instead of pasting secrets.
  */
 var CLASP_MIRROR_CHANGELOG =
+  '2026-04-17 — Migrate qr_code_web_service to admin@truesight.me project; consolidate processBatch to send one email per owner across multiple QR codes.\n' +
   '2026-04-15 — loadSheets: openById + getSheetByNameOrGid_ fallback (fix undefined signaturesSheet / getDataRange crash).\n' +
   '2026-04-15 — Identity web app: add doPost email verification trigger for DApp email onboarding (Edgar → Gmail).\n' +
   '2026-04-12 — Added default Version.gs for clasp deploy audit trail (tokenomics).\n';

--- a/google_app_scripts/agroverse_qr_codes/qr_code_web_service.gs
+++ b/google_app_scripts/agroverse_qr_codes/qr_code_web_service.gs
@@ -1679,22 +1679,48 @@ function testSendEmail() {
 }
 
 /**
- * Processes all records with valid email in column L and no sent date in column M
+ * Processes all records with valid email in column L and no sent date in column M.
+ * Groups rows by email address so owners who bought multiple items receive one consolidated email.
  */
 function processBatch() {
   const sheet = SpreadsheetApp.openByUrl(SUBSCRIPTION_NOTIFICATION_WORKBOOK_URL).getSheetByName(SHEET_NAME);
   const data = sheet.getDataRange().getValues();
   const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+  const now = new Date();
 
-  // Iterate through rows, starting at 1 to skip header
+  // Collect all pending rows grouped by email
+  const pendingByEmail = {};
   for (let i = 1; i < data.length; i++) {
-    const email = data[i][EMAIL_COLUMN - 1]; // Column L
-    const notificationDate = data[i][TIMESTAMP_COLUMN - 1]; // Column M
-    const qrCode = data[i][QR_CODE_COLUMN - 1]; // Column A
-
-    // Check if email is valid and no notification date exists
+    const email = String(data[i][EMAIL_COLUMN - 1] || '').trim();
+    const notificationDate = data[i][TIMESTAMP_COLUMN - 1];
+    const qrCode = data[i][QR_CODE_COLUMN - 1];
+    const baseUrl = data[i][1]; // Column B
     if (emailRegex.test(email) && !notificationDate) {
-      sendEmailForQRCode(qrCode);
+      if (!pendingByEmail[email]) pendingByEmail[email] = [];
+      pendingByEmail[email].push({ rowIndex: i, qrCode, baseUrl });
+    }
+  }
+
+  const doc = DocumentApp.openById(GOOGLE_DOC_ID);
+  const subject = doc.getName();
+
+  for (const email in pendingByEmail) {
+    const items = pendingByEmail[email];
+    let body = doc.getBody().getText();
+
+    // Build one tracking link per QR code; join with line break for multiple items
+    const trackingLinksHtml = items
+      .map(item => `<a href="${item.baseUrl}?qr_code=${encodeURIComponent(item.qrCode)}">${item.qrCode}</a>`)
+      .join('<br>');
+
+    body = body.replace('{{TRACKING_LINK}}', trackingLinksHtml);
+    const htmlBody = HtmlService.createHtmlOutput(body.replace(/\n/g, '<br>')).getContent();
+
+    MailApp.sendEmail({ to: email, subject, htmlBody });
+
+    // Stamp column M for every row included in this send
+    for (const item of items) {
+      sheet.getRange(item.rowIndex + 1, TIMESTAMP_COLUMN).setValue(now);
     }
   }
 }


### PR DESCRIPTION
## Summary
- Migrate `qr_code_web_service` GAS project from `garyjob@agroverse.shop` to `admin@truesight.me` by updating `.clasp.json` scriptId to the new project (`1MnAsIQAxcSfZO…`)
- Rewrite `processBatch()` to group pending rows by email address before sending — owners who bought multiple items now receive one consolidated email listing all their QR tracking links, rather than a separate email per QR code
- Bump `Version.gs` changelog with migration note

## Test plan
- [ ] Verify new GAS project (`https://script.google.com/home/projects/1MnAsIQAxcSfZO_hALOtMFJ4y1k4OnqeXKMwYs6xev600rPNUYepqcXsT/edit`) has the updated code after `clasp push`
- [ ] Run `testSendEmail()` in the new project editor to verify email delivery from admin@truesight.me
- [ ] Confirm old project cron trigger (`1slQVojn…`) and ghost project (`1IBrXqW…`) triggers are deleted
- [ ] Confirm `batch_qr_generator.html` in dapp repo points to the new exec URL (separate PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)