### PR TITLE
feat(metrics): GAS to mirror Pipeline Dashboard → ecosystem_change_logs

### DIFF
--- a/clasp_mirrors/11fA8NXSOwKyddXDZmmx3BRCDU1Y38GVidENCj0mujH0pT-AqIoOyaetj/.clasp.json
+++ b/clasp_mirrors/11fA8NXSOwKyddXDZmmx3BRCDU1Y38GVidENCj0mujH0pT-AqIoOyaetj/.clasp.json
@@ -1,0 +1,16 @@
+{
+  "scriptId": "11fA8NXSOwKyddXDZmmx3BRCDU1Y38GVidENCj0mujH0pT-AqIoOyaetj",
+  "rootDir": "",
+  "scriptExtensions": [
+    ".js",
+    ".gs"
+  ],
+  "htmlExtensions": [
+    ".html"
+  ],
+  "jsonExtensions": [
+    ".json"
+  ],
+  "filePushOrder": [],
+  "skipSubdirectories": false
+}

--- a/google_app_scripts/README.md
+++ b/google_app_scripts/README.md
@@ -24,6 +24,7 @@ This repository contains Google Apps Script projects that power the TrueSight DA
 - **[agroverse_qr_code_web_service](./agroverse_qr_code_web_service/)** - Standalone web service for QR code operations and currency management
 - **[holistic_hit_list_store_history](./holistic_hit_list_store_history/)** - Read-only web API for the holistic wellness hit list: store autocomplete and interaction history for the DApp human-in-the-loop email workflow
 - **[newsletter_subscriber_sync](./newsletter_subscriber_sync/)** - Daily (time-driven) sync into **Agroverse News Letter Subscribers** from Email Agent Suggestions, Agroverse QR codes, and Hit List rows with Status **Partnered**
+- **[pipeline_metrics_snapshot](./pipeline_metrics_snapshot/)** - Daily sync of the Pipeline Dashboard funnel into `TrueSightDAO/ecosystem_change_logs` as `metrics/weekly.json` + `metrics/weekly.md` (feeds the "Operator metrics" section of `ADVISORY_SNAPSHOT.md`)
 
 ## Getting Started
 

