### PR TITLE
feat(metrics): outreach_visibility in weekly JSON; store history pipeline touches

### DIFF
--- a/google_app_scripts/holistic_hit_list_store_history/README.md
+++ b/google_app_scripts/holistic_hit_list_store_history/README.md
@@ -4,7 +4,7 @@ Google Apps Script web app backing the **Store Interaction History** DApp page. 
 [20251104 - holistic wellness hit list](https://docs.google.com/spreadsheets/d/1eiqZr3LW-qEI6Hmy0Vrur_8flbRwxwA7jXVrbUnHbvc/edit) and returns:
 
 - **Autocomplete** — `Shop Name` / `Store Key` matches from **Hit List**
-- **Full context** — the **Hit List** row for the store plus every row from **DApp Remarks**, **Email Agent Follow Up**, and **Email Agent Suggestions** that matches `store_key`, `to_email` ↔ Hit List `Email`, or `shop_name`. Those three arrays are returned **newest-first** (by `created_at_utc`, `Date Sent`, etc., when available; otherwise sheet order is reversed).
+- **Full context** — the **Hit List** row for the store plus every row from **DApp Remarks**, **Email Agent Follow Up**, and **Email Agent Drafts** that matches `store_key`, `to_email` ↔ Hit List `Email`, or `shop_name`. Those three arrays are returned **newest-first** (by `created_at_utc`, `Date Sent`, etc., when available; otherwise sheet order is reversed).
 
 ## Setup
 
@@ -33,10 +33,10 @@ The script runs under your Google account; it only reads the spreadsheet (no wri
 | Query | Returns |
 |--------|---------|
 | `?action=suggestStores&q=partial` | `{ status, data: { suggestions: [{ shop_name, store_key, email, hit_list_row }] } }` — requires `q` length ≥ 2 |
-| `?action=getStoreHistory&store_key=...` | Full payload: `hit_list`, `dapp_remarks`, `email_agent_follow_up`, `email_agent_suggestions` |
+| `?action=getStoreHistory&store_key=...` | Full payload: `hit_list`, `dapp_remarks`, `email_agent_follow_up`, `email_agent_drafts` |
 | `?action=getStoreHistory&shop=...` | Same, if `store_key` omitted (exact normalized match on Hit List `Shop Name`) |
-| `?action=listStoresByFilter` | Paginated Hit List rows: `status` and `shop_type` may be repeated (exact cell match). Omit both to return all rows (subject to limit). `limit` (default 200, max 500), `offset` (default 0). Response: `{ rows: [...], total, offset, limit, returned }` where each row includes `store_key`, `shop_name`, `status`, `shop_type`, `city`, `state`, `email`, `status_updated`, `hit_list_row`. |
-| `?action=listStatusSummary` | Pipeline-style counts from **Hit List** (one pass): `by_status[]` `{ status, count }`, `by_shop_type[]` `{ shop_type, count }`, plus `total_data_rows`, `blank_status`, `blank_shop_type`. Used by `stores_by_status.html` for the overview chips. |
+| `?action=listStoresByFilter` | Paginated Hit List rows: `status` and `shop_type` may be repeated (exact cell match). Omit both to return all rows (subject to limit). `limit` (default 200, max 500), `offset` (default 0). Response: `{ rows: [...], total, offset, limit, returned }` where each row includes `store_key`, `shop_name`, `status`, `shop_type`, `city`, `state`, `email`, `status_updated`, `hit_list_row`, and when AU/AV columns exist: **`warmup_sent`**, **`followup_sent`** (integer counts from sheet formulas). |
+| `?action=listStatusSummary` | Pipeline-style counts from **Hit List** (one pass): `by_status[]` / `by_shop_type[]` with **`count`**, optional **`warmup`** / **`followup`** each `{ none, once, repeat }` (stores by sends: 0 / 1 / 2+ from columns **Warm-up email sent** / **Follow-up emails sent**), plus `total_data_rows`, `blank_status`, `blank_shop_type`, **`touch_metrics_available`**. Used by `stores_by_status.html`. |
 
 Always append `&token=...` when `STORE_HISTORY_API_TOKEN` is set.
 

--- a/google_app_scripts/holistic_hit_list_store_history/email_agent_drafts.gs
+++ b/google_app_scripts/holistic_hit_list_store_history/email_agent_drafts.gs
@@ -1,7 +1,7 @@
 /**
  * Apps Script editor:
  * https://script.google.com/home/projects/14gKJ0VW49RsSn4S03pgxKXy0sp4Z7Z3Wm1Wj8jQiWW5dj1sFuPnp95sh/edit
- * Email Agent drafts — Hit List → Gmail drafts + Email Agent Suggestions
+ * Email Agent drafts — Hit List → Gmail drafts + Email Agent Drafts
  *
  * Mirrors the Python workflows in market_research (repo: TrueSightDAO/content_schedule):
  *   - suggest_manager_followup_drafts.py  → Status "Manager Follow-up" (plain draft, no PDF)
@@ -28,7 +28,7 @@
 var HIT_LIST_SPREADSHEET_ID = '1eiqZr3LW-qEI6Hmy0Vrur_8flbRwxwA7jXVrbUnHbvc';
 var SHEET_HIT_LIST = 'Hit List';
 var SHEET_LOG = 'Email Agent Follow Up';
-var SHEET_SUGG = 'Email Agent Suggestions';
+var SHEET_SUGG = 'Email Agent Drafts';
 
 var STATUS_MANAGER = 'Manager Follow-up';
 var STATUS_BULK = 'Bulk Info Requested';
@@ -105,7 +105,7 @@ function runDraftsForStatus_(hitStatus, attachPdf, protocolVersion) {
   var hitSh = ss.getSheetByName(SHEET_HIT_LIST);
   var logSh = ss.getSheetByName(SHEET_LOG);
   var suggSh = ss.getSheetByName(SHEET_SUGG);
-  if (!hitSh || !suggSh) throw new Error('Hit List or Email Agent Suggestions sheet missing.');
+  if (!hitSh || !suggSh) throw new Error('Hit List or Email Agent Drafts sheet missing.');
 
   var pending = pendingToEmails_(suggSh);
   var lastSent = lastSentByToEmail_(logSh);

--- a/google_app_scripts/holistic_hit_list_store_history/store_interaction_history_api.gs
+++ b/google_app_scripts/holistic_hit_list_store_history/store_interaction_history_api.gs
@@ -6,7 +6,7 @@
  *
  * Description: Read-only REST-style GET API for the DApp "Store Interaction History".
  *   Autocomplete against Hit List; return one Hit List row plus matching rows from
- *   DApp Remarks, Email Agent Follow Up, and Email Agent Suggestions (human-in-the-loop
+ *   DApp Remarks, Email Agent Follow Up, and Email Agent Drafts (human-in-the-loop
  *   context before sending partner email). History arrays are sorted newest-first when
  *   date/timestamp columns are present; otherwise row order is reversed (sheet old→new).
  *
@@ -39,7 +39,7 @@ var HIT_LIST_SPREADSHEET_ID = '1eiqZr3LW-qEI6Hmy0Vrur_8flbRwxwA7jXVrbUnHbvc';
 var SHEET_HIT_LIST = 'Hit List';
 var SHEET_DAPP_REMARKS = 'DApp Remarks';
 var SHEET_EMAIL_FOLLOW_UP = 'Email Agent Follow Up';
-var SHEET_EMAIL_SUGGESTIONS = 'Email Agent Suggestions';
+var SHEET_EMAIL_DRAFTS = 'Email Agent Drafts';
 
 /** Max autocomplete results per suggestStores request. */
 var SUGGEST_LIMIT = 30;
@@ -114,6 +114,80 @@ function getParamList_(e, key) {
   return [single];
 }
 
+/** Integer sent-touch count from Hit List formula cells (AU / AV). */
+function hitListTouchCountFromCell_(v) {
+  if (v === '' || v === null || v === undefined) return 0;
+  var n = parseFloat(String(v).trim().replace(/,/g, ''));
+  if (isNaN(n) || n < 0) return 0;
+  return Math.floor(n);
+}
+
+/**
+ * Locate **Warm-up email sent** (AU) and **Follow-up emails sent** (AV) columns (0-based indices).
+ * Falls back to columns 47 / 48 when headers exist but names differ.
+ */
+function hitListFindTouchColumns_(hdr, headerRow) {
+  var au = hdr['Warm-up email sent'];
+  var av = hdr['Follow-up emails sent'];
+  var i;
+  var h;
+  if (au === undefined) {
+    for (i = 0; i < headerRow.length; i++) {
+      h = String(headerRow[i] || '')
+        .trim()
+        .toLowerCase();
+      if (h.indexOf('warm') !== -1 && h.indexOf('email') !== -1) {
+        au = i;
+        break;
+      }
+    }
+  }
+  if (av === undefined) {
+    for (i = 0; i < headerRow.length; i++) {
+      h = String(headerRow[i] || '')
+        .trim()
+        .toLowerCase();
+      if (h.indexOf('follow') !== -1 && h.indexOf('email') !== -1) {
+        av = i;
+        break;
+      }
+    }
+  }
+  if (au === undefined && headerRow.length >= 47) au = 46;
+  if (av === undefined && headerRow.length >= 48) av = 47;
+  return { au: au, av: av };
+}
+
+function hitListMakeEmptyTouchAgg_() {
+  return { count: 0, wu0: 0, wu1: 0, wu2p: 0, fu0: 0, fu1: 0, fu2p: 0 };
+}
+
+function hitListBumpTouchAgg_(agg, wu, fu) {
+  agg.count++;
+  if (wu <= 0) agg.wu0++;
+  else if (wu === 1) agg.wu1++;
+  else agg.wu2p++;
+  if (fu <= 0) agg.fu0++;
+  else if (fu === 1) agg.fu1++;
+  else agg.fu2p++;
+}
+
+function hitListTouchAggToBuckets_(agg) {
+  return {
+    none: agg.wu0,
+    once: agg.wu1,
+    repeat: agg.wu2p,
+  };
+}
+
+function hitListTouchAggToBucketsFu_(agg) {
+  return {
+    none: agg.fu0,
+    once: agg.fu1,
+    repeat: agg.fu2p,
+  };
+}
+
 /**
  * Filter Hit List rows by Status / Shop Type (exact match to sheet cell values).
  * Empty statusList = no status filter (all). Empty shopTypeList = no shop-type filter (all).
@@ -134,6 +208,9 @@ function listHitListByFilter_(statusList, shopTypeList, limit, offset) {
 
   var wantStatus = statusList && statusList.length > 0;
   var wantShopType = shopTypeList && shopTypeList.length > 0;
+
+  var hdr = headerMap_(headers);
+  var touchCols = hitListFindTouchColumns_(hdr, headers);
 
   var matched = [];
   var r;
@@ -166,6 +243,9 @@ function listHitListByFilter_(statusList, shopTypeList, limit, offset) {
       if (!ok2) continue;
     }
 
+    var wu = touchCols.au !== undefined ? hitListTouchCountFromCell_(row[touchCols.au]) : 0;
+    var fu = touchCols.av !== undefined ? hitListTouchCountFromCell_(row[touchCols.av]) : 0;
+
     matched.push({
       store_key: (rowObj['Store Key'] || '').trim(),
       shop_name: (rowObj['Shop Name'] || '').trim(),
@@ -177,6 +257,8 @@ function listHitListByFilter_(statusList, shopTypeList, limit, offset) {
       status_updated:
         (rowObj['Status Updated Date'] || rowObj['Status Updated At'] || rowObj['Status Updated'] || '').trim(),
       hit_list_row: r + 1,
+      warmup_sent: wu,
+      followup_sent: fu,
     });
   }
 
@@ -191,7 +273,8 @@ function listHitListByFilter_(statusList, shopTypeList, limit, offset) {
 
 /**
  * One-pass counts for Pipeline-style overview (mirrors Hit List, not the "Pipeline Dashboard" sheet formulas).
- * Returns sorted-by-count-desc arrays for quick DApp filtering.
+ * Each bucket includes **warmup** / **followup** sent-touch **stages** from Hit List columns AU / AV
+ * (none · exactly one · two or more sends per ``sync_email_agent_followup.py`` / sheet formulas).
  */
 function hitListPipelineSummary_() {
   var ss = SpreadsheetApp.openById(HIT_LIST_SPREADSHEET_ID);
@@ -203,6 +286,7 @@ function hitListPipelineSummary_() {
       total_data_rows: 0,
       blank_status: 0,
       blank_shop_type: 0,
+      touch_metrics_available: false,
     };
   }
 
@@ -214,6 +298,7 @@ function hitListPipelineSummary_() {
       total_data_rows: 0,
       blank_status: 0,
       blank_shop_type: 0,
+      touch_metrics_available: false,
     };
   }
 
@@ -228,52 +313,79 @@ function hitListPipelineSummary_() {
       total_data_rows: values.length - 1,
       blank_status: 0,
       blank_shop_type: 0,
+      touch_metrics_available: false,
     };
   }
 
