### PR TITLE
find_nearby_stores: async [RETAIL FIELD REPORT EVENT] scanner

### DIFF
--- a/google_app_scripts/_clasp_default/Version.gs
+++ b/google_app_scripts/_clasp_default/Version.gs
@@ -13,12 +13,13 @@
  */
 
 /** ISO UTC timestamp of the last clasp push for this mirror */
-var CLASP_MIRROR_LAST_CLASP_PUSH_UTC = '2026-04-17T00:00:00Z';
+var CLASP_MIRROR_LAST_CLASP_PUSH_UTC = '2026-04-27T18:30:00Z';
 
 /**
  * Newest first. Keep lines short; link PRs/commits in git instead of pasting secrets.
  */
 var CLASP_MIRROR_CHANGELOG =
+  '2026-04-27 — find_nearby_stores: async [RETAIL FIELD REPORT EVENT] scanner — Telegram Chat Logs → Hit List + DApp Remarks + Stores Visits Field Reports (dedup on col G update_id).\n' +
   '2026-04-17 — Migrate qr_code_web_service to admin@truesight.me project; consolidate processBatch to send one email per owner across multiple QR codes.\n' +
   '2026-04-15 — loadSheets: openById + getSheetByNameOrGid_ fallback (fix undefined signaturesSheet / getDataRange crash).\n' +
   '2026-04-15 — Identity web app: add doPost email verification trigger for DApp email onboarding (Edgar → Gmail).\n' +