--- a/google_app_scripts/pipeline_metrics_snapshot/README.md
+++ b/google_app_scripts/pipeline_metrics_snapshot/README.md
@@ -1,0 +1,69 @@
+# pipeline_metrics_snapshot
+
+Google Apps Script that mirrors the **Pipeline Dashboard** tab of the Holistic
+Hit List workbook into `TrueSightDAO/ecosystem_change_logs` as a machine feed
+(`metrics/weekly.json`) and human mirror (`metrics/weekly.md`).
+
+## Why this exists
+
+The advisory snapshot generator
+(`market_research/scripts/generate_advisory_snapshot.py`) embeds an "Operator
+metrics" block into `ADVISORY_SNAPSHOT.md`, which the iChing Oracle GAS fetches
+on every `mode=oracle_advice` call. That block used to read from
+`agentic_ai_context/METRICS_WEEKLY.md`, which was an operator-curated stub that
+never got filled in — so every oracle response flagged "No operator metrics
+are populated" as a context gap.
+
+This GAS replaces that manual step: the operator maintains the Pipeline
+Dashboard (which they already do for the DApp `stores_by_status.html` view),
+and the GAS publishes the funnel snapshot on a schedule.
+
+## Source
+
+Pipeline Dashboard tab (curated funnel order in cols C–E):
+<https://docs.google.com/spreadsheets/d/1eiqZr3LW-qEI6Hmy0Vrur_8flbRwxwA7jXVrbUnHbvc/edit#gid=1606881029>
+
+## Outputs
+
+- `metrics/weekly.json` — canonical machine feed. Schema: `generated_at`,
+  `source{workbook_id,tab,gid,url}`, `totals{all_stores,partnered}`,
+  `funnel[]{order,status,stores}`.
+- `metrics/weekly.md` — dropped verbatim under the "## Operator metrics"
+  heading in `ADVISORY_SNAPSHOT.md`.
+
+Both land in `TrueSightDAO/ecosystem_change_logs@main` via the GitHub
+Contents API (no git push from GAS).
+
+## Setup
+
+1. Create a new Apps Script project, paste `sync_pipeline_metrics.gs` in.
+2. Add the script's editor URL to the file's header comment.
+3. Project → Script Properties:
+   - `GITHUB_TOKEN` — fine-grained PAT with **Contents: Read and write** on
+     `TrueSightDAO/ecosystem_change_logs` (classic PAT with `repo` scope also
+     works).
+4. From the editor, run `runOneSetup()` once to grant
+   `SpreadsheetApp` + `UrlFetchApp` permissions and confirm the GitHub token
+   works. Check the execution log — all three sections should report `ok:true`.
+5. Run `installDailyTrigger()` once to schedule `syncPipelineMetrics()` daily
+   at 06:00 (project timezone).
+6. Manually invoke `syncPipelineMetrics()` once to seed both files on the
+   first run. After that the daily trigger keeps them fresh.
+
+## Consumers
+
+- `market_research/scripts/generate_advisory_snapshot.py` — reads
+  `metrics/weekly.md` from the sibling checkout of `ecosystem_change_logs`
+  during the 6-hourly `advisory-snapshot-refresh.yml` CI run.
+- `iching_oracle/gas/oracle_advisory_bridge.gs` — downstream of the above
+  (reads `ADVISORY_SNAPSHOT.md` raw).
+
+## Relation to other Hit List GAS
+
+`holistic_hit_list_store_history/store_interaction_history_api.gs` already
+exposes a `listStatusSummary` action that buckets Hit List rows by status —
+but it reads the source tab (`Hit List`), not the operator-curated funnel
+order in the Pipeline Dashboard. This GAS uses the Dashboard view precisely
+because the ordering is operator-intent, not alphabetical — the oracle wants
+stages in sequence (Partnered → Meeting Scheduled → Shortlisted → … →
+Rejected), which the source tab alone can't provide.

--- a/google_app_scripts/pipeline_metrics_snapshot/README.md
+++ b/google_app_scripts/pipeline_metrics_snapshot/README.md
@@ -36,15 +36,19 @@ Contents API (no git push from GAS).
 
 ## Setup
 
-1. Create a new Apps Script project, paste `sync_pipeline_metrics.gs` in.
-2. Add the script's editor URL to the file's header comment.
+1. **Deployed project:** <https://script.google.com/home/projects/11fA8NXSOwKyddXDZmmx3BRCDU1Y38GVidENCj0mujH0pT-AqIoOyaetj/edit>
+2. Work locally from the clasp mirror: `clasp_mirrors/11fA8NXSOwKyddXDZmmx3BRCDU1Y38GVidENCj0mujH0pT-AqIoOyaetj/`.
+   After editing `google_app_scripts/pipeline_metrics_snapshot/sync_pipeline_metrics.gs`,
+   copy into the mirror and `clasp push` from the mirror folder.
 3. Project → Script Properties:
-   - `GITHUB_TOKEN` — fine-grained PAT with **Contents: Read and write** on
-     `TrueSightDAO/ecosystem_change_logs` (classic PAT with `repo` scope also
-     works).
-4. From the editor, run `runOneSetup()` once to grant
-   `SpreadsheetApp` + `UrlFetchApp` permissions and confirm the GitHub token
-   works. Check the execution log — all three sections should report `ok:true`.
+   - `ORACLE_ADVISORY_PUSH_TOKEN` — same fine-grained PAT used by the
+     `advisory-snapshot-refresh` CI workflow secret (Contents: Read+Write on
+     `TrueSightDAO/agentic_ai_context` **and**
+     `TrueSightDAO/ecosystem_change_logs`). Reuse the existing token so one
+     PAT covers both publishers of the oracle context instead of a new one.
+4. From the editor, run `runOneSetup()` once to grant `SpreadsheetApp` +
+   `UrlFetchApp` permissions and confirm the push token works. Check the
+   execution log — `sheet_read.ok` and `github_ping.ok` should both be true.
 5. Run `installDailyTrigger()` once to schedule `syncPipelineMetrics()` daily
    at 06:00 (project timezone).
 6. Manually invoke `syncPipelineMetrics()` once to seed both files on the

