### PR TITLE
feat(gas): notify treasury-cache-publisher on 5 additional write-paths

### DIFF
--- a/google_app_scripts/tdg_asset_management/capital_injection_processing.gs
+++ b/google_app_scripts/tdg_asset_management/capital_injection_processing.gs
@@ -677,13 +677,46 @@ function parseAndProcessCapitalInjectionLogs() {
     }
     
     Logger.log(`\n📊 Parsing complete: ${processedCount} capital injections recorded, ${skippedCount} skipped`);
-    
+
     // Now process the NEW records
     Logger.log(`\n🔄 Processing NEW capital injection records...`);
     processNewCapitalInjections();
-    
+
+    if (processedCount > 0) {
+      notifyTreasuryCachePublisher_('capital_injection');
+    }
+
   } catch (e) {
     Logger.log(`ERROR in parseAndProcessCapitalInjectionLogs: ${e.message}`);
+  }
+}
+
+/**
+ * Fire-and-forget notification to the treasury-cache-publisher web app so it
+ * rebuilds dao_offchain_treasury.json + SNAPSHOT.md. Safety-net cron on the
+ * publisher still runs every 30 min, so a silent skip here just defers the
+ * refresh — it never loses data. Requires TREASURY_CACHE_PUBLISH_SECRET script
+ * property (shared with publisher project 1u4lVtGaO5Gj…).
+ */
+function notifyTreasuryCachePublisher_(trigger) {
+  try {
+    const secret = PropertiesService.getScriptProperties()
+      .getProperty('TREASURY_CACHE_PUBLISH_SECRET');
+    if (!secret) {
+      Logger.log('notifyTreasuryCachePublisher_: TREASURY_CACHE_PUBLISH_SECRET not set; skipping (cron will catch up)');
+      return;
+    }
+    const url = 'https://script.google.com/macros/s/AKfycbyBmjwmFhR8nQ5ZCtdqQwr-OgC5-htdFnMeXOKLD-Z-NWvNpLGvi7nPbMQVvnhrnbSXdQ/exec'
+      + '?action=publish&trigger=' + encodeURIComponent(trigger || 'movement')
+      + '&token=' + encodeURIComponent(secret);
+    const resp = UrlFetchApp.fetch(url, {
+      method: 'get',
+      muteHttpExceptions: true,
+      followRedirects: true
+    });
+    Logger.log(`notifyTreasuryCachePublisher_: HTTP ${resp.getResponseCode()}`);
+  } catch (err) {
+    Logger.log(`notifyTreasuryCachePublisher_: notify failed (non-fatal): ${err}`);
   }
 }
 

