### PR TITLE
feat(tdg_identity_management): dao_members.json cache publisher + doGet action

### DIFF
--- a/google_app_scripts/tdg_identity_management/dao_members_cache_publisher.gs
+++ b/google_app_scripts/tdg_identity_management/dao_members_cache_publisher.gs
@@ -1,0 +1,299 @@
+/**
+ * File: google_app_scripts/tdg_identity_management/dao_members_cache_publisher.gs
+ * Repository: https://github.com/TrueSightDAO/tokenomics
+ *
+ * Summary:
+ * - Publishes `dao_members.json` to `TrueSightDAO/treasury-cache` (branch: main)
+ *   so `dao_client/cache/contributors.py` can flip from GAS to GitHub-raw.
+ * - Contributor-aggregated shape (a contributor can have N active public keys):
+ *     {
+ *       generated_at, schema_version: 1,
+ *       contributors: [
+ *         { name, voting_rights, public_keys: [{ public_key, status,
+ *           created_at, last_active_at }] }
+ *       ]
+ *     }
+ *
+ * Triggers:
+ * - Edgar → doGet(?action=refresh_dao_members_cache&secret=...) on every
+ *   successful [EMAIL VERIFICATION EVENT] activation.
+ * - Daily safety-net time trigger (installDaoMembersCacheDailyTrigger()) so
+ *   the cache self-heals if Edgar's ping ever drops.
+ *
+ * Script properties required (Project Settings → Script properties):
+ * - CONTRIBUTORS_CACHE_GITHUB_PAT — GitHub PAT with `contents:write` on
+ *   TrueSightDAO/treasury-cache. Scope the token to that single repo.
+ * - EMAIL_VERIFICATION_SECRET — reused from edgar_send_email_verification.gs;
+ *   doGet routing requires the same shared secret.
+ *
+ * Manual smoke test:
+ * - Run `publishDaoMembersCacheNow()` from the Apps Script editor once to
+ *   confirm PAT + repo access. Check treasury-cache git history for the commit.
+ */
+
+const DAO_MEMBERS_CACHE_SPREADSHEET_ID =
+    '1GE7PUq-UT6x2rBN-Q2ksogbWpgyuh2SaxJyG_uEK6PU';
+const DAO_MEMBERS_CACHE_SIGS_SHEET = 'Contributors Digital Signatures';
+const DAO_MEMBERS_CACHE_VOTING_SHEET = 'Contributors voting weight';
+const DAO_MEMBERS_CACHE_REPO_OWNER = 'TrueSightDAO';
+const DAO_MEMBERS_CACHE_REPO_NAME = 'treasury-cache';
+const DAO_MEMBERS_CACHE_REPO_PATH = 'dao_members.json';
+const DAO_MEMBERS_CACHE_BRANCH = 'main';
+const DAO_MEMBERS_CACHE_SCHEMA_VERSION = 1;
+
+/**
+ * doGet-routed entry (see Code.js).
+ * body = { secret, force }
+ */
+function handleDaoMembersCacheRefreshRequest_(body) {
+  try {
+    const expected = PropertiesService.getScriptProperties()
+        .getProperty('EMAIL_VERIFICATION_SECRET');
+    if (!expected || String(body.secret || '') !== String(expected)) {
+      return ContentService
+          .createTextOutput(JSON.stringify({ ok: false, error: 'Unauthorized' }))
+          .setMimeType(ContentService.MimeType.JSON);
+    }
+    const result = publishDaoMembersCacheToGithub_({
+      trigger: 'edgar_webhook',
+      force: body.force === '1' || body.force === 'true' || body.force === true,
+    });
+    return ContentService
+        .createTextOutput(JSON.stringify({ ok: true, ...result }))
+        .setMimeType(ContentService.MimeType.JSON);
+  } catch (err) {
+    Logger.log('handleDaoMembersCacheRefreshRequest_ failed: ' + err);
+    return ContentService
+        .createTextOutput(JSON.stringify({ ok: false, error: String(err) }))
+        .setMimeType(ContentService.MimeType.JSON);
+  }
+}
+
+/** Manual trigger for Apps Script editor smoke-testing. */
+function publishDaoMembersCacheNow() {
+  const result = publishDaoMembersCacheToGithub_({ trigger: 'manual', force: true });
+  Logger.log(JSON.stringify(result, null, 2));
+  return result;
+}
+
+/** Time-based trigger entry. Install once via installDaoMembersCacheDailyTrigger(). */
+function refreshDaoMembersCacheFromTrigger_() {
+  try {
+    return publishDaoMembersCacheToGithub_({ trigger: 'cron', force: false });
+  } catch (err) {
+    Logger.log('refreshDaoMembersCacheFromTrigger_ failed: ' + err);
+    throw err;
+  }
+}
+
+/** One-time setup. Creates a daily time trigger at ~03:00 UTC. */
+function installDaoMembersCacheDailyTrigger() {
+  const triggers = ScriptApp.getProjectTriggers();
+  triggers.forEach(function (t) {
+    if (t.getHandlerFunction() === 'refreshDaoMembersCacheFromTrigger_') {
+      ScriptApp.deleteTrigger(t);
+    }
+  });
+  ScriptApp.newTrigger('refreshDaoMembersCacheFromTrigger_')
+      .timeBased()
+      .everyDays(1)
+      .atHour(3)
+      .inTimezone('UTC')
+      .create();
+  Logger.log('Installed daily UTC 03:00 refresh trigger.');
+}
+
+/**
+ * Core: read the two contributor tabs, build the JSON, PUT to GitHub.
+ * Returns a summary dict for logging / HTTP response.
+ */
+function publishDaoMembersCacheToGithub_(opts) {
+  const o = opts || {};
+  const token = PropertiesService.getScriptProperties()
+      .getProperty('CONTRIBUTORS_CACHE_GITHUB_PAT');
+  if (!token) {
+    throw new Error('Script property CONTRIBUTORS_CACHE_GITHUB_PAT is not set.');
+  }
+
+  const ss = SpreadsheetApp.openById(DAO_MEMBERS_CACHE_SPREADSHEET_ID);
+
+  // ----- Contributors Digital Signatures (header row 1; A-H) ---------------
+  const sigsSheet = ss.getSheetByName(DAO_MEMBERS_CACHE_SIGS_SHEET);
+  if (!sigsSheet) throw new Error('Missing sheet: ' + DAO_MEMBERS_CACHE_SIGS_SHEET);
+  const sigsLastRow = sigsSheet.getLastRow();
+  const sigsRows = sigsLastRow >= 2
+      ? sigsSheet.getRange(2, 1, sigsLastRow - 1, 8).getValues()
+      : [];
+
+  // ----- Contributors voting weight (header row 4; C = name, I = total TDG) -
+  const votingSheet = ss.getSheetByName(DAO_MEMBERS_CACHE_VOTING_SHEET);
+  if (!votingSheet) throw new Error('Missing sheet: ' + DAO_MEMBERS_CACHE_VOTING_SHEET);
+  const votingLastRow = votingSheet.getLastRow();
+  const votingByName = {};
+  if (votingLastRow >= 5) {
+    // Columns C(3)..K(11): name, wallet, quadratic, TDG in wallet, unissued,
+    // legacy controlled, total controlled, percentage, voting power.
+    const votingRows = votingSheet.getRange(5, 3, votingLastRow - 4, 9).getValues();
+    votingRows.forEach(function (row) {
+      const name = String(row[0] || '').trim();
+      if (!name) return;
+      votingByName[name.toLowerCase()] = {
+        voting_rights: toNumberOrNull_(row[6]),          // I = Total TDG controlled
+        total_voting_power_pct: String(row[8] || ''),     // K = Total Voting Power
+      };
+    });
+  }
+
+  // ----- Aggregate signatures by contributor name --------------------------
+  const byName = {};
+  sigsRows.forEach(function (row) {
+    const name = String(row[0] || '').trim();
+    const status = String(row[3] || '').trim().toUpperCase();
+    const publicKey = String(row[4] || '').trim();
+    if (!name || !publicKey || status !== 'ACTIVE') return;
+    const key = name.toLowerCase();
+    if (!byName[key]) byName[key] = { name: name, public_keys: [] };
+    byName[key].public_keys.push({
+      public_key: publicKey,
+      status: status,
+      created_at: formatTimestamp_(row[1]),
+      last_active_at: formatTimestamp_(row[2]),
+    });
+  });
+
+  // ----- Merge voting weight + emit stable-sorted contributors list --------
+  const contributors = Object.keys(byName).sort().map(function (k) {
+    const entry = byName[k];
+    const voting = votingByName[k] || {};
+    return {
+      name: entry.name,
+      voting_rights: voting.voting_rights,                 // may be null
+      total_voting_power_pct: voting.total_voting_power_pct || null,
+      public_keys: entry.public_keys,
+    };
+  });
+
+  const snapshot = {
+    generated_at: new Date().toISOString(),
+    schema_version: DAO_MEMBERS_CACHE_SCHEMA_VERSION,
+    source: 'dao_members_cache_publisher',
+    trigger: o.trigger || 'unknown',
+    counts: {
+      contributors: contributors.length,
+      active_public_keys: contributors.reduce(function (sum, c) {
+        return sum + c.public_keys.length;
+      }, 0),
+    },
+    contributors: contributors,
+  };
+
+  const content = JSON.stringify(snapshot, null, 2) + '\n';
+  const commitMessage =
+      'chore: refresh dao_members.json (' + snapshot.counts.contributors +
+      ' contributors, ' + snapshot.counts.active_public_keys +
+      ' active keys, trigger=' + snapshot.trigger + ')';
+
+  const commit = commitJsonToGithub_({
+    token: token,
+    owner: DAO_MEMBERS_CACHE_REPO_OWNER,
+    repo: DAO_MEMBERS_CACHE_REPO_NAME,
+    path: DAO_MEMBERS_CACHE_REPO_PATH,
+    branch: DAO_MEMBERS_CACHE_BRANCH,
+    content: content,
+    commitMessage: commitMessage,
+    skipIfUnchanged: !o.force,
+  });
+
+  return {
+    counts: snapshot.counts,
+    generated_at: snapshot.generated_at,
+    github: commit,
+  };
+}
+
+function commitJsonToGithub_(args) {
+  const baseUrl = 'https://api.github.com/repos/' + args.owner + '/' + args.repo +
+      '/contents/' + args.path;
+  const headers = {
+    'Authorization': 'token ' + args.token,
+    'Accept': 'application/vnd.github+json',
+    'User-Agent': 'TrueSightDAO-tdg-identity-management/1.0',
+  };
+
+  // GET current file to capture sha + detect no-op writes.
+  const existing = UrlFetchApp.fetch(baseUrl + '?ref=' + encodeURIComponent(args.branch), {
+    method: 'get',
+    headers: headers,
+    muteHttpExceptions: true,
+  });
+  let sha = null;
+  if (existing.getResponseCode() === 200) {
+    const existingJson = JSON.parse(existing.getContentText());
+    sha = existingJson.sha;
+    if (args.skipIfUnchanged && existingJson.content) {
+      const existingContent = Utilities.newBlob(
+          Utilities.base64Decode(existingJson.content.replace(/\n/g, ''))
+      ).getDataAsString();
+      // Compare everything except `generated_at` / `trigger` so cron reruns
+      // don't create empty commits.
+      if (stripVolatileFields_(existingContent) === stripVolatileFields_(args.content)) {
+        return { status: 'unchanged', sha: sha };
+      }
+    }
+  } else if (existing.getResponseCode() !== 404) {
+    throw new Error(
+        'GitHub GET failed (HTTP ' + existing.getResponseCode() + '): ' +
+        existing.getContentText().substring(0, 400));
+  }
+
+  const payload = {
+    message: args.commitMessage,
+    content: Utilities.base64Encode(args.content),
+    branch: args.branch,
+  };
+  if (sha) payload.sha = sha;
+
+  const resp = UrlFetchApp.fetch(baseUrl, {
+    method: 'put',
+    contentType: 'application/json',
+    headers: headers,
+    payload: JSON.stringify(payload),
+    muteHttpExceptions: true,
+  });
+  if (resp.getResponseCode() < 200 || resp.getResponseCode() >= 300) {
+    throw new Error(
+        'GitHub PUT failed (HTTP ' + resp.getResponseCode() + '): ' +
+        resp.getContentText().substring(0, 400));
+  }
+  const body = JSON.parse(resp.getContentText());
+  return {
+    status: sha ? 'updated' : 'created',
+    sha: body.content && body.content.sha,
+    commit_url: body.commit && body.commit.html_url,
+  };
+}
+
+function stripVolatileFields_(jsonStr) {
+  try {
+    const parsed = JSON.parse(jsonStr);
+    delete parsed.generated_at;
+    delete parsed.trigger;
+    return JSON.stringify(parsed);
+  } catch (_) {
+    return jsonStr;
+  }
+}
+
+function formatTimestamp_(value) {
+  if (value === null || value === undefined || value === '') return '';
+  if (Object.prototype.toString.call(value) === '[object Date]') {
+    return value.toISOString();
+  }
+  return String(value);
+}
+
+function toNumberOrNull_(value) {
+  if (value === null || value === undefined || value === '') return null;
+  const n = typeof value === 'number' ? value : parseFloat(String(value).replace(/,/g, ''));
+  return isFinite(n) ? n : null;
+}

