### PR TITLE
Fix Hit List API: listStoresByFilter bucket params (warmupBucket undefined)

### DIFF
--- a/google_app_scripts/holistic_hit_list_store_history/store_interaction_history_api.gs
+++ b/google_app_scripts/holistic_hit_list_store_history/store_interaction_history_api.gs
@@ -208,8 +208,9 @@ function hitListTouchAggToBucketsFu_(agg) {
 /**
  * Filter Hit List rows by Status / Shop Type (exact match to sheet cell values).
  * Empty statusList = no status filter (all). Empty shopTypeList = no shop-type filter (all).
+ * Optional warmupBucket / followupBucket: integers 0..7 or null (see doGet listStoresByFilter).
  */
-function listHitListByFilter_(statusList, shopTypeList, limit, offset) {
+function listHitListByFilter_(statusList, shopTypeList, limit, offset, warmupBucket, followupBucket) {
   var ss = SpreadsheetApp.openById(HIT_LIST_SPREADSHEET_ID);
   var sh = getSheetSafe_(ss, SHEET_HIT_LIST);
   if (!sh) {


### PR DESCRIPTION
## Bug

`listStoresByFilter` with `warmup_bucket` and/or `followup_bucket` returned HTTP 500:

`warmupBucket is not defined`

`doGet` parsed the query and called `listHitListByFilter_(statusList, shopTypeList, lim, off, warmupB, followB)`, but `listHitListByFilter_` only declared four parameters. The function body referenced `warmupBucket` / `followupBucket` as globals.

## Fix

Add `warmupBucket` and `followupBucket` to the helper signature so the values from `doGet` are in scope.

## Deploy

Redeploy the **holistic_hit_list_store_history** web app from Apps Script after merge (same `/exec` URL). **Edgar proxy** does not need changes for this fix.

Made with [Cursor](https://cursor.com)