--- a/google_app_scripts/find_nearby_stores/README.md
+++ b/google_app_scripts/find_nearby_stores/README.md
@@ -1,0 +1,72 @@
+# find_nearby_stores — Google Apps Script (partial canonical)
+
+Apps Script project: **Agroverse - Stores Nearby**
+Script ID: `1NpHrKJW8Q4suu6-f5gXQcbjHqUZtGOG-KcIf81M1GG8lDShm5-fLphD2`
+Editor: https://script.google.com/home/projects/1NpHrKJW8Q4suu6-f5gXQcbjHqUZtGOG-KcIf81M1GG8lDShm5-fLphD2/edit
+Deployed `/exec`: see `clasp_mirrors/1NpHrKJW…/.clasp.json` and `dapp/routes.js` (`Routes.gas.stores`).
+
+## What this folder canonicalizes (and what it does not)
+
+| File | Canonical here? | Notes |
+|------|-----------------|-------|
+| `process_retail_field_reports_telegram_logs.gs` | **Yes** | Async scanner + helpers. Triggered by Edgar (`?action=processRetailFieldReportsFromTelegramChatLogs`) after every `[RETAIL FIELD REPORT EVENT]` is logged to `Telegram Chat Logs`. |
+| `Code.js` (everything else: `doGet`, `findNearbyStores`, `updateStoreStatus`, `add_store`, `log_field_report_attachment`, `ensureStoresVisitsFieldReportsSheet_`, `appendStoresVisitsFieldReportRow_`, `linkFieldReportUrlsToDappRemarks_`, …) | **No** — only in `clasp_mirrors/1NpHrKJW…/Code.js` (gitignored) | Migration to this folder is a separate task. |
+
+The async scanner depends on `updateStoreStatus`, `appendStoresVisitsFieldReportRow_`, `ensureStoresVisitsFieldReportsSheet_`, and `linkFieldReportUrlsToDappRemarks_` from the legacy `Code.js`. Clasp combines all `.js` / `.gs` files in the mirror into one script project, so the dependency resolves at deploy time.
+
+## Sync to mirror (manual, until full canonicalization)
+
+From `tokenomics/` root, after editing this folder:
+
+```bash
+cp google_app_scripts/find_nearby_stores/process_retail_field_reports_telegram_logs.gs \
+   clasp_mirrors/1NpHrKJW8Q4suu6-f5gXQcbjHqUZtGOG-KcIf81M1GG8lDShm5-fLphD2/process_retail_field_reports_telegram_logs.js
+
+cp google_app_scripts/_clasp_default/Version.gs \
+   clasp_mirrors/1NpHrKJW8Q4suu6-f5gXQcbjHqUZtGOG-KcIf81M1GG8lDShm5-fLphD2/Version.gs
+
+cd clasp_mirrors/1NpHrKJW8Q4suu6-f5gXQcbjHqUZtGOG-KcIf81M1GG8lDShm5-fLphD2/
+clasp push
+clasp deploy --deploymentId <existing-deployment-id> --description "<changelog>"
+```
+
+Then in `Code.js` (mirror only — gitignored), add a branch to the existing `doGet`:
+
+```javascript
+// Async retail field report scanner (Telegram Chat Logs → Hit List + DApp Remarks
+// + Stores Visits Field Reports). Triggered by Edgar `submit_contribution`.
+if (e.parameter.action === 'processRetailFieldReportsFromTelegramChatLogs') {
+  var out = processRetailFieldReportsFromTelegramChatLogs();
+  return ContentService.createTextOutput(JSON.stringify(out)).setMimeType(ContentService.MimeType.JSON);
+}
+```
+
+Place it next to `if (e.parameter.action === 'log_field_report_attachment') { … }`.
+
+## Cron safety net (optional, recommended)
+
+In the Apps Script editor → **Triggers** → add a time-driven trigger:
+
+- Function: `processRetailFieldReportsFromTelegramChatLogs`
+- Type: Time-driven
+- Frequency: Every 30 minutes (mirrors `processRepackagingBatchesFromTelegramChatLogs` / `parseTelegramChatLogs`)
+
+Idempotent (dedup on `update_id` in **Stores Visits Field Reports** col G), so concurrent fires are safe.
+
+## Why a scanner (and not a direct Edgar→GAS call)?
+
+`Edgar` cannot reliably issue a synchronous server-to-server call to GAS for every event:
+GAS web app responses can take 30+ seconds, and `WebhookTriggerWorker` (Sidekiq) is the
+canonical async path. The same pattern is used by:
+
+- `processSalesTelegramLogs` / `parseTelegramChatLogs` (sales)
+- `processQRCodeGenerationTelegramLogs` (QR code generation)
+- `processRepackagingBatchesFromTelegramChatLogs` (repackaging)
+
+Edgar's only synchronous job for `[RETAIL FIELD REPORT EVENT]` is:
+1. Verify signature.
+2. Append to `Telegram Chat Logs` (col G).
+3. Upload the attachment to GitHub at the deterministic blob URL embedded in the payload.
+4. Enqueue this scanner via `WebhookTriggerWorker` (`?action=processRetailFieldReportsFromTelegramChatLogs`).
+
+Everything else — Hit List Status, DApp Remarks, Stores Visits Field Reports — happens here.

