### PR TITLE
feat(gas): inventory unauthorized + scored expense Processing Status

### DIFF
--- a/SCHEMA.md
+++ b/SCHEMA.md
@@ -1,8 +1,17 @@
 # TrueSight DAO - Google Sheets Schema Documentation
 
-> **Last Updated:** 2026-04-21
+> **Last Updated:** 2026-04-22
 > 
 > This document provides a consolidated reference for all Google Sheets used across TrueSight DAO's Google Apps Scripts. Use this as a central schema reference when making code changes.
+
+## 📝 Recent Changes (2026-04-22)
+
+### **Inventory Movement** / **Scored Expense Submissions** — signer vs manager authorization (GAS)
+
+- **`process_movement_telegram_logs.gs`:** Column **N** (`STATUS`) is **`NEW`** when **Telegram Chat Logs** column **S** (`Governor`) is **`YES`**, or when the **ACTIVE** signer (**Contributors Digital Signatures**) matches **`- Manager Name:`** from the movement payload; otherwise **`unauthorized`**. **`processInventoryMovementToLedgers`** only processes **`NEW`** (skips **`unauthorized`**).
+- **`tdg_expenses_processing.gs`:** **Scored Expense Submissions** column **N** — **`Processing Status`**: **`authorized`** under the same governor rule or when **Reporter Name** (column **E**) matches **DAO Member Name** (column **H**); otherwise **`unauthorized`**. **`InsertExpenseRecords`** does not write to ledgers when column **N** is **`unauthorized`** (row is still appended for audit). Legacy scored rows with only columns **A–M** are treated as authorized when inserted into ledgers by older code paths.
+
+---
 
 ## 📝 Recent Changes (2026-04-21)
 
