### PR TITLE
QR Code Sales webhooks: serialize doGet with LockService

### DIFF
--- a/google_app_scripts/tdg_inventory_management/process_sales_telegram_logs.gs
+++ b/google_app_scripts/tdg_inventory_management/process_sales_telegram_logs.gs
@@ -204,36 +204,54 @@ const VALUE_COL = 2; // Column C
 const STATUS_COL = 3; // Column D
 const INVENTORY_TYPE_COL = 8; // Column I
 
+/**
+ * Serializes webhook GETs so concurrent runs cannot race on "QR Code Sales" / Telegram reads.
+ */
 function doGet(e) {
-  const action = e.parameter?.action;
-  if (action === 'parseTelegramChatLogs') {
-    try {
-      Logger.log("Webhook triggered: processing Telegram logs");
-      parseTelegramChatLogs();
-      notifyTreasuryCachePublisher_('process_sales');
-      return ContentService.createTextOutput("✅ Telegram logs processed");
-    } catch (err) {
-      Logger.log("Error in processTelegramLogs: " + err.message);
-      return ContentService.createTextOutput("❌ Error: " + err.message);
-    }
-  } else if (action === 'processSpecificRow') {
-    const rowIndex = parseInt(e.parameter?.rowIndex, 10);
-    if (isNaN(rowIndex) || rowIndex < 2) {
-      Logger.log(`Invalid rowIndex: ${e.parameter?.rowIndex}`);
-      return ContentService.createTextOutput("❌ Error: Invalid or missing rowIndex (must be >= 2)");
-    }
-    try {
-      Logger.log(`Processing specific row: ${rowIndex}`);
-      processSpecificRow(rowIndex);
-      notifyTreasuryCachePublisher_('process_sales');
-      return ContentService.createTextOutput(`✅ Row ${rowIndex} processed`);
-    } catch (err) {
-      Logger.log(`Error processing row ${rowIndex}: ${err.message}`);
-      return ContentService.createTextOutput(`❌ Error processing row ${rowIndex}: ${err.message}`);
-    }
+  const lock = LockService.getScriptLock();
+  const LOCK_WAIT_MS = 300000;
+
+  if (!lock.tryLock(LOCK_WAIT_MS)) {
+    Logger.log('doGet: script lock not acquired within ' + LOCK_WAIT_MS + 'ms; another process_sales run in progress');
+    return ContentService.createTextOutput(
+      '⏳ busy: another process_sales webhook run is in progress; retry later'
+    );
   }
 
-  return ContentService.createTextOutput("ℹ️ No valid action specified");
+  try {
+    const action = e.parameter?.action;
+    if (action === 'parseTelegramChatLogs') {
+      try {
+        Logger.log("Webhook triggered: processing Telegram logs");
+        parseTelegramChatLogs();
+        notifyTreasuryCachePublisher_('process_sales');
+        return ContentService.createTextOutput("✅ Telegram logs processed");
+      } catch (err) {
+        Logger.log("Error in processTelegramLogs: " + err.message);
+        return ContentService.createTextOutput("❌ Error: " + err.message);
+      }
+    }
+    if (action === 'processSpecificRow') {
+      const rowIndex = parseInt(e.parameter?.rowIndex, 10);
+      if (isNaN(rowIndex) || rowIndex < 2) {
+        Logger.log(`Invalid rowIndex: ${e.parameter?.rowIndex}`);
+        return ContentService.createTextOutput("❌ Error: Invalid or missing rowIndex (must be >= 2)");
+      }
+      try {
+        Logger.log(`Processing specific row: ${rowIndex}`);
+        processSpecificRow(rowIndex);
+        notifyTreasuryCachePublisher_('process_sales');
+        return ContentService.createTextOutput(`✅ Row ${rowIndex} processed`);
+      } catch (err) {
+        Logger.log(`Error processing row ${rowIndex}: ${err.message}`);
+        return ContentService.createTextOutput(`❌ Error processing row ${rowIndex}: ${err.message}`);
+      }
+    }
+
+    return ContentService.createTextOutput("ℹ️ No valid action specified");
+  } finally {
+    lock.releaseLock();
+  }
 }
 
 /**

--- a/google_app_scripts/tdg_inventory_management/sales_update_main_dao_offchain_ledger.gs
+++ b/google_app_scripts/tdg_inventory_management/sales_update_main_dao_offchain_ledger.gs
@@ -55,20 +55,38 @@ function soldByContributorForLedger_(row) {
   return (row[CONTRIBUTOR_NAME_COL] || '').toString();
 }
 
+/**
+ * Serializes webhook GETs so concurrent runs cannot race while reading/updating "QR Code Sales"
+ * and writing offchain ledger rows.
+ */
 function doGet(e) {
-  const action = e.parameter?.action;
-  if (action === 'processTokenizedTransactions') {
-    try {
-      Logger.log("Webhook triggered: processing Telegram logs");
-      processTokenizedTransactions();
-      return ContentService.createTextOutput("✅ Telegram logs processed");
-    } catch (err) {
-      Logger.log("Error in processTelegramLogs: " + err.message);
-      return ContentService.createTextOutput("❌ Error: " + err.message);
-    }
+  const lock = LockService.getScriptLock();
+  const LOCK_WAIT_MS = 300000;
+
+  if (!lock.tryLock(LOCK_WAIT_MS)) {
+    Logger.log('doGet: script lock not acquired within ' + LOCK_WAIT_MS + 'ms; another processTokenizedTransactions run in progress');
+    return ContentService.createTextOutput(
+      '⏳ busy: another tokenized-sales webhook run is in progress; retry later'
+    );
   }
 
-  return ContentService.createTextOutput("ℹ️ No valid action specified");
+  try {
+    const action = e.parameter?.action;
+    if (action === 'processTokenizedTransactions') {
+      try {
+        Logger.log("Webhook triggered: processing Telegram logs");
+        processTokenizedTransactions();
+        return ContentService.createTextOutput("✅ Telegram logs processed");
+      } catch (err) {
+        Logger.log("Error in processTelegramLogs: " + err.message);
+        return ContentService.createTextOutput("❌ Error: " + err.message);
+      }
+    }
+
+    return ContentService.createTextOutput("ℹ️ No valid action specified");
+  } finally {
+    lock.releaseLock();
+  }
 }
 
 

--- a/google_app_scripts/tdg_inventory_management/sales_update_managed_agl_ledgers.gs
+++ b/google_app_scripts/tdg_inventory_management/sales_update_managed_agl_ledgers.gs
@@ -55,20 +55,38 @@ function soldByContributorForLedger_(row) {
   return (row[CONTRIBUTOR_NAME_COL] || '').toString();
 }
 
+/**
+ * Serializes webhook GETs so concurrent runs cannot race while reading/updating "QR Code Sales"
+ * and writing AGL ledger rows.
+ */
 function doGet(e) {
-  const action = e.parameter?.action;
-  if (action === 'processNonAgl4Transactions') {
-    try {
-      Logger.log("Webhook triggered: processing Telegram logs");
-      processNonAgl4Transactions();
-      return ContentService.createTextOutput("✅ Telegram logs processed");
-    } catch (err) {
-      Logger.log("Error in processTelegramLogs: " + err.message);
-      return ContentService.createTextOutput("❌ Error: " + err.message);
-    }
+  const lock = LockService.getScriptLock();
+  const LOCK_WAIT_MS = 300000;
+
+  if (!lock.tryLock(LOCK_WAIT_MS)) {
+    Logger.log('doGet: script lock not acquired within ' + LOCK_WAIT_MS + 'ms; another processNonAgl4Transactions run in progress');
+    return ContentService.createTextOutput(
+      '⏳ busy: another non-AGL4 sales webhook run is in progress; retry later'
+    );
   }
 
-  return ContentService.createTextOutput("ℹ️ No valid action specified");
+  try {
+    const action = e.parameter?.action;
+    if (action === 'processNonAgl4Transactions') {
+      try {
+        Logger.log("Webhook triggered: processing Telegram logs");
+        processNonAgl4Transactions();
+        return ContentService.createTextOutput("✅ Telegram logs processed");
+      } catch (err) {
+        Logger.log("Error in processTelegramLogs: " + err.message);
+        return ContentService.createTextOutput("❌ Error: " + err.message);
+      }
+    }
+
+    return ContentService.createTextOutput("ℹ️ No valid action specified");
+  } finally {
+    lock.releaseLock();
+  }
 }
 
 


### PR DESCRIPTION
## Summary
Adds `LockService.getScriptLock()` (5-minute `tryLock`) to `doGet` in three standalone web apps that read or write the **QR Code Sales** tab on spreadsheet `1qbZZhf-…`:

| Source | Role |
|--------|------|
| `process_sales_telegram_logs.gs` | Writes parsed rows to **QR Code Sales** |
| `sales_update_main_dao_offchain_ledger.gs` | Reads **QR Code Sales** → offchain transactions |
| `sales_update_managed_agl_ledgers.gs` | Reads **QR Code Sales** → AGL ledgers |

If the lock cannot be acquired, the handler returns a short **busy** plain-text response so callers can retry.

## Deploy
`clasp push --force` was run for script projects `1dsWec…` (Parse Telegram Chat Logs), `1wmgYP…` (tokenized / offchain), and `1duQFf…` (non-AGL4).

## Note
`getScriptLock()` serializes **per Apps Script project**. Concurrent calls to **different** deployments can still interleave on the same sheet; eliminating that fully would require a container-bound document lock, a single coordinator endpoint, or stronger sheet-level idempotency.

Made with [Cursor](https://cursor.com)