### PR TITLE
feat(dao-members-cache): add roles + email per contributor (schema v3)

### DIFF
--- a/google_app_scripts/tdg_identity_management/dao_members_cache_publisher.gs
+++ b/google_app_scripts/tdg_identity_management/dao_members_cache_publisher.gs
@@ -7,12 +7,24 @@
  *   so `dao_client/cache/contributors.py` can flip from GAS to GitHub-raw.
  * - Contributor-aggregated shape (a contributor can have N active public keys):
  *     {
- *       generated_at, schema_version: 1,
+ *       generated_at, schema_version: 3,
  *       contributors: [
- *         { name, voting_rights, public_keys: [{ public_key, status,
+ *         { name, email, roles, voting_rights, public_keys: [{ public_key, status,
  *           created_at, last_active_at }] }
  *       ]
  *     }
+ *
+ * Schema v3 (current):
+ *   - `email` — first non-empty `Contributor Email Address` (col F) seen across
+ *     the contributor's ACTIVE rows on `Contributors Digital Signatures`. May be
+ *     `null` if no row has an email yet (older legacy contributors).
+ *   - `roles` — string array; always includes "member"; includes "governor" if
+ *     the contributor's name appears on the `Governors` tab (auto-derived 4×/year
+ *     from the trailing 180-day contribution leaderboard).
+ *   These two fields back the dapp permission model: `permissions.js` resolves
+ *   the signed-in RSA → contributor → roles, and gates governor-only UI/actions
+ *   (add-contributor, governor chat, act-on-behalf-of-other) accordingly. The
+ *   email is also used by the dedup pre-flight on the new add-contributor flow.
  *
  * Triggers:
  * - Edgar → doGet(?action=refresh_dao_members_cache&secret=...) on every
@@ -35,11 +47,17 @@ const DAO_MEMBERS_CACHE_SPREADSHEET_ID =
     '1GE7PUq-UT6x2rBN-Q2ksogbWpgyuh2SaxJyG_uEK6PU';
 const DAO_MEMBERS_CACHE_SIGS_SHEET = 'Contributors Digital Signatures';
 const DAO_MEMBERS_CACHE_VOTING_SHEET = 'Contributors voting weight';
+const DAO_MEMBERS_CACHE_GOVERNORS_SHEET = 'Governors';
+// Governor names live in column A starting at row 11 (rows 1–10 are header /
+// configuration / equinox-rotation copy). The cell list is auto-populated by
+// formulas elsewhere in the workbook based on the trailing contribution
+// leaderboard; we just read the resolved name strings here.
+const DAO_MEMBERS_CACHE_GOVERNORS_FIRST_ROW = 11;
 const DAO_MEMBERS_CACHE_REPO_OWNER = 'TrueSightDAO';
 const DAO_MEMBERS_CACHE_REPO_NAME = 'treasury-cache';
 const DAO_MEMBERS_CACHE_REPO_PATH = 'dao_members.json';
 const DAO_MEMBERS_CACHE_BRANCH = 'main';
-const DAO_MEMBERS_CACHE_SCHEMA_VERSION = 2;
+const DAO_MEMBERS_CACHE_SCHEMA_VERSION = 3;
 
 // assetVerify web app in tdg_asset_management — source of DAO-wide aggregates
 // (voting_rights_circulated, total_assets, asset_per_circulated_voting_right,
@@ -152,15 +170,46 @@ function publishDaoMembersCacheToGithub_(opts) {
     });
   }
 
+  // ----- Governors tab — names of currently-elected governors --------------
+  // Read column A from row 11 to last-row, lowercase, stash in a Set-like map.
+  // The leaderboard is recomputed quarterly (equinoxes / solstices) by the
+  // workbook itself; we just take a snapshot of the current resolved names.
+  const governorsSheet = ss.getSheetByName(DAO_MEMBERS_CACHE_GOVERNORS_SHEET);
+  const governorsByName = {};
+  if (governorsSheet) {
+    const govLastRow = governorsSheet.getLastRow();
+    if (govLastRow >= DAO_MEMBERS_CACHE_GOVERNORS_FIRST_ROW) {
+      const govRows = governorsSheet
+          .getRange(DAO_MEMBERS_CACHE_GOVERNORS_FIRST_ROW, 1,
+                    govLastRow - DAO_MEMBERS_CACHE_GOVERNORS_FIRST_ROW + 1, 1)
+          .getValues();
+      govRows.forEach(function (row) {
+        const name = String(row[0] || '').trim();
+        if (!name) return;
+        governorsByName[name.toLowerCase()] = true;
+      });
+    }
+  } else {
+    Logger.log(
+        'Warning: ' + DAO_MEMBERS_CACHE_GOVERNORS_SHEET + ' tab not found; ' +
+        'all contributors will be emitted with roles=["member"] only.');
+  }
+
   // ----- Aggregate signatures by contributor name --------------------------
