### PR TITLE
feat(metrics): highlight Meeting Scheduled + Shortlisted in summary

### DIFF
--- a/google_app_scripts/pipeline_metrics_snapshot/README.md
+++ b/google_app_scripts/pipeline_metrics_snapshot/README.md
@@ -26,10 +26,14 @@ Pipeline Dashboard tab (curated funnel order in cols C–E):
 ## Outputs
 
 - `metrics/weekly.json` — canonical machine feed. Schema: `generated_at`,
-  `source{workbook_id,tab,gid,url}`, `totals{all_stores,partnered}`,
-  `funnel[]{order,status,stores}`.
+  `source{workbook_id,tab,gid,url}`, `totals{all_stores, partnered,
+  highlights[]{status, stores, north_star}}`, `funnel[]{order, status,
+  stores}`.
 - `metrics/weekly.md` — dropped verbatim under the "## Operator metrics"
-  heading in `ADVISORY_SNAPSHOT.md`.
+  heading in `ADVISORY_SNAPSHOT.md`. Summary block surfaces the stages in
+  `HIGHLIGHT_STATUSES` (currently `Partnered`, `Meeting Scheduled`,
+  `Shortlisted`) above the full funnel breakdown so the oracle gets a fast
+  "where's the action this week" read.
 
 Both land in `TrueSightDAO/ecosystem_change_logs@main` via the GitHub
 Contents API (no git push from GAS).

--- a/google_app_scripts/pipeline_metrics_snapshot/sync_pipeline_metrics.gs
+++ b/google_app_scripts/pipeline_metrics_snapshot/sync_pipeline_metrics.gs
@@ -52,10 +52,19 @@ var STATUS_COL = 4;  // D
 var COUNT_COL = 5;   // E
 var DATA_START_ROW = 2;
 
-// Stages classified as "partnered success" — the north-star metric the oracle
-// cares about most. Keep as a set so funnel label changes elsewhere don't
-// silently break the total.
-var PARTNERED_STATUSES = ['Partnered'];
+// North-star: stages that count as a closed partnership win. Keep as a set
+// so funnel label changes don't silently break the "partnered" total.
+var NORTH_STAR_STATUSES = ['Partnered'];
+
+// Stages surfaced in the summary block above the full funnel breakdown —
+// "where's the action this week". Ordered intentionally (north-star first,
+// then stages close to conversion). A stage not present in the Pipeline
+// Dashboard is quietly skipped so the summary never shows phantom zeroes.
+var HIGHLIGHT_STATUSES = [
+  'Partnered',          // north-star win
+  'Meeting Scheduled',  // one step from Partnered
+  'Shortlisted'         // warm candidates; one personal email away
+];
 
 var TARGET_REPO_OWNER = 'TrueSightDAO';
 var TARGET_REPO = 'ecosystem_change_logs';
@@ -191,10 +200,11 @@ function _readPipelineFunnel_() {
   var rows = [];
   var totalStores = 0;
   var partnered = 0;
-  var partneredSet = {};
-  for (var p = 0; p < PARTNERED_STATUSES.length; p++) {
-    partneredSet[PARTNERED_STATUSES[p]] = true;
+  var northStarSet = {};
+  for (var p = 0; p < NORTH_STAR_STATUSES.length; p++) {
+    northStarSet[NORTH_STAR_STATUSES[p]] = true;
   }
+  var countsByStatus = {};
 
   for (var i = 0; i < values.length; i++) {
     var orderVal = values[i][0];
@@ -212,7 +222,8 @@ function _readPipelineFunnel_() {
 
     rows.push({ order: order, status: status, stores: count });
     totalStores += count;
-    if (partneredSet[status]) partnered += count;
+    if (northStarSet[status]) partnered += count;
+    countsByStatus[status] = count;
   }
 
   // Sort by curated order; rows without an order number trail, stable by position.
@@ -223,10 +234,26 @@ function _readPipelineFunnel_() {
     return a.order - b.order;
   });
 
+  // Resolve highlights in the order declared by HIGHLIGHT_STATUSES. Missing
+  // labels are quietly dropped so a sheet relabel doesn't render phantom zeroes
+  // (they still appear in the full funnel below).
+  var highlights = [];
+  for (var h = 0; h < HIGHLIGHT_STATUSES.length; h++) {
+    var label = HIGHLIGHT_STATUSES[h];
+    if (Object.prototype.hasOwnProperty.call(countsByStatus, label)) {
+      highlights.push({
+        status: label,
+        stores: countsByStatus[label],
+        north_star: Boolean(northStarSet[label])
+      });
+    }
+  }
+
   return {
     rows: rows,
     total_stores: totalStores,
-    partnered: partnered
+    partnered: partnered,
+    highlights: highlights
   };
 }
 
@@ -248,12 +275,18 @@ function _buildArtifacts_(funnel) {
     },
     totals: {
       all_stores: funnel.total_stores,
-      partnered: funnel.partnered
+      partnered: funnel.partnered,
+      highlights: funnel.highlights
     },
     funnel: funnel.rows
   };
 
   var jsonText = JSON.stringify(jsonObj, null, 2) + '\n';