--- a/google_app_scripts/pipeline_metrics_snapshot/sync_pipeline_metrics.gs
+++ b/google_app_scripts/pipeline_metrics_snapshot/sync_pipeline_metrics.gs
@@ -1,0 +1,384 @@
+/**
+ * File: google_app_scripts/pipeline_metrics_snapshot/sync_pipeline_metrics.gs
+ * Repository: https://github.com/TrueSightDAO/tokenomics
+ * Apps Script editor: (set after first `clasp push` / manual create)
+ *
+ * Purpose: Mirror the Holistic Hit List "Pipeline Dashboard" tab into
+ *   TrueSightDAO/ecosystem_change_logs as `metrics/weekly.json` + `metrics/weekly.md`.
+ *
+ *   The advisory snapshot generator (market_research/scripts/generate_advisory_snapshot.py)
+ *   reads `metrics/weekly.md` into the "Operator metrics" section of ADVISORY_SNAPSHOT.md.
+ *   Previously that section pointed at agentic_ai_context/METRICS_WEEKLY.md which was an
+ *   operator-edited stub that went stale and surfaced as TODO comments in the oracle
+ *   context. Auto-syncing from the Pipeline Dashboard removes the manual step.
+ *
+ * Source: Pipeline Dashboard tab of the Holistic Hit List workbook
+ *   https://docs.google.com/spreadsheets/d/1eiqZr3LW-qEI6Hmy0Vrur_8flbRwxwA7jXVrbUnHbvc/edit#gid=1606881029
+ *
+ *   Layout (col C = pipeline order, col D = status label, col E = store count),
+ *   rows 2..N. Column pair A/B is an alphabetized mirror; ignored because the
+ *   oracle benefits from the curated funnel order in cols C–E.
+ *
+ * Outputs (committed to TrueSightDAO/ecosystem_change_logs main via Contents API):
+ *   - metrics/weekly.json  — machine feed (schema described in weekly.md header)
+ *   - metrics/weekly.md    — human mirror; embedded verbatim into ADVISORY_SNAPSHOT.md
+ *
+ * Setup:
+ *   1. Create a GAS project, paste this file in, note the script id, add it to the
+ *      header comment above.
+ *   2. Script Properties:
+ *      - GITHUB_TOKEN — fine-grained PAT with Contents:Read+Write on
+ *        TrueSightDAO/ecosystem_change_logs (classic `repo` scope also works).
+ *   3. Run `runOneSetup()` once from the editor to grant SpreadsheetApp + UrlFetch
+ *      permissions and verify the GitHub token works.
+ *   4. Run `installDailyTrigger()` once to schedule syncPipelineMetrics() daily.
+ */
+
+// ============================================================================
+// CONSTANTS
+// ============================================================================
+
+var HIT_LIST_SPREADSHEET_ID = '1eiqZr3LW-qEI6Hmy0Vrur_8flbRwxwA7jXVrbUnHbvc';
+var PIPELINE_TAB = 'Pipeline Dashboard';
+var PIPELINE_TAB_GID = 1606881029;
+var PIPELINE_TAB_URL =
+  'https://docs.google.com/spreadsheets/d/' + HIT_LIST_SPREADSHEET_ID +
+  '/edit#gid=' + PIPELINE_TAB_GID;
+
+// Ordered funnel lives in cols C (order), D (status label), E (store count).
+var ORDER_COL = 3;   // C
+var STATUS_COL = 4;  // D
+var COUNT_COL = 5;   // E
+var DATA_START_ROW = 2;
+
+// Stages classified as "partnered success" — the north-star metric the oracle
+// cares about most. Keep as a set so funnel label changes elsewhere don't
+// silently break the total.
+var PARTNERED_STATUSES = ['Partnered'];
+
+var TARGET_REPO_OWNER = 'TrueSightDAO';
+var TARGET_REPO = 'ecosystem_change_logs';
+var TARGET_BRANCH = 'main';
+var WEEKLY_JSON_PATH = 'metrics/weekly.json';
+var WEEKLY_MD_PATH = 'metrics/weekly.md';
+
+// ============================================================================
+// ENTRY POINTS
+// ============================================================================
+
+/**
+ * Main sync. Reads the Pipeline Dashboard, builds JSON + MD artifacts, and
+ * commits both to TrueSightDAO/ecosystem_change_logs@main.
+ *
+ * Idempotent: if neither artifact's bytes changed, the GitHub API returns 200
+ * on the GET-sha check and we skip the PUT to avoid empty commits.
+ */
+function syncPipelineMetrics() {
+  var token = _requireGithubToken_();
+  var funnel = _readPipelineFunnel_();
+  var artifacts = _buildArtifacts_(funnel);
+
+  var jsonResult = _upsertFile_(
+    token,
+    WEEKLY_JSON_PATH,
+    artifacts.json,
+    'chore(metrics): refresh pipeline funnel weekly.json'
+  );
+  var mdResult = _upsertFile_(
+    token,
+    WEEKLY_MD_PATH,
+    artifacts.md,
+    'chore(metrics): refresh pipeline funnel weekly.md'
+  );
+
+  Logger.log('json: ' + jsonResult.status + ' | md: ' + mdResult.status);
+  return { json: jsonResult, md: mdResult, funnel: funnel };
+}
+
+/**
+ * One-time authorization + smoke test. Run from the editor after first paste.
+ * Does NOT write to GitHub — just reads the sheet and pings the contents API
+ * so any auth failures surface immediately.
+ */
+function runOneSetup() {
+  var props = PropertiesService.getScriptProperties();
+  var token = (props.getProperty('GITHUB_TOKEN') || '').trim();
+  var status = {
+    now_utc: new Date().toISOString(),
+    github_token_present: Boolean(token),
+    sheet_read: null,
+    github_ping: null
+  };
+
+  try {
+    var funnel = _readPipelineFunnel_();
+    status.sheet_read = {
+      ok: true,
+      stages: funnel.rows.length,
+      total_stores: funnel.total_stores,
+      partnered: funnel.partnered
+    };
+  } catch (err) {
+    status.sheet_read = { ok: false, error: String(err && err.message || err) };
+  }
+
+  if (token) {
+    try {
+      var url = 'https://api.github.com/repos/' + TARGET_REPO_OWNER + '/' + TARGET_REPO;
+      var res = UrlFetchApp.fetch(url, {
+        method: 'get',
+        muteHttpExceptions: true,
+        headers: {
+          Authorization: 'token ' + token,
+          Accept: 'application/vnd.github.v3+json'
+        }
+      });
+      status.github_ping = {
+        response_code: res.getResponseCode(),
+        ok: res.getResponseCode() === 200
+      };
+    } catch (err) {
+      status.github_ping = { ok: false, error: String(err && err.message || err) };
+    }
+  }
+
+  Logger.log(JSON.stringify(status, null, 2));
+  return status;
+}
+
+/**
+ * Install a time-driven trigger that runs syncPipelineMetrics() daily.
+ * Runs at 06:00 in the script's timezone (set in GAS project settings) so the
+ * artifact is fresh before the first advisory-snapshot-refresh CI run of the
+ * day (which currently fires at :27 every 6 hours). Safe to re-run; it
+ * removes any existing syncPipelineMetrics triggers before creating the new one.
+ */
+function installDailyTrigger() {
+  var triggers = ScriptApp.getProjectTriggers();
+  for (var i = 0; i < triggers.length; i++) {
+    if (triggers[i].getHandlerFunction() === 'syncPipelineMetrics') {
+      ScriptApp.deleteTrigger(triggers[i]);
+    }
+  }
+  ScriptApp.newTrigger('syncPipelineMetrics')
+    .timeBased()
+    .everyDays(1)
+    .atHour(6)
+    .create();
+  Logger.log('Daily trigger installed: syncPipelineMetrics @ 06:00 project TZ');
+}
+
+// ============================================================================
+// SHEET READ
+// ============================================================================
+
+function _readPipelineFunnel_() {
+  var ss = SpreadsheetApp.openById(HIT_LIST_SPREADSHEET_ID);
+  var sh = ss.getSheetByName(PIPELINE_TAB);
+  if (!sh) {
+    throw new Error('Pipeline Dashboard tab not found in workbook');
+  }
+  var lastRow = sh.getLastRow();
+  if (lastRow < DATA_START_ROW) {
+    return { rows: [], total_stores: 0, partnered: 0 };
+  }
+
+  // Pull C..E in one call for the full data range.
+  var numRows = lastRow - DATA_START_ROW + 1;
+  var values = sh.getRange(DATA_START_ROW, ORDER_COL, numRows, 3).getValues();
+
+  var rows = [];
+  var totalStores = 0;
+  var partnered = 0;
+  var partneredSet = {};
+  for (var p = 0; p < PARTNERED_STATUSES.length; p++) {
+    partneredSet[PARTNERED_STATUSES[p]] = true;
+  }
+
+  for (var i = 0; i < values.length; i++) {
+    var orderVal = values[i][0];
+    var statusVal = values[i][1];
+    var countVal = values[i][2];
+
+    var status = String(statusVal || '').trim();
+    if (!status) continue; // skip blank rows (footers, spacers)
+
+    var order = (orderVal === '' || orderVal === null) ? null : Number(orderVal);
+    if (order !== null && !isFinite(order)) order = null;
+
+    var count = (countVal === '' || countVal === null) ? 0 : Number(countVal);
+    if (!isFinite(count)) count = 0;
+
+    rows.push({ order: order, status: status, stores: count });
+    totalStores += count;
+    if (partneredSet[status]) partnered += count;
+  }
+
+  // Sort by curated order; rows without an order number trail, stable by position.
+  rows.sort(function (a, b) {
+    if (a.order === null && b.order === null) return 0;
+    if (a.order === null) return 1;
+    if (b.order === null) return -1;
+    return a.order - b.order;
+  });
+
+  return {
+    rows: rows,
+    total_stores: totalStores,
+    partnered: partnered
+  };
+}
+
+// ============================================================================
+// ARTIFACT BUILDERS
+// ============================================================================
+
+function _buildArtifacts_(funnel) {
+  var now = new Date();
+  var generatedAt = now.toISOString();
+
+  var jsonObj = {
+    generated_at: generatedAt,
+    source: {
+      workbook_id: HIT_LIST_SPREADSHEET_ID,
+      tab: PIPELINE_TAB,
+      gid: PIPELINE_TAB_GID,
+      url: PIPELINE_TAB_URL
+    },
+    totals: {
+      all_stores: funnel.total_stores,
+      partnered: funnel.partnered
+    },
+    funnel: funnel.rows
+  };
+
+  var jsonText = JSON.stringify(jsonObj, null, 2) + '\n';
+
+  // Markdown ordered from highest-signal (closest to conversion) down. The
+  // advisory snapshot embeds this verbatim under "## Operator metrics ...".
+  var mdLines = [];
+  mdLines.push('# Operator metrics — pipeline funnel');
+  mdLines.push('');
+  mdLines.push('_Auto-synced from the Pipeline Dashboard tab of the Holistic Hit List workbook._');
+  mdLines.push('_Do not edit by hand — see `google_app_scripts/pipeline_metrics_snapshot/` in tokenomics._');
+  mdLines.push('');
+  mdLines.push('- Generated (UTC): `' + generatedAt + '`');
+  mdLines.push('- Source: [Pipeline Dashboard](' + PIPELINE_TAB_URL + ')');
+  mdLines.push('- Total stores tracked: **' + funnel.total_stores + '**');
+  mdLines.push('- Partnered (north-star): **' + funnel.partnered + '**');
+  mdLines.push('');
+  mdLines.push('## Funnel by status (curated order)');
+  mdLines.push('');
+
+  if (!funnel.rows.length) {
+    mdLines.push('_(no stages — Pipeline Dashboard is empty)_');
+  } else {
+    for (var i = 0; i < funnel.rows.length; i++) {
+      var r = funnel.rows[i];
+      var orderTag = (r.order === null || r.order === undefined) ? '—' : ('#' + r.order);
+      var isPartnered = false;
+      for (var p = 0; p < PARTNERED_STATUSES.length; p++) {
+        if (PARTNERED_STATUSES[p] === r.status) { isPartnered = true; break; }
+      }
+      var label = isPartnered ? ('**' + r.status + ': ' + r.stores + '**') : (r.status + ': ' + r.stores);
+      mdLines.push('- ' + label + '  (' + orderTag + ')');
+    }
+  }
+
+  mdLines.push('');
+  return { json: jsonText, md: mdLines.join('\n') };
+}
+
+// ============================================================================
+// GITHUB CONTENTS API
+// ============================================================================
+
+function _requireGithubToken_() {
+  var token = (PropertiesService.getScriptProperties().getProperty('GITHUB_TOKEN') || '').trim();
+  if (!token) {
+    throw new Error('Missing script property GITHUB_TOKEN — fine-grained PAT with Contents:Read+Write on ' + TARGET_REPO_OWNER + '/' + TARGET_REPO);
+  }
+  return token;
+}
+
+/**
+ * Create-or-update a single file in the target repo/branch. Skips the PUT if
+ * the remote file's content already matches, which keeps commit history clean
+ * when the dashboard hasn't moved.
+ */
+function _upsertFile_(token, path, content, commitMessage) {
+  var contentsUrl =
+    'https://api.github.com/repos/' + TARGET_REPO_OWNER + '/' + TARGET_REPO +
+    '/contents/' + encodeURI(path) + '?ref=' + encodeURIComponent(TARGET_BRANCH);
+
+  var existing = UrlFetchApp.fetch(contentsUrl, {
+    method: 'get',
+    muteHttpExceptions: true,
+    headers: {
+      Authorization: 'token ' + token,
+      Accept: 'application/vnd.github.v3+json'
+    }
+  });
+
+  var existingSha = null;
+  var existingBytes = null;
+  var code = existing.getResponseCode();
+  if (code === 200) {
+    var parsed = JSON.parse(existing.getContentText());
+    existingSha = parsed.sha || null;
+    if (parsed.content && parsed.encoding === 'base64') {
+      existingBytes = Utilities.base64Decode(parsed.content.replace(/\n/g, ''));
+    }
+  } else if (code !== 404) {
+    throw new Error('GitHub GET ' + path + ' failed (' + code + '): ' +
+      existing.getContentText().slice(0, 400));
+  }
+
+  var newBytes = Utilities.newBlob(content, 'text/plain', path).getBytes();
+
+  if (existingBytes && _bytesEqual_(existingBytes, newBytes)) {
+    return { path: path, status: 'unchanged', sha: existingSha };
+  }
+
+  var payload = {
+    message: commitMessage,
+    branch: TARGET_BRANCH,
+    content: Utilities.base64Encode(newBytes)
+  };
+  if (existingSha) payload.sha = existingSha;
+
+  var putUrl =
+    'https://api.github.com/repos/' + TARGET_REPO_OWNER + '/' + TARGET_REPO +
+    '/contents/' + encodeURI(path);
+  var res = UrlFetchApp.fetch(putUrl, {
+    method: 'put',
+    contentType: 'application/json',
+    muteHttpExceptions: true,
+    headers: {
+      Authorization: 'token ' + token,
+      Accept: 'application/vnd.github.v3+json'
+    },
+    payload: JSON.stringify(payload)
+  });
+
+  var putCode = res.getResponseCode();
+  if (putCode !== 200 && putCode !== 201) {
+    throw new Error('GitHub PUT ' + path + ' failed (' + putCode + '): ' +
+      res.getContentText().slice(0, 400));
+  }
+  var body = JSON.parse(res.getContentText());
+  return {
+    path: path,
+    status: existingSha ? 'updated' : 'created',
+    commit_url: body && body.commit && body.commit.html_url || null,
+    sha: body && body.content && body.content.sha || null
+  };
+}
+
+function _bytesEqual_(a, b) {
+  if (a.length !== b.length) return false;
+  for (var i = 0; i < a.length; i++) {
+    if (a[i] !== b[i]) return false;
+  }
+  return true;
+}