--- a/google_app_scripts/tdg_asset_management/tdg_expenses_processing.gs
+++ b/google_app_scripts/tdg_asset_management/tdg_expenses_processing.gs
@@ -1146,6 +1146,7 @@ function doGet(e) {
     try {
       Logger.log("Webhook triggered: processing Telegram logs for expense submissions");
       parseAndProcessTelegramLogs();
+      notifyTreasuryCachePublisher_('expense_processing');
       Logger.log("Webhook processing completed successfully");
       return ContentService.createTextOutput("✅ Telegram logs processed successfully. Check execution logs for details.");
     } catch (err) {
@@ -1157,6 +1158,35 @@ function doGet(e) {
 
   Logger.log(`No valid action specified. Received action: ${action || 'none'}`);
   return ContentService.createTextOutput("ℹ️ No valid action specified. Expected: ?action=parseAndProcessTelegramLogs");
+}
+
+/**
+ * Fire-and-forget notification to the treasury-cache-publisher web app so it
+ * rebuilds dao_offchain_treasury.json + SNAPSHOT.md. Safety-net cron on the
+ * publisher still runs every 30 min, so a silent skip here just defers the
+ * refresh — it never loses data. Requires TREASURY_CACHE_PUBLISH_SECRET script
+ * property (shared with publisher project 1u4lVtGaO5Gj…).
+ */
+function notifyTreasuryCachePublisher_(trigger) {
+  try {
+    const secret = PropertiesService.getScriptProperties()
+      .getProperty('TREASURY_CACHE_PUBLISH_SECRET');
+    if (!secret) {
+      Logger.log('notifyTreasuryCachePublisher_: TREASURY_CACHE_PUBLISH_SECRET not set; skipping (cron will catch up)');
+      return;
+    }
+    const url = 'https://script.google.com/macros/s/AKfycbyBmjwmFhR8nQ5ZCtdqQwr-OgC5-htdFnMeXOKLD-Z-NWvNpLGvi7nPbMQVvnhrnbSXdQ/exec'
+      + '?action=publish&trigger=' + encodeURIComponent(trigger || 'movement')
+      + '&token=' + encodeURIComponent(secret);
+    const resp = UrlFetchApp.fetch(url, {
+      method: 'get',
+      muteHttpExceptions: true,
+      followRedirects: true
+    });
+    Logger.log(`notifyTreasuryCachePublisher_: HTTP ${resp.getResponseCode()}`);
+  } catch (err) {
+    Logger.log(`notifyTreasuryCachePublisher_: notify failed (non-fatal): ${err}`);
+  }
 }
 
 // Test function to process a specific row from the source sheet

--- a/google_app_scripts/tdg_inventory_management/Version.gs
+++ b/google_app_scripts/tdg_inventory_management/Version.gs
@@ -13,12 +13,13 @@
  */
 
 /** ISO UTC timestamp of the last clasp push for mirrors that include this file */
-var TDG_INVENTORY_LAST_CLASP_PUSH_UTC = '2026-04-21T19:50:00Z';
+var TDG_INVENTORY_LAST_CLASP_PUSH_UTC = '2026-04-21T21:00:00Z';
 
 /**
  * Newest first. Keep lines short; link PRs/commits in git instead of pasting secrets.
  */
 var TDG_INVENTORY_CHANGELOG =
+  '2026-04-21 — process_sales_telegram_logs + sales_update_main_dao_offchain_ledger + sales_update_managed_agl_ledgers: notify treasury-cache-publisher at write-completion (each needs TREASURY_CACHE_PUBLISH_SECRET script prop on its own mirror).\n' +
   '2026-04-21 — process_movement_telegram_logs: notify treasury-cache-publisher after each INVENTORY MOVEMENT batch lands (fire-and-forget; requires TREASURY_CACHE_PUBLISH_SECRET script prop on mirror 1wONDeDwZ_…).\n' +
   '2026-04-12 — QR Code Sales L–R column order: L Owner email, M Stripe Session, N Shipping, O Tracking, P Sold by, Q Cash Collected By, R Remarks; process_sales row tail + ledger scripts + sentiment_importer Stripe append aligned.\n' +
   '2026-04-12 — process_sales_telegram_logs: append QR Code Sales row with Status=IGNORED + Remarks (col R) when no sale or blocked; 18-col append (J–R); dedupe Telegram id stops repeat Grok.\n' +

--- a/google_app_scripts/tdg_inventory_management/process_sales_telegram_logs.gs
+++ b/google_app_scripts/tdg_inventory_management/process_sales_telegram_logs.gs
@@ -210,6 +210,7 @@ function doGet(e) {
     try {
       Logger.log("Webhook triggered: processing Telegram logs");
       parseTelegramChatLogs();
+      notifyTreasuryCachePublisher_('process_sales');
       return ContentService.createTextOutput("✅ Telegram logs processed");
     } catch (err) {
       Logger.log("Error in processTelegramLogs: " + err.message);
@@ -224,6 +225,7 @@ function doGet(e) {
     try {
       Logger.log(`Processing specific row: ${rowIndex}`);
       processSpecificRow(rowIndex);
+      notifyTreasuryCachePublisher_('process_sales');
       return ContentService.createTextOutput(`✅ Row ${rowIndex} processed`);
     } catch (err) {
       Logger.log(`Error processing row ${rowIndex}: ${err.message}`);
@@ -232,6 +234,35 @@ function doGet(e) {
   }
 
   return ContentService.createTextOutput("ℹ️ No valid action specified");
+}
+
+/**
+ * Fire-and-forget notification to the treasury-cache-publisher web app so it
+ * rebuilds dao_offchain_treasury.json + SNAPSHOT.md. Safety-net cron on the
+ * publisher still runs every 30 min, so a silent skip here just defers the
+ * refresh — it never loses data. Requires TREASURY_CACHE_PUBLISH_SECRET script
+ * property (shared with publisher project 1u4lVtGaO5Gj…).
+ */
+function notifyTreasuryCachePublisher_(trigger) {
+  try {
+    const secret = PropertiesService.getScriptProperties()
+      .getProperty('TREASURY_CACHE_PUBLISH_SECRET');
+    if (!secret) {
+      Logger.log('notifyTreasuryCachePublisher_: TREASURY_CACHE_PUBLISH_SECRET not set; skipping (cron will catch up)');
+      return;
+    }
+    const url = 'https://script.google.com/macros/s/AKfycbyBmjwmFhR8nQ5ZCtdqQwr-OgC5-htdFnMeXOKLD-Z-NWvNpLGvi7nPbMQVvnhrnbSXdQ/exec'
+      + '?action=publish&trigger=' + encodeURIComponent(trigger || 'movement')
+      + '&token=' + encodeURIComponent(secret);
+    const resp = UrlFetchApp.fetch(url, {
+      method: 'get',
+      muteHttpExceptions: true,
+      followRedirects: true
+    });
+    Logger.log(`notifyTreasuryCachePublisher_: HTTP ${resp.getResponseCode()}`);
+  } catch (err) {
+    Logger.log(`notifyTreasuryCachePublisher_: notify failed (non-fatal): ${err}`);
+  }
 }
 
 // Function to check if contributorName is valid (matches Column H in Contributors sheet)

--- a/google_app_scripts/tdg_inventory_management/sales_update_main_dao_offchain_ledger.gs
+++ b/google_app_scripts/tdg_inventory_management/sales_update_main_dao_offchain_ledger.gs
@@ -214,6 +214,39 @@ function processTokenizedTransactions() {
   }
   
   Logger.log(`Processed ${sourceData.length - 1} rows, updated ${processedRows} records.`);
+
+  if (processedRows > 0) {
+    notifyTreasuryCachePublisher_('sales_update_main');
+  }
+}
+
+/**
+ * Fire-and-forget notification to the treasury-cache-publisher web app so it
+ * rebuilds dao_offchain_treasury.json + SNAPSHOT.md. Safety-net cron on the
+ * publisher still runs every 30 min, so a silent skip here just defers the
+ * refresh — it never loses data. Requires TREASURY_CACHE_PUBLISH_SECRET script
+ * property (shared with publisher project 1u4lVtGaO5Gj…).
+ */
+function notifyTreasuryCachePublisher_(trigger) {
+  try {
+    const secret = PropertiesService.getScriptProperties()
+      .getProperty('TREASURY_CACHE_PUBLISH_SECRET');
+    if (!secret) {
+      Logger.log('notifyTreasuryCachePublisher_: TREASURY_CACHE_PUBLISH_SECRET not set; skipping (cron will catch up)');
+      return;
+    }
+    const url = 'https://script.google.com/macros/s/AKfycbyBmjwmFhR8nQ5ZCtdqQwr-OgC5-htdFnMeXOKLD-Z-NWvNpLGvi7nPbMQVvnhrnbSXdQ/exec'
+      + '?action=publish&trigger=' + encodeURIComponent(trigger || 'movement')
+      + '&token=' + encodeURIComponent(secret);
+    const resp = UrlFetchApp.fetch(url, {
+      method: 'get',
+      muteHttpExceptions: true,
+      followRedirects: true
+    });
+    Logger.log(`notifyTreasuryCachePublisher_: HTTP ${resp.getResponseCode()}`);
+  } catch (err) {
+    Logger.log(`notifyTreasuryCachePublisher_: notify failed (non-fatal): ${err}`);
+  }
 }
 
 // Function to run the script manually or set up a trigger

--- a/google_app_scripts/tdg_inventory_management/sales_update_managed_agl_ledgers.gs
+++ b/google_app_scripts/tdg_inventory_management/sales_update_managed_agl_ledgers.gs
@@ -384,6 +384,39 @@ function processNonAgl4Transactions() {
   }
   
   Logger.log(`Processed ${sourceData.length - 1} rows, updated ${processedRows} records.`);
+
+  if (processedRows > 0) {
+    notifyTreasuryCachePublisher_('sales_update_agl');
+  }
+}
+
+/**
+ * Fire-and-forget notification to the treasury-cache-publisher web app so it
+ * rebuilds dao_offchain_treasury.json + SNAPSHOT.md. Safety-net cron on the
+ * publisher still runs every 30 min, so a silent skip here just defers the
+ * refresh — it never loses data. Requires TREASURY_CACHE_PUBLISH_SECRET script
+ * property (shared with publisher project 1u4lVtGaO5Gj…).
+ */
+function notifyTreasuryCachePublisher_(trigger) {
+  try {
+    const secret = PropertiesService.getScriptProperties()
+      .getProperty('TREASURY_CACHE_PUBLISH_SECRET');
+    if (!secret) {
+      Logger.log('notifyTreasuryCachePublisher_: TREASURY_CACHE_PUBLISH_SECRET not set; skipping (cron will catch up)');
+      return;
+    }
+    const url = 'https://script.google.com/macros/s/AKfycbyBmjwmFhR8nQ5ZCtdqQwr-OgC5-htdFnMeXOKLD-Z-NWvNpLGvi7nPbMQVvnhrnbSXdQ/exec'
+      + '?action=publish&trigger=' + encodeURIComponent(trigger || 'movement')
+      + '&token=' + encodeURIComponent(secret);
+    const resp = UrlFetchApp.fetch(url, {
+      method: 'get',
+      muteHttpExceptions: true,
+      followRedirects: true
+    });
+    Logger.log(`notifyTreasuryCachePublisher_: HTTP ${resp.getResponseCode()}`);
+  } catch (err) {
+    Logger.log(`notifyTreasuryCachePublisher_: notify failed (non-fatal): ${err}`);
+  }
 }
 
 // Function to run the script manually or set up a trigger


### PR DESCRIPTION
## Summary

Extends the cache-invalidation pattern started in #230 to every other GAS in `tdg_inventory_management` + `tdg_asset_management` that writes to the sheets the treasury-cache aggregates from. Each now fires a fire-and-forget GET at the [treasury-cache-publisher](https://github.com/TrueSightDAO/treasury-cache) webhook right after its write path successfully lands rows.

## Scripts affected (already clasp-pushed)

| Script | ScriptId | Trigger label | Writes to |
|---|---|---|---|
| `process_sales_telegram_logs.gs` | `1dsWecVw…` | `process_sales` | QR Code Sales; Agroverse QR codes status/metadata |
| `sales_update_main_dao_offchain_ledger.gs` | `1wmgYPwf…` | `sales_update_main` | `offchain transactions` (3-row asset/cash/liability blocks) |
| `sales_update_managed_agl_ledgers.gs` | `1duQFfTO…` | `sales_update_agl` | managed AGL ledger `Transactions` / `Balance` sheets |
| `capital_injection_processing.gs` | `1orWgdGc…` | `capital_injection` | Capital Injection sheet + managed AGL ledger transactions |
| `tdg_expenses_processing.gs` | `19Wag9x-…` | `expense_processing` | `offchain transactions` + managed AGL ledgers |

Already wired in #230: `process_movement_telegram_logs.gs` (`1wONDeDwZ_…`).

## Why each needs a hook

All of these eventually mutate one of:

1. **`offchain asset location`** (Main Ledger) — manager-controlled inventory by currency/amount
2. **managed AGL `Balance` sheets** (per-shipment spreadsheets, URLs in `Shipment Ledger Listing`)
3. **`Currencies` tab** (unit_cost_usd in col B; unit_weight_g in col K)

Those three are exactly what `treasury-cache-publisher` reads. Without hooks, the cache only refreshes on the 30-min safety-net cron — which is still correct, just stale-ish.

## Safety

- Pure additive change to each script — no write-processing logic touched.
- Each `notifyTreasuryCachePublisher_` is fire-and-forget (muted exceptions, non-fatal). If the webhook is down or the secret is missing, the script logs and returns — the underlying sheet write still lands.
- The publisher cron remains the safety net: worst-case staleness bounded at 30 min regardless of hook reliability.
- Webhook is guarded by `TREASURY_CACHE_PUBLISH_SECRET` — an unauthenticated caller gets `{ok:false, error:'unauthorized'}`.

## Operator steps (required)

For each of the 5 scriptIds above, open **Project Settings → Script properties** and add:

- Key: `TREASURY_CACHE_PUBLISH_SECRET`
- Value: same string already on the publisher (`1u4lVtGa…`) and movement processor (`1wONDeDwZ_…`)

Editor URLs:
- https://script.google.com/home/projects/1dsWecVwbN0dOvilIz9r8DNt7LD3Ay13V8G9qliow4tZtF5LHsvQOFpF7/edit
- https://script.google.com/home/projects/1wmgYPwfRDxpiboa8OH-C6Ndovklf8HaJY305n7dhRzs7BmUBQg7fL_sZ/edit
- https://script.google.com/home/projects/1duQFfTO0Pj0lC4tPVNmMOhNOS1GvJgzqVxXbsEDu-eqt_64DwxvrOVyl/edit
- https://script.google.com/home/projects/1orWgdGckts55owiYOysR_y4sde52T_eUmrtDGAEkb4YV5DlUfJ0JZC5J/edit
- https://script.google.com/home/projects/19Wag9x-sjbLVgIsPh2vj90ZG7Rgq2iGaVOomAeAvtg6CdZKJHLZ9AJrC/edit

Web-app deployments don't need bumping unless the operator wants the `/exec` URL to serve the new code path (only `tdg_expenses_processing` is reached via a `/exec` doGet; the others are triggered by time-based triggers or Edgar-side calls that invoke the functions directly).

## Test plan

- [x] Clasp pushed to all 5 projects (2026-04-21 14:41 PT).
- [ ] Operator sets `TREASURY_CACHE_PUBLISH_SECRET` script prop on each.
- [ ] Trigger any one of the scripts (e.g. run an `[INVENTORY EXPENSE]` through Edgar → tdg_expenses_processing).
- [ ] Confirm Execution log shows `notifyTreasuryCachePublisher_: HTTP 200`.
- [ ] Confirm new commit on https://github.com/TrueSightDAO/treasury-cache/commits/main with `trigger=<source>` in commit message.

🤖 Generated with [Claude Code](https://claude.com/claude-code)