### PR TITLE
feat(tdg-inventory): notify treasury-cache-publisher after inventory movements

### DIFF
--- a/google_app_scripts/tdg_inventory_management/Version.gs
+++ b/google_app_scripts/tdg_inventory_management/Version.gs
@@ -13,12 +13,13 @@
  */
 
 /** ISO UTC timestamp of the last clasp push for mirrors that include this file */
-var TDG_INVENTORY_LAST_CLASP_PUSH_UTC = '2026-04-12T20:31:26Z';
+var TDG_INVENTORY_LAST_CLASP_PUSH_UTC = '2026-04-21T19:50:00Z';
 
 /**
  * Newest first. Keep lines short; link PRs/commits in git instead of pasting secrets.
  */
 var TDG_INVENTORY_CHANGELOG =
+  '2026-04-21 — process_movement_telegram_logs: notify treasury-cache-publisher after each INVENTORY MOVEMENT batch lands (fire-and-forget; requires TREASURY_CACHE_PUBLISH_SECRET script prop on mirror 1wONDeDwZ_…).\n' +
   '2026-04-12 — QR Code Sales L–R column order: L Owner email, M Stripe Session, N Shipping, O Tracking, P Sold by, Q Cash Collected By, R Remarks; process_sales row tail + ledger scripts + sentiment_importer Stripe append aligned.\n' +
   '2026-04-12 — process_sales_telegram_logs: append QR Code Sales row with Status=IGNORED + Remarks (col R) when no sale or blocked; 18-col append (J–R); dedupe Telegram id stops repeat Grok.\n' +
   '2026-04-12 — Version.gs: deploy metadata (last clasp push UTC + changelog) added to Parse Telegram, offchain ledger, and managed AGL clasp projects; source in tokenomics google_app_scripts/tdg_inventory_management (dfc39c3).\n' +

--- a/google_app_scripts/tdg_inventory_management/process_movement_telegram_logs.gs
+++ b/google_app_scripts/tdg_inventory_management/process_movement_telegram_logs.gs
@@ -908,6 +908,7 @@ function processTelegramChatLogsToInventoryMovement() {
     if (newRows.length > 0) {
       inventorySheet.getRange(inventoryLastRow + 1, 1, newRows.length, 14).setValues(newRows);
       Logger.log(`✅ Immediately inserted ${newRows.length} new records into Inventory Movement sheet`);
+      notifyTreasuryCachePublisher_('movement');
     }
 
     // Log comprehensive execution summary
@@ -1462,5 +1463,37 @@ function checkFileExistsInGitHub(fileUrl) {
   } catch (e) {
     Logger.log(`checkFileExistsInGitHub: Error checking file existence in GitHub: ${e.message}`);
     return false;
+  }
+}
+
+/**
+ * Fire-and-forget notification to the treasury-cache-publisher web app so it
+ * rebuilds dao_offchain_treasury.json + SNAPSHOT.md (TrueSightDAO/treasury-cache)
+ * right after an inventory movement lands. Safety-net cron on the publisher
+ * project still runs every 30 minutes, so silently skipping here (e.g. missing
+ * secret, transient network error) just defers the refresh — it never loses data.
+ *
+ * Requires script property TREASURY_CACHE_PUBLISH_SECRET (shared with the
+ * publisher project 1u4lVtGaO5GjpG0XQo7b8hc3QFAXcsrJKclBead2sDcgvatMdE6dm3mzx).
+ */
+function notifyTreasuryCachePublisher_(trigger) {
+  try {
+    const secret = PropertiesService.getScriptProperties()
+      .getProperty('TREASURY_CACHE_PUBLISH_SECRET');
+    if (!secret) {
+      Logger.log('notifyTreasuryCachePublisher_: TREASURY_CACHE_PUBLISH_SECRET not set; skipping (cron will catch up)');
+      return;
+    }
+    const url = 'https://script.google.com/macros/s/AKfycbyBmjwmFhR8nQ5ZCtdqQwr-OgC5-htdFnMeXOKLD-Z-NWvNpLGvi7nPbMQVvnhrnbSXdQ/exec'
+      + '?action=publish&trigger=' + encodeURIComponent(trigger || 'movement')
+      + '&token=' + encodeURIComponent(secret);
+    const resp = UrlFetchApp.fetch(url, {
+      method: 'get',
+      muteHttpExceptions: true,
+      followRedirects: true
+    });
+    Logger.log(`notifyTreasuryCachePublisher_: HTTP ${resp.getResponseCode()}`);
+  } catch (err) {
+    Logger.log(`notifyTreasuryCachePublisher_: notify failed (non-fatal): ${err}`);
   }
 }


### PR DESCRIPTION
## Summary

- Adds `notifyTreasuryCachePublisher_(trigger)` helper to `process_movement_telegram_logs.gs` and calls it from `processTelegramChatLogsToInventoryMovement()` when a batch of `[INVENTORY MOVEMENT]` rows lands in the 'Inventory Movement' sheet.
- Fire-and-forget GET to the new **treasury-cache-publisher** Apps Script (project `1u4lVtGa…`, webhook already deployed) which rebuilds [`dao_offchain_treasury.json`](https://github.com/TrueSightDAO/treasury-cache/blob/main/dao_offchain_treasury.json) + [`SNAPSHOT.md`](https://github.com/TrueSightDAO/treasury-cache/blob/main/SNAPSHOT.md) on `TrueSightDAO/treasury-cache` and commits them to `main` via the GitHub Contents API. Publishes within a minute of a movement instead of waiting up to 30 min for the safety-net cron on the publisher project.
- Version.gs bump + changelog entry.

## Backstory

The Warehouse Manager + Inventory Item dropdowns on [`dapp/report_inventory_movement.html`](https://dapp.truesight.me/report_inventory_movement.html) currently fan out to the `tdg_inventory_management` web app on every page load, which aggregates across every AGL ledger in real time. Cold load is slow, and integrations can't pick up the data without going through the same GAS. The treasury-cache repo is the pre-computed snapshot; this PR is the 'refresh now' side of the pipeline.

## Safety

- Pure additive change — no movement-processing logic touched.
- If `TREASURY_CACHE_PUBLISH_SECRET` script property is missing, the helper logs a skip line and returns — movement still lands on the sheet.
- If the webhook is down or returns 5xx, `muteHttpExceptions: true` swallows the error; the safety-net cron on the publisher project catches up within 30 min.
- Webhook itself is guarded by a shared secret (PAT stays on the publisher project; we only ship the lightweight publish token here).

## Test plan

- [x] Script property `TREASURY_CACHE_PUBLISH_SECRET` set on movement-processor project (`1wONDeDwZ_…`) by operator.
- [x] Code pushed to that project via clasp from `clasp_mirrors/1wONDeDwZ_…/`.
- [ ] Redeploy the web app so `/exec` serves the new code (Deploy → Manage deployments → New version).
- [ ] Post a `[INVENTORY MOVEMENT]` test message through the Telegram → Edgar → 'Telegram Chat Logs' pipeline (or invoke `processTelegramChatLogsToInventoryMovement` manually against a fresh test row).
- [ ] Confirm Execution log shows `notifyTreasuryCachePublisher_: HTTP 200`.
- [ ] Confirm new commit on https://github.com/TrueSightDAO/treasury-cache/commits/main with trigger=movement.
- [ ] Confirm updated totals in `dao_offchain_treasury.json` reflect the test movement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)