### PR TITLE
fix(find_nearby_stores): GAS scanner bullet-strip + addNewStore setValues bug

### DIFF
--- a/google_app_scripts/_clasp_default/Version.gs
+++ b/google_app_scripts/_clasp_default/Version.gs
@@ -13,12 +13,14 @@
  */
 
 /** ISO UTC timestamp of the last clasp push for this mirror */
-var CLASP_MIRROR_LAST_CLASP_PUSH_UTC = '2026-04-28T18:00:00Z';
+var CLASP_MIRROR_LAST_CLASP_PUSH_UTC = '2026-04-28T19:00:00Z';
 
 /**
  * Newest first. Keep lines short; link PRs/commits in git instead of pasting secrets.
  */
 var CLASP_MIRROR_CHANGELOG =
+  '2026-04-28 — find_nearby_stores: fix applyHitListAuAvFormulasToRow_ getRange args (was treating 4th arg as endCol; now correctly numRows=1, numCols=2). Caused "data has 1 but range has 526" on every addNewStore + retail-field-report status update. Hit List row still landed because appendRow runs first; only the AU/AV formula write threw.\n' +
+  '2026-04-28 — find_nearby_stores: parseRetailFieldReportText_ now strips leading `- ` bullet so dao_client `update_store` payloads (`- Label: Value`) parse the same as the DApp page (`Label: Value`). Same logic the sibling store-add parser already had.\n' +
   '2026-04-28 — find_nearby_stores: async [STORE ADD EVENT] scanner — Telegram Chat Logs → Hit List row + Store Adds dedup log (1qbZZhf-…, gid 1208101506). Reuses existing addNewStore() for the Hit List write.\n' +
   '2026-04-27 — find_nearby_stores: async [RETAIL FIELD REPORT EVENT] scanner — Telegram Chat Logs → Hit List + DApp Remarks + Stores Visits Field Reports (dedup on col G update_id).\n' +
   '2026-04-17 — Migrate qr_code_web_service to admin@truesight.me project; consolidate processBatch to send one email per owner across multiple QR codes.\n' +

--- a/google_app_scripts/find_nearby_stores/process_retail_field_reports_telegram_logs.gs
+++ b/google_app_scripts/find_nearby_stores/process_retail_field_reports_telegram_logs.gs
@@ -65,6 +65,12 @@ function parseRetailFieldReportText_(text) {
     var line = (lines[i] || '').trim();
     if (!line) continue;
     if (line.indexOf('[RETAIL FIELD REPORT EVENT]') === 0) continue;
+    // Bullet prefix from dao_client's `build_share_text` — `- Label: Value`.
+    // The DApp's older `buildRetailFieldReportText` builds without the bullet,
+    // so we strip defensively to support both clients. (Patched 2026-04-28
+    // when the new dao_client `update_store` module landed and surfaced the
+    // gap — same logic the sibling store-add parser already had.)
+    if (line.charAt(0) === '-') line = line.substring(1).trim();
     var m = line.match(/^([A-Za-z][A-Za-z0-9_\s\/\-]*):\s*(.*)$/);
     if (!m) continue;
     var key = m[1].trim().toLowerCase().replace(/\s+/g, '_');


### PR DESCRIPTION
## Goal

Two bugs surfaced this afternoon while live-firing the new `dao_client update_store` module on Psychic Sister + during the `[STORE ADD EVENT]` end-to-end test (TrueSightDAO/tokenomics#250). Both fixes already deployed via clasp `@30 → @31`; this PR tracks the source change in git.

## Bug 1 — `applyHitListAuAvFormulasToRow_` getRange args

`getRange(row, column, numRows, numColumns)` was being called as `getRange(rowNum, HIT_LIST_COL_AU, rowNum, HIT_LIST_COL_AV)`, treating the 3rd/4th args as `(endRow, endCol)`. For `rowNum=526` that produced a **526-row × 48-column range** but `setFormulas([[w, fu]])` only provided 1 row × 2 cols, so every `addNewStore` and every retail-field-report status update threw:

> *"The number of rows in the data does not match the number of rows in the range. The data has 1 but the range has 526."*

Hit List rows still landed (appendRow runs before this call), but the throw escaped to GAS scanner / DApp callers as `error`. That's why all 3 Psychic Sister referrals (Clary Sage / Casa de Ritual / La Sirena Botanica) showed `status: error` on Store Adds yesterday even though the rows themselves were correct.

**Fix**: `getRange(rowNum, HIT_LIST_COL_AU, 1, 2)` — 1 row, 2 columns (AU + AV).

## Bug 2 — `parseRetailFieldReportText_` bullet-strip

DApp's `buildRetailFieldReportText` produces lines without leading bullets (`Shop Name: X`); dao_client's `build_share_text` produces them with bullets (`- Shop Name: X`). The retail field report parser only matched the no-bullet form (regex requires `^[A-Za-z]…`). So a `dao_client update_store` submission's fields were all silently dropped — scanner reported `skipped` (missing `shop_name` / `new_status`) even though the Telegram Chat Logs row was correct.

The sibling store-add parser already strips the bullet correctly. This PR copies that one-line patch into the retail-field-report parser.

## Deploy state

Already shipped:
- `clasp push` synced 4 files into the mirror.
- `clasp deploy --deploymentId AKfycbwB2zqNV9…` bumped `@30 → @31`, `/exec` URL preserved.
- Smoke-tested by re-firing `processRetailFieldReportsFromTelegramChatLogs` on the existing Psychic Sister Telegram Chat Logs row.

## Test plan

- [x] `clasp push` + `clasp deploy` succeeded.
- [ ] Verify Psychic Sister status now updates from `AI: Prospect replied` → `Not Appropriate` after re-firing the scanner against the existing Telegram row.
- [ ] On the next `[STORE ADD EVENT]` end-to-end test, Store Adds dedup log shows `status: added` instead of `status: error`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)