--- a/google_app_scripts/pipeline_metrics_snapshot/sync_pipeline_metrics.gs
+++ b/google_app_scripts/pipeline_metrics_snapshot/sync_pipeline_metrics.gs
@@ -24,13 +24,14 @@
  *   - metrics/weekly.md    — human mirror; embedded verbatim into ADVISORY_SNAPSHOT.md
  *
  * Setup:
- *   1. Create a GAS project, paste this file in, note the script id, add it to the
- *      header comment above.
+ *   1. Deployed project: https://script.google.com/home/projects/11fA8NXSOwKyddXDZmmx3BRCDU1Y38GVidENCj0mujH0pT-AqIoOyaetj/edit
  *   2. Script Properties:
- *      - GITHUB_TOKEN — fine-grained PAT with Contents:Read+Write on
- *        TrueSightDAO/ecosystem_change_logs (classic `repo` scope also works).
+ *      - ORACLE_ADVISORY_PUSH_TOKEN — same fine-grained PAT used by the advisory-snapshot-refresh
+ *        CI secret (Contents: Read+Write on TrueSightDAO/agentic_ai_context and
+ *        TrueSightDAO/ecosystem_change_logs). Reused here so one token covers both publishers
+ *        of the oracle context instead of proliferating PATs.
  *   3. Run `runOneSetup()` once from the editor to grant SpreadsheetApp + UrlFetch
