### PR TITLE
fix(inventory): only auto-add new recipient on authorized movements

### DIFF
--- a/google_app_scripts/tdg_inventory_management/process_movement_telegram_logs.gs
+++ b/google_app_scripts/tdg_inventory_management/process_movement_telegram_logs.gs
@@ -930,34 +930,48 @@ function processTelegramChatLogsToInventoryMovement() {
         // Extract QR code from contribution if present
         const qrCodeMatch = lines.find(line => line.startsWith('- QR Code:'));
         const qrCode = qrCodeMatch ? qrCodeMatch.replace('- QR Code:', '').trim() : null;
-        
-        // Check if recipient exists, if not add them to Contributors sheet
-        if (reportResult.recipient_name && reportResult.recipient_name.trim() !== '') {
-          const exists = recipientExists(reportResult.recipient_name);
-          if (!exists) {
-            const added = addNewRecipient(reportResult.recipient_name);
-            if (added) {
-              Logger.log(`Successfully added new recipient "${reportResult.recipient_name}" to Contributors sheet`);
-            } else {
-              Logger.log(`Warning: Failed to add new recipient "${reportResult.recipient_name}" to Contributors sheet`);
-            }
-          }
-        }
-        
-        // If QR code is provided, update the Manager Name in Agroverse QR codes sheet
-        // The Manager Name should be set to the recipient name, as the recipient is now the holder of the QR code
-        if (qrCode && reportResult.recipient_name) {
-          const updated = updateAgroverseQrManagerName(qrCode, reportResult.recipient_name);
-          if (updated) {
-            Logger.log(`Successfully updated Manager Name for QR code ${qrCode} to ${reportResult.recipient_name} (recipient is now the holder)`);
-          } else {
-            Logger.log(`Warning: Failed to update Manager Name for QR code ${qrCode}`);
-          }
-        }
 
+        // Auth check FIRST. We used to auto-add an unknown recipient to the
+        // Contributors sheet before computing movementStatus, which meant an
+        // 'unauthorized' submission with a fabricated recipient name still
+        // created a ghost contributor row even though Phase 2 skipped the
+        // movement itself. Now both side effects (recipient auto-add + QR
+        // manager-name update) only run when the movement is authorized.
         const movementStatus = inventoryMovementStatusFromTelegramRow_(row, contribution, reportResult.sender_name);
         if (movementStatus === 'unauthorized') {
           Logger.log(`Update ID ${updateId}: Column N = unauthorized (signer is not warehouse manager and Governor is not YES)`);
+          if (reportResult.recipient_name && reportResult.recipient_name.trim() !== '' &&
+              !recipientExists(reportResult.recipient_name)) {
+            Logger.log(
+              `Update ID ${updateId}: Skipped auto-add of new recipient ` +
+              `"${reportResult.recipient_name}" because movement is unauthorized. ` +
+              `A Governor must add the contributor explicitly via the dedicated ` +
+              `add-contributor flow before this recipient can receive inventory.`);
+          }
+        }
+
+        if (movementStatus === 'NEW') {
+          // Authorized movement → perform the contributor + QR side effects.
+          if (reportResult.recipient_name && reportResult.recipient_name.trim() !== '') {
+            const exists = recipientExists(reportResult.recipient_name);
+            if (!exists) {
+              const added = addNewRecipient(reportResult.recipient_name);
+              if (added) {
+                Logger.log(`Successfully added new recipient "${reportResult.recipient_name}" to Contributors sheet`);
+              } else {
+                Logger.log(`Warning: Failed to add new recipient "${reportResult.recipient_name}" to Contributors sheet`);
+              }
+            }
+          }
+
+          if (qrCode && reportResult.recipient_name) {
+            const updated = updateAgroverseQrManagerName(qrCode, reportResult.recipient_name);
+            if (updated) {
+              Logger.log(`Successfully updated Manager Name for QR code ${qrCode} to ${reportResult.recipient_name} (recipient is now the holder)`);
+            } else {
+              Logger.log(`Warning: Failed to update Manager Name for QR code ${qrCode}`);
+            }
+          }
         }
 
         // Create new row for Inventory Movement


### PR DESCRIPTION
## Summary

Closes a quiet \"ghost contributor\" injection vector in the `[INVENTORY MOVEMENT]` Edgar handler. Previously `process_movement_telegram_logs.gs` called `addNewRecipient()` for any unknown recipient name **before** computing `movementStatus` — so an unauthorized submission (signer is neither Governor nor matching warehouse manager) still wrote a Contributors row to Main Ledger, even though Phase 2 correctly skipped the inventory move itself.

Anyone with any active signature could mint arbitrary contributor rows just by sending a fabricated `[INVENTORY MOVEMENT]`. This PR removes that backdoor.

## Fix

Compute `movementStatus` first; gate both side effects (recipient auto-add + QR Manager Name update) on `movementStatus === 'NEW'`. Unauthorized events log loudly (with a specific note that the recipient auto-add was skipped) so ops can spot abuse.

## Why this is the correct shape

| Path | Trigger | Behavior after fix |
|---|---|---|
| Governor submits `[INVENTORY MOVEMENT]` | `isTelegramGovernorYes_()` → `'NEW'` | Recipient auto-add runs (consistent with current convenience for warehouse onboarding) |
| Warehouse manager submits move where they are the named Manager | `authNamesMatch_()` → `'NEW'` | Recipient auto-add runs |
| Anyone else | → `'unauthorized'` | Recipient auto-add SKIPPED. Movement also skipped by Phase 2 (existing behavior). |

Phase 2's auto-add at line ~1298 needs no change — Phase 2 already filters by `status === 'NEW'`, so it's implicitly gated by the same auth check.

## Alignment with the broader permission model

Per the partnership-readiness work the DAO is doing (DApp permission rework — governor-only add-contributor flow at `governor_contributor_admin.html`, dedicated `[CONTRIBUTOR ADD EVENT]` handler in Edgar with name + email + dedup), the canonical path for minting new contributors is governor-explicit. This PR removes the silent backdoor that bypassed it.

## Test plan

- [ ] Submit `[INVENTORY MOVEMENT]` with a forged recipient name from a non-governor non-manager signer; verify Contributors sheet is unchanged AND log shows the explicit \"Skipped auto-add of new recipient ... because movement is unauthorized\" line.
- [ ] Governor submits same; verify Contributors row is created.
- [ ] Warehouse manager Kirsten submits a move to a brand-new shop owner Bob; verify Bob is added to Contributors.
- [ ] Existing recipient receives inventory; verify no duplicate row.

## Deploy

After merge, push `process_movement_telegram_logs.gs` to the deployed Apps Script project at `1wONDeDwZ_fXNapDKpstWrBION3aV3r7NXwq7PCdqbW1LvI5ceaykQNbR` (the inventory-management project). The clasp mirror at that script ID was synced locally for the next push.

🤖 Generated with [Claude Code](https://claude.com/claude-code)