--- a/google_app_scripts/find_nearby_stores/process_retail_field_reports_telegram_logs.gs
+++ b/google_app_scripts/find_nearby_stores/process_retail_field_reports_telegram_logs.gs
@@ -1,0 +1,255 @@
+/**
+ * File: google_app_scripts/find_nearby_stores/process_retail_field_reports_telegram_logs.gs
+ * Repository: https://github.com/TrueSightDAO/tokenomics
+ * Apps Script editor:
+ * https://script.google.com/home/projects/1NpHrKJW8Q4suu6-f5gXQcbjHqUZtGOG-KcIf81M1GG8lDShm5-fLphD2/edit
+ *
+ * Description: Async scanner for `[RETAIL FIELD REPORT EVENT]` rows on the canonical
+ *   **Telegram Chat Logs** intake (`1qbZZhf-_7xzmDTriaJVWj6OZshyQsFkdsAV8-pyzASQ`).
+ *
+ *   Edgar (`sentiment_importer/app/controllers/dao_controller.rb#submit_contribution`)
+ *   writes the signed payload into Telegram Chat Logs col G, uploads the attachment
+ *   to GitHub at the deterministic blob URL embedded in the payload, then enqueues a
+ *   webhook to this script (`?action=processRetailFieldReportsFromTelegramChatLogs`).
+ *
+ *   For each Telegram log row whose `Update ID` (SFR_…) is not yet present in
+ *   **Stores Visits Field Reports** col G on the Hit List workbook, this scanner:
+ *     1. Calls `updateStoreStatus(...)` (Hit List Status / DApp Remarks).
+ *     2. Appends one row A–N to **Stores Visits Field Reports** — col L `github_blob_url`
+ *        and col M `github_raw_url` are the addresses of the blob Edgar uploaded.
+ *     3. Copies the URLs onto the matching DApp Remarks row via
+ *        `linkFieldReportUrlsToDappRemarks_`.
+ *
+ *   The append in step 2 also serves as the dedup log for future runs (idempotent).
+ *
+ *   Browsers cannot reliably issue cross-origin POSTs to GAS web apps, so the DApp
+ *   only POSTs the signed event to Edgar. Everything sheet-side happens here.
+ *
+ * Mirror canonicalization status (2026-04-27):
+ *   No thematic folder exists for the rest of `find_nearby_stores`. The other
+ *   functions (`updateStoreStatus`, `appendStoresVisitsFieldReportRow_`,
+ *   `linkFieldReportUrlsToDappRemarks_`, `ensureStoresVisitsFieldReportsSheet_`,
+ *   `doGet`) currently live only in the local mirror
+ *   `tokenomics/clasp_mirrors/1NpHrKJW…/Code.js` (gitignored). When this file is
+ *   `cp`ed into that mirror alongside Code.js, clasp pushes both. Adding a
+ *   `?action=processRetailFieldReportsFromTelegramChatLogs` branch to the mirror's
+ *   `doGet` is a one-time edit — see the README in this folder.
+ *
+ *   Sync command (run from `tokenomics/`):
+ *     cp google_app_scripts/find_nearby_stores/process_retail_field_reports_telegram_logs.gs \
+ *        clasp_mirrors/1NpHrKJW8Q4suu6-f5gXQcbjHqUZtGOG-KcIf81M1GG8lDShm5-fLphD2/process_retail_field_reports_telegram_logs.js
+ */
+
+/** Telegram Chat Logs intake spreadsheet (Edgar writes col G of every signed event here). */
+var TELEGRAM_CHAT_LOGS_SPREADSHEET_ID = '1qbZZhf-_7xzmDTriaJVWj6OZshyQsFkdsAV8-pyzASQ';
+var TELEGRAM_CHAT_LOGS_SHEET = 'Telegram Chat Logs';
+/** Telegram Chat Logs col G (zero-based 6) — signed event text Edgar wrote. */
+var TELEGRAM_CHAT_LOGS_MESSAGE_COL = 6;
+/** Per-fire scan window. Cron safety-net picks up older rows if it ever falls behind. */
+var RETAIL_FIELD_REPORT_SCAN_BATCH = 200;
+
+/**
+ * Parse a `[RETAIL FIELD REPORT EVENT]` body into a key→value map. Mirrors the Ruby
+ * parser in `dao_controller.rb#parse_retail_field_report` (stops at the `--------`
+ * signature separator; lowercases + snake-cases the label). Use this only for the
+ * fields **before** the separator; `My Digital Signature:` lives after.
+ * @param {string} text
+ * @return {Object<string,string>}
+ */
+function parseRetailFieldReportText_(text) {
+  var result = {};
+  if (!text) return result;
+  var body = String(text).split('--------', 1)[0] || String(text);
+  var lines = body.split(/\r?\n/);
+  for (var i = 0; i < lines.length; i++) {
+    var line = (lines[i] || '').trim();
+    if (!line) continue;
+    if (line.indexOf('[RETAIL FIELD REPORT EVENT]') === 0) continue;
+    var m = line.match(/^([A-Za-z][A-Za-z0-9_\s\/\-]*):\s*(.*)$/);
+    if (!m) continue;
+    var key = m[1].trim().toLowerCase().replace(/\s+/g, '_');
+    result[key] = m[2].trim();
+  }
+  return result;
+}
+
+/**
+ * Pull the contributor public key from the signed payload. Lives after `--------`
+ * so the body parser intentionally skips it.
+ * @param {string} text
+ * @return {string}
+ */
+function extractMyDigitalSignatureFromText_(text) {
+  if (!text) return '';
+  var m = String(text).match(/My Digital Signature:\s*([^\n\r]+)/);
+  return m ? m[1].trim() : '';
+}
+
+/**
+ * Strip the GitHub blob prefix to recover the repo-relative path
+ * (`store_visits_field_reports/<store-key>/<update_id>/01_<filename>`).
+ * @param {string} blobUrl
+ * @return {string}
+ */
+function deriveGithubPathFromBlobUrl_(blobUrl) {
+  if (!blobUrl) return '';
+  return String(blobUrl).replace(
+    /^https:\/\/github\.com\/[^/]+\/[^/]+\/(?:blob|tree)\/[^/]+\//,
+    ''
+  );
+}
+
+/**
+ * HTTP / time-driven entry point. Triggered from Edgar after every
+ * `[RETAIL FIELD REPORT EVENT]` submission, plus a safety-net cron for retries.
+ *
+ * Idempotent: dedup is keyed on `Update ID` (col G) of **Stores Visits Field Reports**.
+ * Re-runs over the same Telegram log rows skip already-recorded `update_id`s.
+ *
+ * Serialized via `LockService.getScriptLock()` so concurrent webhook fires cannot
+ * race when reading/writing the dedup set.
+ *
+ * @return {{success:boolean, processed?:number, skipped?:number, errors?:number, error?:string}}
+ */
+function processRetailFieldReportsFromTelegramChatLogs() {
+  var lock = LockService.getScriptLock();
+  if (!lock.tryLock(180000)) {
+    Logger.log('processRetailFieldReportsFromTelegramChatLogs: another run is in progress; skipping.');
+    return { success: false, error: 'busy' };
+  }
+  try {
+    var tcSpreadsheet = SpreadsheetApp.openById(TELEGRAM_CHAT_LOGS_SPREADSHEET_ID);
+    var tcSheet = tcSpreadsheet.getSheetByName(TELEGRAM_CHAT_LOGS_SHEET);
+    if (!tcSheet) {
+      throw new Error('Telegram Chat Logs sheet "' + TELEGRAM_CHAT_LOGS_SHEET + '" not found');
+    }
+
+    var hitListSpreadsheet = SpreadsheetApp.openById(SPREADSHEET_ID);
+    var reportsSheet = ensureStoresVisitsFieldReportsSheet_(hitListSpreadsheet);
+
+    // Build dedup set from existing **Stores Visits Field Reports** col G (`update_id`).
+    var reportsValues = reportsSheet.getDataRange().getValues();
+    var seenUpdateIds = {};
+    for (var r = 1; r < reportsValues.length; r++) {
+      var existingId = String(reportsValues[r][6] || '').trim();
+      if (existingId) seenUpdateIds[existingId] = true;
+    }
+
+    // Scan the trailing window of Telegram Chat Logs for new RETAIL FIELD REPORT events.
+    var lastRow = tcSheet.getLastRow();
+    if (lastRow < 2) {
+      return { success: true, processed: 0, skipped: 0, errors: 0 };
+    }
+    var startRow = Math.max(2, lastRow - RETAIL_FIELD_REPORT_SCAN_BATCH + 1);
+    var numRows = lastRow - startRow + 1;
+    var lastCol = Math.max(tcSheet.getLastColumn(), TELEGRAM_CHAT_LOGS_MESSAGE_COL + 1);
+    var tcRange = tcSheet.getRange(startRow, 1, numRows, lastCol).getValues();
+
+    var processed = 0;
+    var skipped = 0;
+    var errors = 0;
+    for (var i = 0; i < tcRange.length; i++) {
+      var message = String(tcRange[i][TELEGRAM_CHAT_LOGS_MESSAGE_COL] || '');
+      if (message.indexOf('[RETAIL FIELD REPORT EVENT]') === -1) continue;
+
+      var fields = parseRetailFieldReportText_(message);
+      var updateId = String(fields.update_id || '').trim();
+      if (!updateId) {
+        Logger.log('Skipping retail field report at Telegram row ' + (startRow + i) + ': no Update ID.');
+        skipped++;
+        continue;
+      }
+      if (seenUpdateIds[updateId]) {
+        skipped++;
+        continue;
+      }
+
+      var shopName = String(fields.shop_name || '').trim();
+      var newStatus = String(fields.new_status || '').trim();
+      if (!shopName || !newStatus) {
+        Logger.log('Retail field report ' + updateId + ': missing shop_name or new_status; skipping.');
+        skipped++;
+        continue;
+      }
+
+      var digitalSignature = extractMyDigitalSignatureFromText_(message);
+      var submittedBy =
+        digitalSignature ||
+        String(fields.my_digital_signature || fields.digital_signature || '').trim();
+
+      try {
+        // 1. Hit List Status + DApp Remarks (existing function in find_nearby_stores Code.js).
+        updateStoreStatus(
+          shopName,
+          newStatus,
+          digitalSignature,
+          String(fields.remarks || ''),
+          submittedBy,
+          String(fields.shop_type || ''),
+          String(fields.instagram || ''),
+          String(fields.owner_name || ''),
+          String(fields.contact_person || ''),
+          String(fields.email || ''),
+          String(fields.cell_phone || ''),
+          String(fields.phone || ''),
+          String(fields.website || ''),
+          String(fields.follow_up_date || ''),
+          String(fields.visit_date || ''),
+          String(fields.contact_date || ''),
+          String(fields.contact_method || ''),
+          updateId
+        );
+
+        // 2. Stores Visits Field Reports A–N — also the dedup record for future runs.
+        var blobUrl = String(fields.attachment_github_url || '').trim();
+        var rawUrl = String(fields.attachment_raw_url || '').trim();
+        var githubPath = deriveGithubPathFromBlobUrl_(blobUrl);
+        appendStoresVisitsFieldReportRow_({
+          shop_name: shopName,
+          store_key: String(fields.store_key || ''),
+          email: String(fields.email || ''),
+          hit_list_row: '',
+          update_id: updateId,
+          digital_signature: submittedBy,
+          filename_original: String(fields.attachment_filename || ''),
+          mime_type: String(fields.attachment_mime_type || ''),
+          github_path: githubPath,
+          github_blob_url: blobUrl,
+          github_raw_url: rawUrl || blobUrl,
+          remarks: String(fields.remarks || '').slice(0, 2000)
+        });
+
+        // 3. Copy URLs onto the matching DApp Remarks row (no-op when no match).
+        linkFieldReportUrlsToDappRemarks_(
+          hitListSpreadsheet,
+          updateId,
+          submittedBy,
+          rawUrl || blobUrl,
+          blobUrl || rawUrl
+        );
+
+        seenUpdateIds[updateId] = true;
+        processed++;
+      } catch (rowErr) {
+        errors++;
+        Logger.log('Retail field report ' + updateId + ' failed: ' + rowErr);
+      }
+    }
+
+    Logger.log(
+      'processRetailFieldReportsFromTelegramChatLogs: processed=' +
+        processed +
+        ' skipped=' +
+        skipped +
+        ' errors=' +
+        errors +
+        ' window=' +
+        startRow +
+        '-' +
+        lastRow
+    );
+    return { success: true, processed: processed, skipped: skipped, errors: errors };
+  } finally {
+    lock.releaseLock();
+  }
+}