- *      permissions and verify the GitHub token works.
+ *      permissions and verify the push token works.
  *   4. Run `installDailyTrigger()` once to schedule syncPipelineMetrics() daily.
  */
 
@@ -102,7 +103,7 @@ function syncPipelineMetrics() {
  */
 function runOneSetup() {
   var props = PropertiesService.getScriptProperties();
-  var token = (props.getProperty('GITHUB_TOKEN') || '').trim();
+  var token = (props.getProperty('ORACLE_ADVISORY_PUSH_TOKEN') || '').trim();
   var status = {
     now_utc: new Date().toISOString(),
     github_token_present: Boolean(token),
@@ -294,9 +295,9 @@ function _buildArtifacts_(funnel) {
 // ============================================================================
 
 function _requireGithubToken_() {
-  var token = (PropertiesService.getScriptProperties().getProperty('GITHUB_TOKEN') || '').trim();
+  var token = (PropertiesService.getScriptProperties().getProperty('ORACLE_ADVISORY_PUSH_TOKEN') || '').trim();
   if (!token) {
-    throw new Error('Missing script property GITHUB_TOKEN — fine-grained PAT with Contents:Read+Write on ' + TARGET_REPO_OWNER + '/' + TARGET_REPO);
+    throw new Error('Missing script property ORACLE_ADVISORY_PUSH_TOKEN — fine-grained PAT with Contents:Read+Write on ' + TARGET_REPO_OWNER + '/' + TARGET_REPO);
   }
   return token;
 }


### PR DESCRIPTION
## Summary

- New GAS project `google_app_scripts/pipeline_metrics_snapshot/sync_pipeline_metrics.gs` mirrors the Pipeline Dashboard tab of the Holistic Hit List workbook into `TrueSightDAO/ecosystem_change_logs@main` as `metrics/weekly.json` + `metrics/weekly.md` via the GitHub Contents API.
- Replaces the operator-curated `agentic_ai_context/METRICS_WEEKLY.md` stub that kept going stale and surfacing as literal `<!-- TODO: replace... -->` comments in `ADVISORY_SNAPSHOT.md`, which `oracle.truesight.me` flagged as "No operator metrics are populated" on every call.
- **Already deployed** via `clasp push` to <https://script.google.com/home/projects/11fA8NXSOwKyddXDZmmx3BRCDU1Y38GVidENCj0mujH0pT-AqIoOyaetj/edit>. Clasp mirror registered at `clasp_mirrors/11fA8NXS…aetj/`.

## Why

The oracle reads `ADVISORY_SNAPSHOT.md` from `agentic_ai_context`. That snapshot is regenerated every 6 hours by the `advisory-snapshot-refresh` CI in `market_research`, but two of its sections (Operator metrics, Constraints) were concatenated straight from `METRICS_WEEKLY.md` / `CONSTRAINTS.md` — files only ever committed as template stubs and never filled in. Result: the advisor LLM has been correctly flagging missing context for days.

Auto-sync the numeric slice from the dashboard the operator already maintains for DApp `stores_by_status.html` instead of asking them to curate a weekly markdown file.

## Script Property

- **`ORACLE_ADVISORY_PUSH_TOKEN`** — the same fine-grained PAT the `advisory-snapshot-refresh` CI workflow already uses (Contents: Read+Write on `TrueSightDAO/agentic_ai_context` **and** `TrueSightDAO/ecosystem_change_logs`). Reusing it keeps one PAT for all publishers of the oracle context rather than proliferating tokens.

## What it does

- Reads cols C (order) / D (status) / E (count) from the Pipeline Dashboard (curated funnel order, not alphabetical).
- Emits JSON + bulleted MD with `generated_at`, source URL, totals (`all_stores`, `partnered` as the north-star metric), and the full funnel array.
- Upsert via Contents API, skipping PUT when bytes haven't changed (no empty commits).
- Daily trigger at 06:00 project TZ, fresh before the first 6-hourly CI run of the day.

Paired PRs:
- market_research — repoints generator: https://github.com/TrueSightDAO/go_to_market/pull/63
- agentic_ai_context — deletes stubs: https://github.com/TrueSightDAO/agentic_ai_context/pull/33

## Test plan

- [x] Clasp push to deployed project — 3 files uploaded (appsscript.json, Code.js, Version.gs) ✓
- [ ] In the deployed GAS, set Script Property `ORACLE_ADVISORY_PUSH_TOKEN` to the existing CI PAT value
- [ ] Run `runOneSetup()` from the editor — `sheet_read.ok: true`, `github_ping.ok: true`
- [ ] Run `syncPipelineMetrics()` once — new commits on `ecosystem_change_logs@main` creating `metrics/weekly.json` + `metrics/weekly.md`
- [ ] Verify MD renders cleanly on GitHub (funnel stages in curated order, Partnered bolded)
- [ ] Run `installDailyTrigger()` — Triggers view shows one time-based trigger for `syncPipelineMetrics` at ~06:00 daily
- [ ] Re-run `syncPipelineMetrics()` immediately — both artifacts report `status: 'unchanged'` (idempotency)
- [ ] After paired market_research PR merges, verify next 6-hour `advisory-snapshot-refresh` run produces `ADVISORY_SNAPSHOT.md` with a real funnel (not "_Not yet created_")

🤖 Generated with [Claude Code](https://claude.com/claude-code)