+
+  var northStarSet = {};
+  for (var ns = 0; ns < NORTH_STAR_STATUSES.length; ns++) {
+    northStarSet[NORTH_STAR_STATUSES[ns]] = true;
+  }
 
   // Markdown ordered from highest-signal (closest to conversion) down. The
   // advisory snapshot embeds this verbatim under "## Operator metrics ...".
@@ -266,7 +299,11 @@ function _buildArtifacts_(funnel) {
   mdLines.push('- Generated (UTC): `' + generatedAt + '`');
   mdLines.push('- Source: [Pipeline Dashboard](' + PIPELINE_TAB_URL + ')');
   mdLines.push('- Total stores tracked: **' + funnel.total_stores + '**');
-  mdLines.push('- Partnered (north-star): **' + funnel.partnered + '**');
+  for (var hi = 0; hi < funnel.highlights.length; hi++) {
+    var hl = funnel.highlights[hi];
+    var suffix = hl.north_star ? ' (north-star)' : '';
+    mdLines.push('- ' + hl.status + suffix + ': **' + hl.stores + '**');
+  }
   mdLines.push('');
   mdLines.push('## Funnel by status (curated order)');
   mdLines.push('');
@@ -277,11 +314,9 @@ function _buildArtifacts_(funnel) {
     for (var i = 0; i < funnel.rows.length; i++) {
       var r = funnel.rows[i];
       var orderTag = (r.order === null || r.order === undefined) ? '—' : ('#' + r.order);
-      var isPartnered = false;
-      for (var p = 0; p < PARTNERED_STATUSES.length; p++) {
-        if (PARTNERED_STATUSES[p] === r.status) { isPartnered = true; break; }
-      }
-      var label = isPartnered ? ('**' + r.status + ': ' + r.stores + '**') : (r.status + ': ' + r.stores);
+      var label = northStarSet[r.status]
+        ? ('**' + r.status + ': ' + r.stores + '**')
+        : (r.status + ': ' + r.stores);
       mdLines.push('- ' + label + '  (' + orderTag + ')');
     }
   }


### PR DESCRIPTION
## Summary

Expand the summary block at the top of `metrics/weekly.md` (and the `totals` section of `metrics/weekly.json`) to surface not just **Partnered** but also **Meeting Scheduled** and **Shortlisted** — the stages where a single email this week is likely to advance a store into Partnered.

Previously the oracle had to parse the full 15-stage funnel to find near-conversion signal. Now the fast read is at the top.

## MD preview (sample)

```
- Generated (UTC): `2026-04-21T21:08:42Z`
- Source: [Pipeline Dashboard](...)
- Total stores tracked: **516**
- Partnered (north-star): **13**
- Meeting Scheduled: **1**
- Shortlisted: **3**

## Funnel by status (curated order)

- ...  <full 15-stage breakdown unchanged>
```

## JSON schema change

`totals` gains one key:

```json
"totals": {
  "all_stores": 516,
  "partnered": 13,
  "highlights": [
    {"status": "Partnered",         "stores": 13, "north_star": true},
    {"status": "Meeting Scheduled", "stores": 1,  "north_star": false},
    {"status": "Shortlisted",       "stores": 3,  "north_star": false}
  ]
}
```

Additive only — `all_stores` and `partnered` still exist, order preserved. No breaking change for any consumer.

## Implementation notes

- New `HIGHLIGHT_STATUSES` constant at the top of the GAS — reorder / add / remove stages there without touching any logic.
- Renamed the existing `PARTNERED_STATUSES` to `NORTH_STAR_STATUSES` to separate the two concerns (what counts as a win vs. what gets surfaced in the summary).
- Missing labels (e.g. operator renames "Shortlisted" in the sheet) are silently dropped from the summary so the output never shows phantom zero rows — they'd still appear in the full funnel below with whatever the new label is.

## Deployment

Already pushed live via `clasp push` to <https://script.google.com/home/projects/11fA8NXSOwKyddXDZmmx3BRCDU1Y38GVidENCj0mujH0pT-AqIoOyaetj/edit>. Next `syncPipelineMetrics()` run (manual or tomorrow 06:00 trigger) will produce the new format. No Script Property or trigger changes needed.

## Test plan

- [x] Node parse-check of the `.gs` file passes
- [x] Dry-run `_buildArtifacts_` with sample funnel data produces expected MD + JSON
- [x] `clasp push --force` successful — 3 files pushed to deployed project
- [ ] After merge, run `syncPipelineMetrics()` once in the editor
- [ ] Verify `metrics/weekly.md` on ecosystem_change_logs main shows 3 highlighted bullets (Partnered, Meeting Scheduled, Shortlisted)
- [ ] Verify `metrics/weekly.json` shows `totals.highlights[]` populated
- [ ] Trigger `advisory-snapshot-refresh` and confirm `ADVISORY_SNAPSHOT.md` picks up the new format cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)