### PR TITLE
fix(tdg-scoring): skip [STORE ADD EVENT] and [RETAIL FIELD REPORT EVENT]

### DIFF
--- a/google_app_scripts/tdg_scoring/grok_scoring_for_telegram_and_whatsapp_logs.gs
+++ b/google_app_scripts/tdg_scoring/grok_scoring_for_telegram_and_whatsapp_logs.gs
@@ -54,7 +54,9 @@ const SKIP_MESSAGE_STRINGS = [
   '[INVENTORY MOVEMENT]',
   '[FARM REGISTRATION]',
   '[TREE PLANTING EVENT]',
-  '[NOTARIZATION EVENT]'
+  '[NOTARIZATION EVENT]',
+  '[STORE ADD EVENT]',
+  '[RETAIL FIELD REPORT EVENT]'
 ];
 
 // Load API keys and configuration settings from Credentials.gs


### PR DESCRIPTION
## Summary
Adds the two new dao_client event types that landed on Telegram Chat Logs 2026-04-28 to the Grok TDG scorer's skip list, so they stop spilling into the **Scored Chatlogs** sheet.

Without these entries, [4 spurious rows landed on Scored Chatlogs today](https://docs.google.com/spreadsheets/d/1Tbj7H5ur_egQLRugdXUaSIhEYIKp0vvVv2IZ7WTLCUo/edit?gid=0#gid=0):
- 3 × `[STORE ADD EVENT]` (Clary Sage / Casa de Ritual / La Sirena Botanica — Psychic Sister referrals)
- 1 × `[RETAIL FIELD REPORT EVENT]` (Psychic Sister status update)

Both event types already have dedicated dedup logs (`Store Adds` tab on the Telegram compilation workbook; `Stores Visits Field Reports` tab on the Hit List workbook), so they should never be treated as scoreable contributions for TDG awards.

## Files
- `google_app_scripts/tdg_scoring/grok_scoring_for_telegram_and_whatsapp_logs.gs` — appends both tags to `SKIP_MESSAGE_STRINGS`.

## After-merge ops
1. `clasp push` from `clasp_mirrors/1BHAGZd_T1I5mQnqnAFqUJKX2x_N8Uv05n1O2OohRA908Ja8wVwVxaR7K/` to deploy.
2. Manually invalidate the 4 spurious rows on Scored Chatlogs.

## Test plan
- [x] Local `shouldSkipMessage()` test against the four sample payloads (mental dry-run — pattern is `messageUpper.includes(skipString.toUpperCase())`, so `[STORE ADD EVENT]` substring matches).
- [ ] Post-deploy: confirm no fresh STORE ADD / RETAIL FIELD REPORT rows on Scored Chatlogs after the next Grok cron firing.