+  // Email lives on col F (`Contributor Email Address`); per-key in the sheet
+  // but we hoist the first non-empty email to the contributor record because
+  // the dedup pre-flight on the new add-contributor flow checks "email seen
+  // for any active key of any contributor."
   const byName = {};
   sigsRows.forEach(function (row) {
     const name = String(row[0] || '').trim();
     const status = String(row[3] || '').trim().toUpperCase();
     const publicKey = String(row[4] || '').trim();
+    const email = String(row[5] || '').trim().toLowerCase();
     if (!name || !publicKey || status !== 'ACTIVE') return;
     const key = name.toLowerCase();
-    if (!byName[key]) byName[key] = { name: name, public_keys: [] };
+    if (!byName[key]) byName[key] = { name: name, email: null, public_keys: [] };
+    if (!byName[key].email && email) byName[key].email = email;
     byName[key].public_keys.push({
       public_key: publicKey,
       status: status,
@@ -169,12 +218,16 @@ function publishDaoMembersCacheToGithub_(opts) {
     });
   });
 
-  // ----- Merge voting weight + emit stable-sorted contributors list --------
+  // ----- Merge voting weight + governor flag + emit sorted contributors ----
   const contributors = Object.keys(byName).sort().map(function (k) {
     const entry = byName[k];
     const voting = votingByName[k] || {};
+    const roles = ['member'];
+    if (governorsByName[k]) roles.unshift('governor');
     return {
       name: entry.name,
+      email: entry.email,                                  // may be null
+      roles: roles,                                        // ["governor","member"] or ["member"]
       voting_rights: voting.voting_rights,                 // may be null
       total_voting_power_pct: voting.total_voting_power_pct || null,
       public_keys: entry.public_keys,
@@ -189,6 +242,19 @@ function publishDaoMembersCacheToGithub_(opts) {
       contributors[0].public_keys[0].public_key) || null;
   const daoTotals = probeKey ? fetchDaoTotalsViaAssetVerify_(probeKey) : null;
 
+  // Surface the raw governor snapshot so ops can spot governor-tab names that
+  // don't join cleanly to a contributor (e.g. typos, ledger codes like
+  // "AGL15", or recently-added governors who haven't yet registered a
+  // signature). These names get no roles flag in `contributors[]` because
+  // there's no contributor record to attach to.
+  const matchedGovernorNames = {};
+  contributors.forEach(function (c) {
+    if (c.roles.indexOf('governor') >= 0) matchedGovernorNames[c.name.toLowerCase()] = true;
+  });
+  const unjoinedGovernorNames = Object.keys(governorsByName)
+      .filter(function (k) { return !matchedGovernorNames[k]; })
+      .sort();
+
   const snapshot = {
     generated_at: new Date().toISOString(),
     schema_version: DAO_MEMBERS_CACHE_SCHEMA_VERSION,
@@ -199,16 +265,25 @@ function publishDaoMembersCacheToGithub_(opts) {
       active_public_keys: contributors.reduce(function (sum, c) {
         return sum + c.public_keys.length;
       }, 0),
+      governors: contributors.reduce(function (sum, c) {
+        return sum + (c.roles.indexOf('governor') >= 0 ? 1 : 0);
+      }, 0),
+      contributors_with_email: contributors.reduce(function (sum, c) {
+        return sum + (c.email ? 1 : 0);
+      }, 0),
     },
     dao_totals: daoTotals,
+    unjoined_governor_names: unjoinedGovernorNames,
     contributors: contributors,
   };
 
   const content = JSON.stringify(snapshot, null, 2) + '\n';
   const commitMessage =
       'chore: refresh dao_members.json (' + snapshot.counts.contributors +
-      ' contributors, ' + snapshot.counts.active_public_keys +
-      ' active keys, trigger=' + snapshot.trigger + ')';
+      ' contributors, ' + snapshot.counts.governors + ' governors, ' +
+      snapshot.counts.contributors_with_email + ' with email, ' +
+      snapshot.counts.active_public_keys + ' active keys, trigger=' +
+      snapshot.trigger + ')';
 
   const commit = commitJsonToGithub_({
     token: token,


### PR DESCRIPTION
## Summary

Bumps `dao_members.json` schema from v2 to v3 by extending `dao_members_cache_publisher.gs` to add two new fields per contributor:

- **`email`** — first non-empty `Contributor Email Address` (col F) seen across the contributor's ACTIVE signature rows. `null` for legacy contributors that haven't yet registered an email.
- **`roles`** — string array; always includes `"member"`; includes `"governor"` when the contributor's display name appears on the `Governors` tab.

## Why

These two fields are the data foundation for the new dapp permission model the DAO is building toward as the user base expands (schools, PTAs, sports leagues, Salvation Army, GO partners per the `GO × Agroverse` partnership proposal). Specifically:

- `roles` lets a `permissions.js` helper in the dapp resolve `(signed-in RSA) → contributor → roles` and gate governor-only UI / actions:
  - The new `governor_contributor_admin.html` page
  - The inline "add contributor" button on `report_inventory_movement.html` (visible to governors only)
  - "+ add new contributor" inline flow on `report_contribution.html` (governor-only)
  - Governor chat access
  - Act-on-behalf-of-other on contribution / inventory submissions
- `email` is the lookup key for the dedup pre-flight on the new add-contributor flow ("`gary@…` is already registered to **Gary Teh** — did you mean to add a new device key instead?").

Both checks are duplicated server-side (Edgar / GAS) for security; the JSON powers the **client-side gate + dedup hint**, not enforcement.

## What's added to the JSON

```json
{
  "schema_version": 3,
  "counts": {
    "contributors": 11,
    "active_public_keys": 42,
    "governors": 5,
    "contributors_with_email": 8
  },
  "unjoined_governor_names": ["agl15"],
  "contributors": [
    {
      "name": "Gary Teh",
      "email": "garyjob@agroverse.shop",
      "roles": ["governor", "member"],
      "voting_rights": 43710,
      "total_voting_power_pct": "...",
      "public_keys": [/* unchanged */]
    }
  ]
}
```

`unjoined_governor_names[]` surfaces names from the Governors tab that didn't join to any contributor (e.g. ledger codes like `AGL15`, typos, or governors who haven't yet registered a signature) — failing loudly beats silent drops.

## Backwards compat

- `schema_version` is canonical. Older consumers (current `dao_client/cache/contributors.py`, `dapp/scripts/dao_members_cache.js`) that don't know about `roles`/`email` will simply ignore the new keys; nothing else moved.
- The `skipIfUnchanged` no-op detection still works — both new fields are deterministic given source sheets.

## How it ships

- Once merged, the next scheduled run (Edgar webhook on `[EMAIL VERIFICATION EVENT]` or daily cron at 03:00 UTC) regenerates `dao_members.json` in `treasury-cache` with the new shape.
- Or run `publishDaoMembersCacheNow()` manually from the Apps Script editor for an immediate refresh after pushing the GAS source.

## Follow-ups (separate PRs)

- `treasury-cache` README: document schema v3.
- `dapp` repo: introduce `permissions.json` + `permissions.js` and the new `governor_contributor_admin.html` page.
- `Edgar`: new `[CONTRIBUTOR ADD EVENT]` handler with governor-gate + email/name dedup → 409 Conflict.
- `dapp` repo: gate the inline "add contributor" button on `report_inventory_movement.html` and the "+ add new contributor" flow on `report_contribution.html`.
- `Edgar`: surface explicit "Permission denied" responses on governor-gated POSTs so the dapp UX can render them verbatim.

## Test plan

- [ ] Run `publishDaoMembersCacheNow()` from Apps Script editor after pushing the GAS source.
- [ ] Spot-check `dao_members.json` on `treasury-cache` main: `schema_version: 3`, `Gary Teh.roles: ["governor","member"]`, `Gary Teh.email: "garyjob@agroverse.shop"`.
- [ ] Confirm `counts.governors` matches the visible row count on the Governors tab (currently 10 max; some may not match → see `unjoined_governor_names`).
- [ ] Confirm older consumers (`dao_client/cache/contributors.py`, `dapp/scripts/dao_members_cache.js`) still parse without errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)