@@ -297,6 +306,7 @@ See [`python_scripts/schema_validation/README.md`](./python_scripts/schema_valid
 | K | Scoring Hash Key | String | Unique identifier for deduplication |
 | L | Ledger Lines Number | String | Row number in destination ledger |
 | M | Target Ledger | String | Target ledger name (e.g., "AGL15", "AGL10", "offchain"). Set explicitly in expense form or derived from Inventory Type when embedded as `[ledger] currency` |
+| N | Processing Status | String | **`authorized`** — ledger insert allowed; **`unauthorized`** — audit row only (reporter ≠ DAO Member for selected inventory and **Telegram Chat Logs** `Governor` ≠ **YES**). Blank on legacy rows (**A–M** only) = treat as authorized for backward compatibility. |
 
 **Used by:**
 - [`tdg_expenses_processing.gs`](https://github.com/TrueSightDAO/tokenomics/blob/main/google_app_scripts/tdg_asset_management/tdg_expenses_processing.gs) - Inserts scored expenses into ledgers. Reads ledger configurations from "Shipment Ledger Listing" sheet (Column A: name, Column L: URL) instead of Wix API. Processes only rows from the last 30 days to prevent timeouts.
@@ -392,7 +402,7 @@ See [`python_scripts/schema_validation/README.md`](./python_scripts/schema_valid
 | K | AMOUNT | Number | Quantity transferred (note: header is uppercase) |
 | L | LEDGER_NAME | String | Source ledger name (e.g., "AGL#25" or "offchain") (note: header is uppercase with underscore) |
 | M | LEDGER_URL | String | Resolved spreadsheet URL (note: header is uppercase) |
-| N | STATUS | String | "NEW" or "PROCESSED" (note: header is uppercase) |
+| N | STATUS | String | **`NEW`** (authorized — ledger processing), **`unauthorized`** (signer is not warehouse manager and **Telegram Chat Logs** `Governor` ≠ **YES**), **`PROCESSED`**, or **`ERROR:`…** (note: header is uppercase) |
 | O | RECORD ROWS | String | Comma-separated destination row numbers (note: renamed from "Row Numbers") |
 
 **Used by:**

--- a/google_app_scripts/tdg_asset_management/tdg_expenses_processing.gs
+++ b/google_app_scripts/tdg_asset_management/tdg_expenses_processing.gs
@@ -57,6 +57,8 @@ const MESSAGE_COL = 6; // Column G (Expense Reported)
 const SALES_DATE_COL = 11; // Column L (Status Date)
 const HASH_KEY_COL = 13; // Column N (Scoring Hash Key)
 const TELEGRAM_FILE_ID_COL = 14; // Column O (Telegram File ID)
+/** Telegram Chat Logs column S (Governor): YES = global ledger authority (Edgar). 0-based index 18. */
+const TELEGRAM_GOVERNOR_COL = 18;
 
 // Column indices for Scored Expense Submissions sheet
 const DEST_UPDATE_ID_COL = 0; // Column A
@@ -72,6 +74,8 @@ const DEST_AMOUNT = 9; // Column J
 const DEST_HASH_KEY_COL = 10; // Column K
 const DEST_TRANSACTION_LINE_COL = 11; // Column L
 const DEST_TARGET_LEDGER_COL = 12; // Column M
+/** Scored Expense Submissions column N — Processing Status (authorized | unauthorized). */
+const DEST_PROCESSING_STATUS_COL = 13; // Column N (0-based)
 
 // Column indices for Contributors sheet
 const TELEGRAM_HANDLE_COL_CONTRIBUTORS = 7; // Column H (Telegram Handle)
@@ -346,6 +350,34 @@ function getLedgerConfigsFromWix() {
  * @return {string|null} return.contributorName - Contributor name if signature is valid and ACTIVE, null otherwise
  * @return {string|null} return.error - Error message if signature not found or not ACTIVE, null if successful
  */
+function normalizeAuthName_(name) {
+  return (name == null ? '' : String(name))
+    .trim()
+    .replace(/\s+/g, ' ')
+    .toLowerCase();
+}
+
+function authNamesMatchForExpense_(a, b) {
+  const na = normalizeAuthName_(a);
+  const nb = normalizeAuthName_(b);
+  return na !== '' && na === nb;
+}
+
+function isTelegramGovernorYesFromRow_(telegramRow) {
+  return String(telegramRow && telegramRow[TELEGRAM_GOVERNOR_COL] != null ? telegramRow[TELEGRAM_GOVERNOR_COL] : '')
+    .trim()
+    .toUpperCase() === 'YES';
+}
+
+/**
+ * Scored Expense column N: authorized if Telegram Governor is YES or reporter matches DAO Member (inventory owner).
+ */
+function computeExpenseProcessingStatus_(telegramRow, reporterName, daoMemberName) {
+  if (isTelegramGovernorYesFromRow_(telegramRow)) return 'authorized';
+  if (authNamesMatchForExpense_(reporterName, daoMemberName)) return 'authorized';
+  return 'unauthorized';
+}
+
 function findContributorByDigitalSignature(digitalSignature) {
   try {
     if (!digitalSignature) {
@@ -373,7 +405,7 @@ function findContributorByDigitalSignature(digitalSignature) {
         Logger.log(`Found contributor: ${contributorName} for signature`);
         
         // Check if status is ACTIVE
-        if (status === 'ACTIVE') {
+        if (String(status || '').trim().toUpperCase() === 'ACTIVE') {
           return { contributorName: contributorName, error: null };
         } else {
           return { 
@@ -660,6 +692,14 @@ function InsertExpenseRecords(scoredRow, rowIndex) {
     Logger.log(`InsertExpenseRecords called for rowIndex ${rowIndex + 1}`);
     Logger.log(`ScoredRow length: ${scoredRow.length}, Column M (index ${DEST_TARGET_LEDGER_COL}): "${scoredRow[DEST_TARGET_LEDGER_COL] || ''}"`);
     Logger.log(`Expense message (Column F): ${scoredRow[DEST_EXPENSE_REPORTED_COL] ? scoredRow[DEST_EXPENSE_REPORTED_COL].substring(0, 100) + '...' : 'empty'}`);
+
+    if (scoredRow.length > DEST_PROCESSING_STATUS_COL) {
+      const proc = String(scoredRow[DEST_PROCESSING_STATUS_COL] || '').trim().toLowerCase();
+      if (proc === 'unauthorized') {
+        Logger.log('InsertExpenseRecords: skipping ledger insert — Column N Processing Status is unauthorized');
+        return null;
+      }
+    }
     
     const expenseDetails = extractExpenseDetails(scoredRow[DEST_EXPENSE_REPORTED_COL]);
     if (!expenseDetails) {
@@ -1065,9 +1105,13 @@ function parseAndProcessTelegramLogs() {
           || (ledgerPrefixMatch ? ledgerPrefixMatch[1] : null)
           || '';
         
+        const processingStatus = computeExpenseProcessingStatus_(sourceData[i], reporterName, expenseDetails.daoMemberName);
+        if (processingStatus === 'unauthorized') {
+          Logger.log(`Row ${i + 1}: Processing Status = unauthorized (reporter is not DAO Member for selected inventory and Governor is not YES)`);
+        }
+
         // Prepare row data for Scored Expense Submissions sheet
-        // Columns: A=Update ID, B=Chat ID, C=Chat Name, D=Message ID, E=Reporter, F=Expense Reported,
-        //          G=Status Date, H=Contributor Name, I=Currency (clean, no ledger), J=Amount, K=Hash Key, L=Ledger Lines, M=Target Ledger
+        // Columns: A=Update ID … M=Target Ledger, N=Processing Status (authorized | unauthorized)
         const rowToAppend = [
           sourceData[i][TELEGRAM_UPDATE_ID_COL], // Column A: Telegram Update ID
           sourceData[i][CHAT_ID_COL], // Column B: Telegram Chatroom ID
@@ -1081,25 +1125,31 @@ function parseAndProcessTelegramLogs() {
           expenseDetails.quantity * -1, // Column J: Amount (negative for expense)
           hashKey, // Column K: Scoring Hash Key (for deduplication)
           '', // Column L: Ledger Lines Number (will be filled after InsertExpenseRecords)
-          targetLedgerForColumnM // Column M: Target Ledger (from form or extracted from inventory type)
+          targetLedgerForColumnM, // Column M: Target Ledger (from form or extracted from inventory type)
+          processingStatus // Column N: Processing Status
         ];
         
         const lastRow = scoredExpenseSheet.getLastRow();
         const scoredRowNumber = lastRow + 1;
         scoredExpenseSheet.getRange(scoredRowNumber, 1, 1, rowToAppend.length).setValues([rowToAppend]);
         
-        Logger.log(`Calling InsertExpenseRecords for row ${scoredRowNumber} with target ledger: ${rowToAppend[DEST_TARGET_LEDGER_COL] || 'not specified'}`);
-        const transactionRowNumber = InsertExpenseRecords(rowToAppend, i);
-        Logger.log(`InsertExpenseRecords returned: ${transactionRowNumber || 'null (failed to insert)'}`);
-        
-        if (transactionRowNumber) {
-          scoredExpenseSheet.getRange(scoredRowNumber, DEST_TRANSACTION_LINE_COL + 1).setValue(transactionRowNumber);
-          Logger.log(`Updated Column L (Ledger Lines Number) with row ${transactionRowNumber}`);
+        let transactionRowNumber = null;
+        if (processingStatus === 'authorized') {
+          Logger.log(`Calling InsertExpenseRecords for row ${scoredRowNumber} with target ledger: ${rowToAppend[DEST_TARGET_LEDGER_COL] || 'not specified'}`);
+          transactionRowNumber = InsertExpenseRecords(rowToAppend, i);
+          Logger.log(`InsertExpenseRecords returned: ${transactionRowNumber || 'null (failed to insert)'}`);
+          
+          if (transactionRowNumber) {
+            scoredExpenseSheet.getRange(scoredRowNumber, DEST_TRANSACTION_LINE_COL + 1).setValue(transactionRowNumber);
+            Logger.log(`Updated Column L (Ledger Lines Number) with row ${transactionRowNumber}`);
+          } else {
+            Logger.log(`Warning: InsertExpenseRecords returned null for row ${scoredRowNumber}. Expense was not inserted into ledger.`);
+          }
+          
+          sendExpenseNotification(rowToAppend, scoredRowNumber, transactionRowNumber);
         } else {
-          Logger.log(`Warning: InsertExpenseRecords returned null for row ${scoredRowNumber}. Expense was not inserted into ledger.`);
+          Logger.log(`Skipping InsertExpenseRecords and notification for row ${scoredRowNumber} (unauthorized)`);
         }
-        
-        sendExpenseNotification(rowToAppend, scoredRowNumber, transactionRowNumber);
         
         existingHashKeys.push(hashKey);
         newEntries++;
@@ -1354,6 +1404,8 @@ function testParseAndProcessRow() {
       Logger.log(`No attached filename or destination for row ${rowNumber}`);
     }
 
+    const processingStatus = computeExpenseProcessingStatus_(sourceData[i], reporterName, expenseDetails.daoMemberName);
+
     // Step 6: Append to scored expense sheet
     const rowToAppend = [
       sourceData[i][TELEGRAM_UPDATE_ID_COL], // Column A: Telegram Update ID
@@ -1368,7 +1420,8 @@ function testParseAndProcessRow() {
       expenseDetails.quantity * -1, // Column J: Amount (negative for expense)
       hashKey, // Column K: Scoring Hash Key
       '', // Column L: Ledger Lines Number (will be filled after insertion)
-      expenseDetails.targetLedger || '' // Column M: Target Ledger (from expense form)
+      expenseDetails.targetLedger || '', // Column M: Target Ledger (from expense form)
+      processingStatus // Column N: Processing Status
     ];
     
     const lastRow = scoredExpenseSheet.getLastRow();
@@ -1378,17 +1431,20 @@ function testParseAndProcessRow() {
     Logger.log(`   Data: ${JSON.stringify(rowToAppend)}`);
 
     // Step 7: Insert into offchain transactions sheet or resolved ledger
-    const transactionRowNumber = InsertExpenseRecords(rowToAppend, i);
-    Logger.log(`Transaction Row Number: ${transactionRowNumber || 'Not recorded'}`);
+    let transactionRowNumber = null;
+    if (processingStatus === 'authorized') {
+      transactionRowNumber = InsertExpenseRecords(rowToAppend, i);
+      Logger.log(`Transaction Row Number: ${transactionRowNumber || 'Not recorded'}`);
 
-    // Update Column L with transaction row number
-    if (transactionRowNumber) {
-      scoredExpenseSheet.getRange(scoredRowNumber, DEST_TRANSACTION_LINE_COL + 1).setValue(transactionRowNumber);
-      Logger.log(`✅ Updated Scored Expense Submissions Column L with transaction row: ${transactionRowNumber}`);
+      if (transactionRowNumber) {
+        scoredExpenseSheet.getRange(scoredRowNumber, DEST_TRANSACTION_LINE_COL + 1).setValue(transactionRowNumber);
+        Logger.log(`✅ Updated Scored Expense Submissions Column L with transaction row: ${transactionRowNumber}`);
+      }
+
+      sendExpenseNotification(rowToAppend, scoredRowNumber, transactionRowNumber);
+    } else {
+      Logger.log('Test: skipped ledger insert — Processing Status unauthorized');
     }
-
-    // Step 8: Send notification
-    sendExpenseNotification(rowToAppend, scoredRowNumber, transactionRowNumber);
 
     // Log test success
     Logger.log(`✅ Test Passed: Successfully processed row ${rowNumber} with hash key: ${hashKey}`);

--- a/google_app_scripts/tdg_inventory_management/process_movement_telegram_logs.gs
+++ b/google_app_scripts/tdg_inventory_management/process_movement_telegram_logs.gs
@@ -39,6 +39,82 @@ const CONTRIBUTORS_DATA_START_ROW = 5; // Data starts at row 5 (row 4 is header)
 const SHIPMENT_ID_COL = 0; // Column A - Shipment ID (ledger name)
 const LEDGER_URL_COL = 11; // Column L - Ledger URL
 
+/** Telegram Chat Logs column S (Governor): YES = global ledger authority (Edgar). 0-based index 18. */
+const TELEGRAM_GOVERNOR_COL = 18;
+
+function normalizeAuthName_(name) {
+  return (name == null ? '' : String(name))
+    .trim()
+    .replace(/\s+/g, ' ')
+    .toLowerCase();
+}
+
+function authNamesMatch_(a, b) {
+  const na = normalizeAuthName_(a);
+  const nb = normalizeAuthName_(b);
+  return na !== '' && na === nb;
+}
+
+function isTelegramGovernorYes_(telegramRow) {
+  return String(telegramRow && telegramRow[TELEGRAM_GOVERNOR_COL] != null ? telegramRow[TELEGRAM_GOVERNOR_COL] : '')
+    .trim()
+    .toUpperCase() === 'YES';
+}
+
+/** PEM or raw SPKI between My Digital Signature and Request Transaction ID (DApp submit format). */
+function extractPublicKeyFromSignedContribution_(text) {
+  if (!text || typeof text !== 'string') return null;
+  const sigPattern = /My Digital Signature:\s*([\s\S]*?)(?:\n\s*Request Transaction ID:|This submission was generated using|$)/i;
+  const sigMatch = text.match(sigPattern);
+  return sigMatch ? sigMatch[1].trim() : null;
+}
+
+/**
+ * Looks up ACTIVE contributor display name by digital signature (Main Ledger Contributors Digital Signatures).
+ * @return {{contributorName: string|null, error: string|null}}
+ */
+function findContributorNameByDigitalSignature_(digitalSignature) {
+  try {
+    if (!digitalSignature) {
+      return { contributorName: null, error: 'No digital signature' };
+    }
+    const contributorsSpreadsheet = SpreadsheetApp.openById(OFFCHAIN_SPREADSHEET_ID);
+    const digitalSignaturesSheet = contributorsSpreadsheet.getSheetByName('Contributors Digital Signatures');
+    if (!digitalSignaturesSheet) {
+      return { contributorName: null, error: 'Contributors Digital Signatures sheet not found' };
+    }
+    const signatureData = digitalSignaturesSheet.getDataRange().getValues();
+    for (let i = 1; i < signatureData.length; i++) {
+      const contributorName = signatureData[i][0];
+      const signature = signatureData[i][4];
+      const status = signatureData[i][3];
+      if (signature && String(signature).trim() === String(digitalSignature).trim()) {
+        if (String(status || '').trim().toUpperCase() === 'ACTIVE') {
+          return { contributorName: contributorName, error: null };
+        }
+        return { contributorName: null, error: 'Signature not ACTIVE' };
+      }
+    }
+    return { contributorName: null, error: 'No matching contributor' };
+  } catch (e) {
+    return { contributorName: null, error: e.message };
+  }
+}
+
+/**
+ * Inventory Movement column N (STATUS): NEW if governor or ACTIVE signer matches warehouse manager (- Manager Name:);
+ * unauthorized otherwise (Phase 2 skips non-NEW).
+ */
+function inventoryMovementStatusFromTelegramRow_(telegramRow, contribution, warehouseManagerName) {
+  if (isTelegramGovernorYes_(telegramRow)) return 'NEW';
+  const pk = extractPublicKeyFromSignedContribution_(contribution);
+  if (!pk) return 'unauthorized';
+  const res = findContributorNameByDigitalSignature_(pk);
+  if (!res.contributorName) return 'unauthorized';
+  if (authNamesMatch_(res.contributorName, warehouseManagerName)) return 'NEW';
+  return 'unauthorized';
+}
+
 /**
  * Resolves redirect URLs to get the final URL.
  * First checks "Shipment Ledger Listing" sheet (Column L -> Column AB lookup)
@@ -746,7 +822,7 @@ function processInventoryReport(reportText) {
  * - Inventory Movement Column K: amount extracted from Column G
  * - Inventory Movement Column L: ledger_name extracted from Column G
  * - Inventory Movement Column M: ledger_url extracted from Column G
- * - Inventory Movement Column N: "NEW"
+ * - Inventory Movement Column N: NEW (authorized) or unauthorized (signer ≠ warehouse manager and Telegram S Governor ≠ YES)
  */
 function processTelegramChatLogsToInventoryMovement() {
   try {
@@ -772,8 +848,8 @@ function processTelegramChatLogsToInventoryMovement() {
       Logger.log('No data in Telegram Chat Logs');
       return;
     }
-    // Read up to Column O (15th column) to include file IDs
-    const telegramData = telegramSheet.getRange(1, 1, telegramLastRow, 15).getValues(); // Columns A to O
+    // Read through column S (19) for Edgar Governor flag (YES/NO) on Telegram Chat Logs
+    const telegramData = telegramSheet.getRange(1, 1, telegramLastRow, 19).getValues(); // Columns A–S
 
     // Prepare array to collect new rows for batch insertion
     const newRows = [];
@@ -879,6 +955,11 @@ function processTelegramChatLogsToInventoryMovement() {
           }
         }
 
+        const movementStatus = inventoryMovementStatusFromTelegramRow_(row, contribution, reportResult.sender_name);
+        if (movementStatus === 'unauthorized') {
+          Logger.log(`Update ID ${updateId}: Column N = unauthorized (signer is not warehouse manager and Governor is not YES)`);
+        }
+
         // Create new row for Inventory Movement
         const newRow = [
           row[0], // Column A: Telegram Update ID
@@ -894,7 +975,7 @@ function processTelegramChatLogsToInventoryMovement() {
           reportResult.amount, // Column K: amount
           reportResult.currency_source.ledger_name, // Column L: ledger_name
           reportResult.currency_source.ledger_url, // Column M: ledger_url
-          'NEW' // Column N: Status
+          movementStatus // Column N: NEW | unauthorized
         ];
 
         newRows.push(newRow);
@@ -1072,7 +1153,10 @@ function processInventoryMovementToLedgers() {
       const rowNumber = index + 1;
       const status = row[13]; // Column N: Status
       if (status !== 'NEW') {
-        return; // Skip if status is not NEW
+        if (String(status || '').trim().toLowerCase() === 'unauthorized') {
+          Logger.log(`Skipping row ${rowNumber}: Inventory Movement STATUS is unauthorized (ledger insert blocked)`);
+        }
+        return; // Skip if status is not NEW (includes unauthorized, PROCESSED, ERROR, …)
       }
 
       stats.totalRowsAttempted++;


### PR DESCRIPTION
## Summary
- **process_movement_telegram_logs:** `Telegram Chat Logs` read **A–S**. Column **N** = `NEW` if **Governor** (S) is **YES** or ACTIVE signer matches **`- Manager Name:`**; else `unauthorized`. Phase 2 skips non-`NEW` (explicit log for `unauthorized`).
- **tdg_expenses_processing:** Scored sheet column **N** `Processing Status` = `authorized` / `unauthorized`; **InsertExpenseRecords** no-ops when **unauthorized**; main path skips ledger + Telegram when unauthorized. Legacy rows without column N still insert.
- **SCHEMA.md:** Inventory **STATUS** values; Scored **Processing Status**; changelog.

## Deploy
`clasp push` already run for mirrors **1wONDeDw…** (movement) and **19Wag9x…** (expenses). Redeploy web app versions in Apps Script if required for `/exec`.

Made with [Cursor](https://cursor.com)