-  var statusCounts = {};
-  var shopCounts = {};
+  var touchCols = hitListFindTouchColumns_(hdr, headers);
+  var touchOk = touchCols.au !== undefined && touchCols.av !== undefined;
+
+  var statusAggs = {};
+  var shopAggs = {};
   var blankSt = 0;
   var blankShop = 0;
   var r;
 
   for (r = 1; r < values.length; r++) {
     var row = values[r];
+    var wu = touchOk ? hitListTouchCountFromCell_(row[touchCols.au]) : 0;
+    var fu = touchOk ? hitListTouchCountFromCell_(row[touchCols.av]) : 0;
+
     if (statusIdx !== undefined) {
       var st = row[statusIdx] !== undefined && row[statusIdx] !== null ? String(row[statusIdx]).trim() : '';
       if (!st) blankSt++;
-      else statusCounts[st] = (statusCounts[st] || 0) + 1;
+      else {
+        if (!statusAggs[st]) statusAggs[st] = hitListMakeEmptyTouchAgg_();
+        hitListBumpTouchAgg_(statusAggs[st], wu, fu);
+      }
     }
     if (shopTypeIdx !== undefined) {
       var stt = row[shopTypeIdx] !== undefined && row[shopTypeIdx] !== null ? String(row[shopTypeIdx]).trim() : '';
       if (!stt) blankShop++;
-      else shopCounts[stt] = (shopCounts[stt] || 0) + 1;
-    }
-  }
-
-  function toSortedPairs_(map) {
-    var out = [];
-    for (var k in map) {
-      if (Object.prototype.hasOwnProperty.call(map, k)) {
-        out.push({ key: k, count: map[k] });
+      else {
+        if (!shopAggs[stt]) shopAggs[stt] = hitListMakeEmptyTouchAgg_();
+        hitListBumpTouchAgg_(shopAggs[stt], wu, fu);
       }
     }
-    out.sort(function (a, b) {
-      return b.count - a.count;
-    });
-    return out;
   }
 
-  var stPairs = toSortedPairs_(statusCounts);
-  var shPairs = toSortedPairs_(shopCounts);
+  function sortKeysByCountDesc_(aggsMap) {
+    var keys = [];
+    for (var k in aggsMap) {
+      if (Object.prototype.hasOwnProperty.call(aggsMap, k)) keys.push(k);
+    }
+    keys.sort(function (a, b) {
+      return aggsMap[b].count - aggsMap[a].count;
+    });
+    return keys;
+  }
 
   var byStatus = [];
-  for (var i = 0; i < stPairs.length; i++) {
-    byStatus.push({ status: stPairs[i].key, count: stPairs[i].count });
+  var stKeys = sortKeysByCountDesc_(statusAggs);
+  var si;
+  for (si = 0; si < stKeys.length; si++) {
+    var stk = stKeys[si];
+    var sa = statusAggs[stk];
+    var rowObj = { status: stk, count: sa.count };
+    if (touchOk) {
+      rowObj.warmup = hitListTouchAggToBuckets_(sa);
+      rowObj.followup = hitListTouchAggToBucketsFu_(sa);
+    }
+    byStatus.push(rowObj);
   }
+
   var byShop = [];
-  for (var j = 0; j < shPairs.length; j++) {
-    byShop.push({ shop_type: shPairs[j].key, count: shPairs[j].count });
+  var shKeys = sortKeysByCountDesc_(shopAggs);
+  var ti;
+  for (ti = 0; ti < shKeys.length; ti++) {
+    var shk = shKeys[ti];
+    var ga = shopAggs[shk];
+    var rowShop = { shop_type: shk, count: ga.count };
+    if (touchOk) {
+      rowShop.warmup = hitListTouchAggToBuckets_(ga);
+      rowShop.followup = hitListTouchAggToBucketsFu_(ga);
+    }
+    byShop.push(rowShop);
   }
 
   return {
@@ -282,6 +394,7 @@ function hitListPipelineSummary_() {
     total_data_rows: values.length - 1,
     blank_status: blankSt,
     blank_shop_type: blankShop,
+    touch_metrics_available: touchOk,
   };
 }
 
@@ -511,7 +624,7 @@ function getStoreHistory_(storeKey, shopName) {
       shop_query: shopName || '',
       dapp_remarks: [],
       email_agent_follow_up: [],
-      email_agent_suggestions: [],
+      email_agent_drafts: [],
       message: 'Store not found for store_key/shop. Pick from suggestions.',
     };
   }
@@ -523,7 +636,7 @@ function getStoreHistory_(storeKey, shopName) {
 
   var remarks = filterRowsForStore_(SHEET_DAPP_REMARKS, ss, sk, '', shop);
   var follow = filterRowsForStore_(SHEET_EMAIL_FOLLOW_UP, ss, sk, email, shop);
-  var sugg = filterRowsForStore_(SHEET_EMAIL_SUGGESTIONS, ss, sk, email, shop);
+  var sugg = filterRowsForStore_(SHEET_EMAIL_DRAFTS, ss, sk, email, shop);
 
   var dappRows = remarks.rows.slice();
   var followRows = follow.rows.slice();
@@ -540,7 +653,7 @@ function getStoreHistory_(storeKey, shopName) {
     primary_email: email,
     dapp_remarks: dappRows,
     email_agent_follow_up: followRows,
-    email_agent_suggestions: suggRows,
+    email_agent_drafts: suggRows,
   };
 }
 
@@ -549,10 +662,12 @@ function getStoreHistory_(storeKey, shopName) {
  *
  * Actions:
  *   - suggestStores — e.parameter.q (min length 2); data.suggestions[]: shop_name, store_key, email, hit_list_row
- *   - getStoreHistory — e.parameter.store_key and/or shop; data includes hit_list, dapp_remarks[], email_agent_*[]
+ *   - getStoreHistory — e.parameter.store_key and/or shop; data includes hit_list, dapp_remarks[], email_agent_follow_up[], email_agent_drafts[]
  *   - listStoresByFilter — optional repeated status=, shop_type=; limit (default 200, max 500), offset (default 0).
- *       Empty status list = all statuses; empty shop_type = all shop types.
- *   - listStatusSummary — no extra params; data.by_status[] { status, count }, data.by_shop_type[] { shop_type, count }.
+ *       Empty status list = all statuses; empty shop_type = all shop types. Each row may include **warmup_sent**,
+ *       **followup_sent** (from Hit List AU / AV when present).
+ *   - listStatusSummary — no extra params; data.by_status[] / by_shop_type[] include **count** plus optional
+ *       **warmup** / **followup** { none, once, repeat } from AU / AV; **touch_metrics_available** when resolved.
  *
  * Auth: e.parameter.token when STORE_HISTORY_API_TOKEN is set (Script Properties).
  */

--- a/google_app_scripts/pipeline_metrics_snapshot/README.md
+++ b/google_app_scripts/pipeline_metrics_snapshot/README.md
@@ -28,7 +28,16 @@ Pipeline Dashboard tab (curated funnel order in cols C–E):
 - `metrics/weekly.json` — canonical machine feed. Schema: `generated_at`,
   `source{workbook_id,tab,gid,url}`, `totals{all_stores, partnered,
   highlights[]{status, stores, north_star}}`, `funnel[]{order, status,
-  stores}`.
+  stores}`, **`outreach_visibility`**:
+  - `email_agent_follow_up` — rows on **Email Agent Follow Up**: `sends_logged`
+    (`warmup`, `follow_up`, `bulk`, `unknown`, `total_rows`) and
+    `distinct_recipients` per bucket (unique `to_email`).
+  - `hit_list` — **Hit List** cohorts for warm-up and follow-up pipeline statuses:
+    `touch_columns_resolved`, `cohorts` keyed by exact Status string (stores,
+    `sum_warmup_sends_au`, `sum_follow_up_sends_av`, `warmup_send_depth` /
+    `follow_up_send_depth` as `{none, once, repeat}` from AU/AV), plus
+    `follow_up_pipeline_combined` (Manager Follow-up + Bulk Info Requested +
+    AI: Prospect replied) with a `note` field describing the union.
 - `metrics/weekly.md` — dropped verbatim under the "## Operator metrics"
   heading in `ADVISORY_SNAPSHOT.md`. Summary block surfaces the stages in
   `HIGHLIGHT_STATUSES` (currently `Partnered`, `Meeting Scheduled`,

--- a/google_app_scripts/pipeline_metrics_snapshot/sync_pipeline_metrics.gs
+++ b/google_app_scripts/pipeline_metrics_snapshot/sync_pipeline_metrics.gs
@@ -20,7 +20,10 @@
  *   oracle benefits from the curated funnel order in cols C–E.
  *
  * Outputs (committed to TrueSightDAO/ecosystem_change_logs main via Contents API):
- *   - metrics/weekly.json  — machine feed (schema described in weekly.md header)
+ *   - metrics/weekly.json  — machine feed (schema described in weekly.md header). Includes
+ *     **outreach_visibility**: Email Agent Follow Up send counts + distinct recipients
+ *     (warmup / follow_up / bulk), and Hit List cohort rollups for warm-up vs follow-up
+ *     pipeline statuses using AU/AV (logged send counts per store).
  *   - metrics/weekly.md    — human mirror; embedded verbatim into ADVISORY_SNAPSHOT.md
  *
  * Setup:
@@ -45,6 +48,18 @@ var PIPELINE_TAB_GID = 1606881029;
 var PIPELINE_TAB_URL =
   'https://docs.google.com/spreadsheets/d/' + HIT_LIST_SPREADSHEET_ID +
   '/edit#gid=' + PIPELINE_TAB_GID;
+
+/** Additional tabs read for oracle / operator email-pipeline visibility. */
+var HIT_LIST_TAB = 'Hit List';
+var EMAIL_AGENT_FOLLOW_UP_TAB = 'Email Agent Follow Up';
+
+/** Hit List Status values used for warm-up vs follow-up cohort summaries. */
+var COHORT_STATUS_WARMUP = 'AI: Warm up prospect';
+var COHORT_STATUSES_FOLLOW_UP_PIPELINE = [
+  'Manager Follow-up',
+  'Bulk Info Requested',
+  'AI: Prospect replied'
+];
 
 // Ordered funnel lives in cols C (order), D (status label), E (store count).
 var ORDER_COL = 3;   // C
@@ -258,12 +273,269 @@ function _readPipelineFunnel_() {
 }
 
 // ============================================================================
+// OUTREACH VISIBILITY (Email Agent Follow Up + Hit List AU / AV)
+// ============================================================================
+
+function _headerMapPipeline_(headerRow) {
+  var map = {};
+  for (var i = 0; i < headerRow.length; i++) {
+    var h = String(headerRow[i] || '').trim();
+    if (h) map[h] = i;
+  }
+  return map;
+}
+
+function _touchCountPipeline_(v) {
+  if (v === '' || v === null || v === undefined) return 0;
+  var n = parseFloat(String(v).trim().replace(/,/g, ''));
+  if (isNaN(n) || n < 0) return 0;
+  return Math.floor(n);
+}
+
+/**
+ * Locate **Warm-up email sent** (AU) and **Follow-up emails sent** (AV) columns (0-based indices).
+ * Mirrors holistic_hit_list_store_history logic.
+ */
+function _findTouchColsPipeline_(hdr, headerRow) {
+  var au = hdr['Warm-up email sent'];
+  var av = hdr['Follow-up emails sent'];
+  var i;
+  var h;
+  if (au === undefined) {
+    for (i = 0; i < headerRow.length; i++) {
+      h = String(headerRow[i] || '')
+        .trim()
+        .toLowerCase();
+      if (h.indexOf('warm') !== -1 && h.indexOf('email') !== -1) {
+        au = i;
+        break;
+      }
+    }
+  }
+  if (av === undefined) {
+    for (i = 0; i < headerRow.length; i++) {
+      h = String(headerRow[i] || '')
+        .trim()
+        .toLowerCase();
+      if (h.indexOf('follow') !== -1 && h.indexOf('email') !== -1) {
+        av = i;
+        break;
+      }
+    }
+  }
+  if (au === undefined && headerRow.length >= 47) au = 46;
+  if (av === undefined && headerRow.length >= 48) av = 47;
+  return { au: au, av: av };
+}
+
+function _makeEmptyCohortAgg_() {
+  return {
+    stores: 0,
+    sum_warmup_sends_au: 0,
+    sum_follow_up_sends_av: 0,
+    warmup_send_depth: { none: 0, once: 0, repeat: 0 },
+    follow_up_send_depth: { none: 0, once: 0, repeat: 0 }
+  };
+}
+
+function _bumpCohortAgg_(agg, au, av) {
+  agg.stores++;
+  agg.sum_warmup_sends_au += au;
+  agg.sum_follow_up_sends_av += av;
+  if (au <= 0) agg.warmup_send_depth.none++;
+  else if (au === 1) agg.warmup_send_depth.once++;
+  else agg.warmup_send_depth.repeat++;
+  if (av <= 0) agg.follow_up_send_depth.none++;
+  else if (av === 1) agg.follow_up_send_depth.once++;
+  else agg.follow_up_send_depth.repeat++;
+}
+
+function _mergeCohortAggs_(dst, src) {
+  dst.stores += src.stores;
+  dst.sum_warmup_sends_au += src.sum_warmup_sends_au;
+  dst.sum_follow_up_sends_av += src.sum_follow_up_sends_av;
+  dst.warmup_send_depth.none += src.warmup_send_depth.none;
+  dst.warmup_send_depth.once += src.warmup_send_depth.once;
+  dst.warmup_send_depth.repeat += src.warmup_send_depth.repeat;
+  dst.follow_up_send_depth.none += src.follow_up_send_depth.none;
+  dst.follow_up_send_depth.once += src.follow_up_send_depth.once;
+  dst.follow_up_send_depth.repeat += src.follow_up_send_depth.repeat;
+}
+
+/**
+ * Logged Gmail **Sent** rows from **Email Agent Follow Up** (`status` = warmup | follow_up | bulk | …).
+ */
+function _readEmailAgentFollowUpLog_() {
+  var base = {
+    ok: false,
+    tab: EMAIL_AGENT_FOLLOW_UP_TAB,
+    sends_logged: { warmup: 0, follow_up: 0, bulk: 0, unknown: 0, total_rows: 0 },
+    distinct_recipients: { warmup: 0, follow_up: 0, bulk: 0, unknown: 0 }
+  };
+
+  var ss = SpreadsheetApp.openById(HIT_LIST_SPREADSHEET_ID);
+  var sh = ss.getSheetByName(EMAIL_AGENT_FOLLOW_UP_TAB);
+  if (!sh) return base;
+
+  var values = sh.getDataRange().getValues();
+  if (values.length < 2) {
+    base.ok = true;
+    return base;
+  }
+
+  var hdr = _headerMapPipeline_(values[0]);
+  var stI = hdr['status'];
+  var emI = hdr['to_email'];
+  if (stI === undefined || emI === undefined) {
+    base.error = 'missing column "status" or "to_email" on Email Agent Follow Up';
+    return base;
+  }
+
+  var setsWarm = {};
+  var setsFu = {};
+  var setsBulk = {};
+  var setsUnk = {};
+
+  var r;
+  for (r = 1; r < values.length; r++) {
+    var row = values[r];
+    var st = String(row[stI] || '').trim().toLowerCase();
+    var em = String(row[emI] || '').trim().toLowerCase();
+
+    base.sends_logged.total_rows++;
+    if (st === 'warmup') base.sends_logged.warmup++;
+    else if (st === 'follow_up') base.sends_logged.follow_up++;
+    else if (st === 'bulk') base.sends_logged.bulk++;
+    else base.sends_logged.unknown++;
+
+    if (!em) continue;
+    if (st === 'warmup') setsWarm[em] = true;
+    else if (st === 'follow_up') setsFu[em] = true;
+    else if (st === 'bulk') setsBulk[em] = true;
+    else setsUnk[em] = true;
+  }
+
+  function countKeys_(obj) {
+    var n = 0;
+    for (var k in obj) {
+      if (Object.prototype.hasOwnProperty.call(obj, k)) n++;
+    }
+    return n;
+  }
+
+  base.distinct_recipients.warmup = countKeys_(setsWarm);
+  base.distinct_recipients.follow_up = countKeys_(setsFu);
+  base.distinct_recipients.bulk = countKeys_(setsBulk);
+  base.distinct_recipients.unknown = countKeys_(setsUnk);
+  base.ok = true;
+  return base;
+}
+
+/**
+ * Per Hit List **Status** cohort: store counts + AU/AV sums and depth buckets (none / once / repeat sends).
+ */
+function _readHitListOutreachDepth_() {
+  var out = {
+    touch_columns_resolved: false,
+    cohorts: {},
+    follow_up_pipeline_combined: null
+  };
+
+  var ss = SpreadsheetApp.openById(HIT_LIST_SPREADSHEET_ID);
+  var sh = ss.getSheetByName(HIT_LIST_TAB);
+  if (!sh) return out;
+
+  var values = sh.getDataRange().getValues();
+  if (values.length < 2) return out;
+
+  var headers = values[0];
+  var hdr = _headerMapPipeline_(headers);
+  var statusIdx = hdr['Status'];
+  if (statusIdx === undefined) return out;
+
+  var touchCols = _findTouchColsPipeline_(hdr, headers);
+  var touchOk = touchCols.au !== undefined && touchCols.av !== undefined;
+  out.touch_columns_resolved = Boolean(touchOk);
+
+  var want = {};
+  want[COHORT_STATUS_WARMUP] = true;
+  for (var wi = 0; wi < COHORT_STATUSES_FOLLOW_UP_PIPELINE.length; wi++) {
+    want[COHORT_STATUSES_FOLLOW_UP_PIPELINE[wi]] = true;
+  }
+
+  for (var k in want) {
+    if (Object.prototype.hasOwnProperty.call(want, k)) {
+      out.cohorts[k] = _makeEmptyCohortAgg_();
+    }
+  }
+
+  var rr;
+  for (rr = 1; rr < values.length; rr++) {
+    var row = values[rr];
+    var st = String(row[statusIdx] || '').trim();
+    if (!want[st]) continue;
+
+    var au = touchOk ? _touchCountPipeline_(row[touchCols.au]) : 0;
+    var av = touchOk ? _touchCountPipeline_(row[touchCols.av]) : 0;
+    _bumpCohortAgg_(out.cohorts[st], au, av);
+  }
+
+  var combined = _makeEmptyCohortAgg_();
+  combined.note =
+    'Union of Hit List rows in statuses: ' + COHORT_STATUSES_FOLLOW_UP_PIPELINE.join(', ');
+  for (var ci = 0; ci < COHORT_STATUSES_FOLLOW_UP_PIPELINE.length; ci++) {
+    var label = COHORT_STATUSES_FOLLOW_UP_PIPELINE[ci];
+    if (out.cohorts[label]) {
+      _mergeCohortAggs_(combined, out.cohorts[label]);
+    }
+  }
+  out.follow_up_pipeline_combined = combined;
+
+  return out;
+}
+
+function _appendCohortMarkdown_(mdLines, title, agg) {
+  if (!agg || !agg.stores) {
+    mdLines.push('- **' + title + '**: _(no rows in this status)_');
+    return;
+  }
+  mdLines.push(
+    '- **' +
+      title +
+      '**: **' +
+      agg.stores +
+      '** stores — sum logged **warmup** sends (AU): **' +
+      agg.sum_warmup_sends_au +
+      '**, sum logged **follow-up** sends (AV): **' +
+      agg.sum_follow_up_sends_av +
+      '**; warmup depth (none / once / ≥2): **' +
+      agg.warmup_send_depth.none +
+      '** / **' +
+      agg.warmup_send_depth.once +
+      '** / **' +
+      agg.warmup_send_depth.repeat +
+      '**; follow-up depth (none / once / ≥2): **' +
+      agg.follow_up_send_depth.none +
+      '** / **' +
+      agg.follow_up_send_depth.once +
+      '** / **' +
+      agg.follow_up_send_depth.repeat +
+      '**'
+  );
+}
+
+// ============================================================================
 // ARTIFACT BUILDERS
 // ============================================================================
 
 function _buildArtifacts_(funnel) {
   var now = new Date();
   var generatedAt = now.toISOString();
+
+  var outreach = {
+    email_agent_follow_up: _readEmailAgentFollowUpLog_(),
+    hit_list: _readHitListOutreachDepth_()
+  };
 
   var jsonObj = {
     generated_at: generatedAt,
@@ -278,7 +550,8 @@ function _buildArtifacts_(funnel) {
       partnered: funnel.partnered,
       highlights: funnel.highlights
     },
-    funnel: funnel.rows
+    funnel: funnel.rows,
+    outreach_visibility: outreach
   };
 
   var jsonText = JSON.stringify(jsonObj, null, 2) + '\n';
@@ -319,6 +592,62 @@ function _buildArtifacts_(funnel) {
         : (r.status + ': ' + r.stores);
       mdLines.push('- ' + label + '  (' + orderTag + ')');
     }
+  }
+
+  mdLines.push('');
+  mdLines.push('## Email outreach visibility (logged sends + Hit List AU/AV)');
+  mdLines.push('');
+
+  var logR = outreach.email_agent_follow_up;
+  if (!logR.ok) {
+    mdLines.push('_(Email Agent Follow Up tab missing or columns incomplete — no log summary.)_');
+    if (logR.error) mdLines.push('- _Error: ' + logR.error + '_');
+  } else {
+    mdLines.push(
+      '- **Email Agent Follow Up** — logged sends: warmup **' +
+        logR.sends_logged.warmup +
+        '**, follow_up **' +
+        logR.sends_logged.follow_up +
+        '**, bulk **' +
+        logR.sends_logged.bulk +
+        '**, unknown **' +
+        logR.sends_logged.unknown +
+        '** (data rows: **' +
+        logR.sends_logged.total_rows +
+        '**)'
+    );
+    mdLines.push(
+      '- Distinct recipient addresses (`to_email`, by log `status`): warmup **' +
+        logR.distinct_recipients.warmup +
+        '**, follow_up **' +
+        logR.distinct_recipients.follow_up +
+        '**, bulk **' +
+        logR.distinct_recipients.bulk +
+        '**, unknown **' +
+        logR.distinct_recipients.unknown +
+        '**'
+    );
+  }
+
+  mdLines.push('');
+  mdLines.push('### Hit List cohorts (stores in stage × AU/AV send counts)');
+  mdLines.push('');
+
+  var hl = outreach.hit_list;
+  if (!hl.touch_columns_resolved) {
+    mdLines.push(
+      '_Warm-up / follow-up **depth** buckets need Hit List columns AU/AV (**Warm-up email sent**, **Follow-up emails sent**). Sums may read as 0 until headers exist._'
+    );
+    mdLines.push('');
+  }
+
+  _appendCohortMarkdown_(mdLines, COHORT_STATUS_WARMUP, hl.cohorts[COHORT_STATUS_WARMUP]);
+  for (var fxi = 0; fxi < COHORT_STATUSES_FOLLOW_UP_PIPELINE.length; fxi++) {
+    var flab = COHORT_STATUSES_FOLLOW_UP_PIPELINE[fxi];
+    _appendCohortMarkdown_(mdLines, flab, hl.cohorts[flab]);
+  }
+  if (hl.follow_up_pipeline_combined && hl.follow_up_pipeline_combined.stores) {
+    _appendCohortMarkdown_(mdLines, 'Follow-up pipeline (combined)', hl.follow_up_pipeline_combined);
   }
 
   mdLines.push('');


### PR DESCRIPTION
Pipeline snapshot GAS now emits outreach_visibility (Email Agent Follow Up send counts + Hit List AU/AV cohorts) into ecosystem_change_logs metrics/weekly.json|md. Store interaction API gains listStatusSummary warmup/follow-up buckets. After merge: clasp push pipeline (11fA8NX…), store history (14gKJ…), and copy find_nearby from go_to_market for 1NpHrKJW… deploy.

Made with [Cursor](https://cursor.com)