### PR DESCRIPTION
## Goal

When a contributor submits a status update on `dapp.truesight.me/store_interaction_history.html`, the **Hit List**, **DApp Remarks**, and **Stores Visits Field Reports** tabs on the Hit List workbook (`1eiqZr3LW…`) should all reflect the change. Today the DApp tries to POST to GAS directly (`action=log_field_report_attachment`), which silently fails cross-origin — no row lands.

## Changes

- **New canonical** `google_app_scripts/find_nearby_stores/process_retail_field_reports_telegram_logs.gs` — `processRetailFieldReportsFromTelegramChatLogs` scans Telegram Chat Logs (`1qbZZhf-…`) col G for `[RETAIL FIELD REPORT EVENT]`, dedups against `Stores Visits Field Reports` col G (`update_id`), and for each new row:
  1. Calls `updateStoreStatus(...)` → Hit List Status + DApp Remarks.
  2. Appends one row A–N to **Stores Visits Field Reports** (GitHub blob/raw URLs land in L/M).
  3. Copies URLs onto the matching DApp Remarks row via `linkFieldReportUrlsToDappRemarks_`.
- **New folder** `google_app_scripts/find_nearby_stores/` with a README that documents the partial canonicalization (other functions still live only in `clasp_mirrors/1NpHrKJW…/Code.js`) and the `cp` sync + one-line doGet branch the operator must apply when redeploying.
- **`_clasp_default/Version.gs`** — bumped UTC + changelog.