--- a/google_app_scripts/tdg_identity_management/edgar_send_email_verification.gs
+++ b/google_app_scripts/tdg_identity_management/edgar_send_email_verification.gs
@@ -1,8 +1,6 @@
 /**
  * File: google_app_scripts/tdg_identity_management/edgar_send_email_verification.gs
  * Repository: https://github.com/TrueSightDAO/tokenomics
- * Apps Script editor:
- * https://script.google.com/home/projects/1m8IZPs1vFN99cuu-39kbC-OGXggRVtJtXq5rfSB0M1sCQjMdolEUDuGU/edit
  *
  * Summary:
  * - Standalone web app invoked by Edgar (`sentiment_importer`) after a verified
@@ -14,7 +12,8 @@
  * Apps Script project (clasp mirror must stay in sync)
  * ---------------------------------------------------------------------------
  * - Script ID: 1m8IZPs1vFN99cuu-39kbC-OGXggRVtJtXq5rfSB0M1sCQjMdolEUDuGU
- * - Editor URL: canonical `https://script.google.com/home/projects/.../edit` link in the repository file header above.
+ * - Editor URL:
+ *   https://script.google.com/u/2/home/projects/1m8IZPs1vFN99cuu-39kbC-OGXggRVtJtXq5rfSB0M1sCQjMdolEUDuGU/edit
  * - Web app deployment URL (`/exec`; Edgar `EMAIL_VERIFICATION_GAS_WEBHOOK_URL` default in `sentiment_importer`):
  *   https://script.google.com/macros/s/AKfycbxfngGYBYMe1ATyW0U4lLODyAlhUnSUATAsBrNgIvKH6k9ARifG3arSFkB4hjn2h2ID2A/exec
  * - Clasp mirror: tokenomics/clasp_mirrors/1m8IZPs1vFN99cuu-39kbC-OGXggRVtJtXq5rfSB0M1sCQjMdolEUDuGU/
@@ -40,10 +39,19 @@ function doGet(e) {
     });
   }
 
+  if (action === 'refresh_dao_members_cache') {
+    // Edgar → GET ?action=refresh_dao_members_cache&secret=...&force=1
+    // Implementation lives in DaoMembersCache.js.
+    return handleDaoMembersCacheRefreshRequest_({
+      secret: e.parameter.secret,
+      force: e.parameter.force || '',
+    });
+  }
+
   return ContentService.createTextOutput(
     JSON.stringify({
       ok: false,
-      error: 'No valid action (use action=sendEmailVerification on GET, or POST JSON for email verification).',
+      error: 'No valid action (use action=sendEmailVerification or action=refresh_dao_members_cache on GET, or POST JSON for email verification).',
     })
   ).setMimeType(ContentService.MimeType.JSON);
 }


### PR DESCRIPTION
## Summary

Adds \`dao_members_cache_publisher.gs\` to the **existing** \`tdg_identity_management\` Apps Script project (script \`1m8IZ…\`, already deployed as Anyone-access web app behind \`edgar_send_email_verification\`). Already clasp-pushed; this PR syncs the canonical \`.gs\` references under \`google_app_scripts/\` so git tracks what's deployed.

## New HTTP action on the existing web app

\`\`\`
GET <gas_exec_url>?action=refresh_dao_members_cache&secret=<EMAIL_VERIFICATION_SECRET>[&force=1]
\`\`\`

Reads \`Contributors Digital Signatures\` (rows where Status=ACTIVE) + \`Contributors voting weight\`, emits the contributor-keyed JSON below, and PUTs it to \`TrueSightDAO/treasury-cache/dao_members.json\` via the contents API.

Cache shape (matches the sketch in [dao_client#4](https://github.com/TrueSightDAO/dao_client/pull/4) — one contributor has N simultaneously-active RSA signatures):

\`\`\`json
{
  "generated_at": "2026-04-21T…Z",
  "schema_version": 1,
  "source": "dao_members_cache_publisher",
  "trigger": "edgar_webhook | cron | manual",
  "counts": { "contributors": N, "active_public_keys": M },
  "contributors": [
    {
      "name": "Gary Teh",
      "voting_rights": 955414.06,
      "total_voting_power_pct": "…%",
      "public_keys": [
        { "public_key": "MIIB…", "status": "ACTIVE", "created_at": "…", "last_active_at": "…" }
      ]
    }
  ]
}
\`\`\`

## Triggers

- **Edgar webhook** (follow-up Rails patch in \`sentiment_importer\`): fire \`GET ?action=refresh_dao_members_cache&secret=…\` after every successful \`[EMAIL VERIFICATION EVENT]\` activation so the cache catches new public keys within seconds.
- **Safety-net cron**: \`installDaoMembersCacheDailyTrigger()\` run once from the editor installs a 03:00 UTC daily trigger. Cache self-heals if Edgar's ping ever drops.
- **Manual**: \`publishDaoMembersCacheNow()\` — for smoke-testing from the editor.

## Operator setup (one-time)

1. Open script \`1m8IZPs1vFN99cuu-39kbC-OGXggRVtJtXq5rfSB0M1sCQjMdolEUDuGU\` in the Apps Script editor.
2. **Project Settings → Script properties** → add \`CONTRIBUTORS_CACHE_GITHUB_PAT\` with a GitHub PAT that has \`contents:write\` scoped to \`TrueSightDAO/treasury-cache\` only.
3. Run \`publishDaoMembersCacheNow()\` once; confirm a new \`dao_members.json\` commit lands in the treasury-cache repo.
4. Run \`installDaoMembersCacheDailyTrigger()\` once.
5. (Separately) land the \`sentiment_importer\` patch that fires the webhook after verification.

## Optimisation

\`stripVolatileFields_\` drops \`generated_at\` / \`trigger\` when comparing against the existing file on GitHub, so cron reruns with no membership change don't produce empty commits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)