Mirror Code.js + Version.gs are gitignored per workspace convention; they need a `clasp push` + `clasp deploy --deploymentId <existing-id>` after merge so the deployed `/exec` URL serves the new action.

## Wiring

Edgar (`sentiment_importer/app/controllers/dao_controller.rb#trigger_immediate_processing`) enqueues `WebhookTriggerWorker` with `?action=processRetailFieldReportsFromTelegramChatLogs` against `config.retail_field_report_processing_webhook_url` (already set to this script's `/exec`). PR for the Edgar side: see TrueSightDAO/sentiment_importer.

Optional safety-net cron: time-driven trigger on `processRetailFieldReportsFromTelegramChatLogs` every 30 min — same shape as the existing sales / QR / repackaging Telegram log processors. Idempotent, so concurrent fires are safe.

## Testing

- Function-level: paste a Telegram Chat Logs row text containing `[RETAIL FIELD REPORT EVENT]` + `Update ID: SFR_…` into the editor, then run `processRetailFieldReportsFromTelegramChatLogs()` from the Apps Script editor and inspect Logger output + the new row on `Stores Visits Field Reports` (`gid 308370165`).
- End-to-end after merge:
  1. `cp google_app_scripts/find_nearby_stores/process_retail_field_reports_telegram_logs.gs clasp_mirrors/1NpHrKJW…/process_retail_field_reports_telegram_logs.js`
  2. Add the `if (e.parameter.action === 'processRetailFieldReportsFromTelegramChatLogs')` branch to the mirror's `Code.js` `doGet` (next to `log_field_report_attachment`).
  3. `clasp push && clasp deploy --deploymentId <existing-id>`
  4. Submit a status update from `dapp.truesight.me/store_interaction_history.html` with an attachment; verify a new row on `Stores Visits Field Reports` cols A–N (with L/M URLs) and DApp Remarks gets `Attachment Raw URL` / `Attachment GitHub URL` populated.

## Rollout / follow-ups

- Operator: clasp sync + redeploy as above.
- Operator: ensure `config.github_pat` on Edgar (also rotated in TrueSightDAO/sentiment_importer PR) has write access to `TrueSightDAO/store_interaction_attachments` — that's the separate root cause for the missing GitHub commits.
- Future: extract the rest of `find_nearby_stores/Code.js` into the new thematic folder so the doGet wiring is also tracked in git.

🤖 Generated with [Claude Code](https://claude.com/claude-code)