### PR TITLE
fix(tdg-scoring): require [CONTRIBUTION EVENT] header to score

### DIFF
--- a/google_app_scripts/tdg_scoring/grok_scoring_for_telegram_and_whatsapp_logs.gs
+++ b/google_app_scripts/tdg_scoring/grok_scoring_for_telegram_and_whatsapp_logs.gs
@@ -42,22 +42,26 @@ function computeIgnoreBeforeDate_() {
   return `${yyyy}${mm}${dd}`;
 }
 
-// List of DAO-specific event strings to skip during message processing
-// - Messages containing these strings will be ignored to avoid errors in TDG scoring
-// - Add or remove strings as needed to filter out specific event types
-const SKIP_MESSAGE_STRINGS = [
-  '[DIGITAL SIGNATURE EVENT]',
-  '[VOTING RIGHTS WITHDRAWAL REQUEST]',
-  '[QR CODE EVENT]',
-  '[SALES EVENT]',
-  '[DAO INVENTORY EXPENSE EVENT]',
-  '[INVENTORY MOVEMENT]',
-  '[FARM REGISTRATION]',
-  '[TREE PLANTING EVENT]',
-  '[NOTARIZATION EVENT]',
-  '[STORE ADD EVENT]',
-  '[RETAIL FIELD REPORT EVENT]'
-];
+// Historical denylist (pre-2026-04-28). The scorer now uses an explicit allowlist —
+// see `shouldSkipMessage` below — that admits only messages with a [CONTRIBUTION EVENT]
+// header. This list is retained as documentation of which event types the DAO has
+// explicitly decided do NOT earn TDGs (each has its own dedicated audit log instead),
+// but is no longer consulted at runtime.
+//
+//   [DIGITAL SIGNATURE EVENT]
+//   [VOTING RIGHTS WITHDRAWAL REQUEST]
+//   [QR CODE EVENT]
+//   [SALES EVENT]
+//   [DAO INVENTORY EXPENSE EVENT]
+//   [INVENTORY MOVEMENT]
+//   [FARM REGISTRATION]
+//   [TREE PLANTING EVENT]
+//   [NOTARIZATION EVENT]
+//   [STORE ADD EVENT]
+//   [RETAIL FIELD REPORT EVENT]
+//   [CONTRIBUTOR ADD EVENT]
+//   [EMAIL VERIFICATION EVENT]
+//   [REPACKAGING BATCH EVENT]
 
 // Load API keys and configuration settings from Credentials.gs
 // - setApiKeys(): Stores sensitive API keys in Google Apps Script’s Script Properties for security.
@@ -1508,31 +1512,27 @@ function testUploadFileToGitHub(fileId, destinationUrl, message) {
 
 
 /**
- * Checks if a message contains any DAO-specific event strings that should be skipped.
+ * Allowlist gate: only score messages that contain the canonical [CONTRIBUTION EVENT] header.
+ *
+ * Rationale (2026-04-28 transition): all scoreable submissions now flow through DApp /
+ * dao_client, which always emits [CONTRIBUTION EVENT] for work-time contributions. Other
+ * event types (e.g. [QR CODE EVENT], [STORE ADD EVENT], [RETAIL FIELD REPORT EVENT],
+ * [CONTRIBUTOR ADD EVENT]) have their own dedicated audit logs and never award TDGs, so
+ * they are skipped here regardless of whether they appear on a future denylist.
+ *
+ * Also fixes a substring-matching false-negative the prior denylist had: a legitimate
+ * [CONTRIBUTION EVENT] whose description text happens to mention another bracketed tag
+ * (e.g. "feat(dao): [RETAIL FIELD REPORT EVENT] archive ...") would otherwise be
+ * incorrectly skipped. Allowlist semantics make the precedence explicit.
+ *
  * @param {string} message - The chat log message to check.
- * @returns {boolean} - True if the message contains a string to skip, false otherwise.
+ * @returns {boolean} - True if the message should be skipped (no [CONTRIBUTION EVENT] header).
  */
 function shouldSkipMessage(message) {
-  const messageUpper = message.toUpperCase();
-  // Also convert skip strings to uppercase for case-insensitive matching
-  let shouldSkip = SKIP_MESSAGE_STRINGS.some(skipString => messageUpper.includes(skipString.toUpperCase()));
-  // Belt-and-suspenders: expense reports use "[DAO Inventory Expense Event]" (see dapp report_dao_expenses.html).
-  // Match even if spacing/unicode spaces differ so Grok never writes these to "Scored Chatlogs".
-  if (!shouldSkip && /\[DAO\s+INVENTORY\s+EXPENSE\s+EVENT\]/i.test(message)) {
-    shouldSkip = true;
-    Logger.log(`shouldSkipMessage: Matched DAO Inventory Expense Event via flexible regex`);
+  const messageUpper = (message || '').toUpperCase();
+  if (!messageUpper.includes('[CONTRIBUTION EVENT]')) {
+    Logger.log(`shouldSkipMessage: skipping (no [CONTRIBUTION EVENT] header): ${(message || '').substring(0, 100)}`);
+    return true;
   }
-  
-  if (shouldSkip) {
-    Logger.log(`shouldSkipMessage: Skipping message due to DAO-specific event: ${message.substring(0, 100)}`);
-  } else {
-    Logger.log(`shouldSkipMessage: Message does not match skip patterns. Checking contents...`);
-    SKIP_MESSAGE_STRINGS.forEach(skipString => {
-      if (messageUpper.includes(skipString.toUpperCase())) {
-        Logger.log(`shouldSkipMessage: WARNING - Found skip pattern "${skipString}" but filter failed!`);
-      }
-    });
-  }
-  
-  return shouldSkip;
+  return false;
 }


### PR DESCRIPTION
## Summary
Flips the Grok TDG scorer from a denylist (`SKIP_MESSAGE_STRINGS` substring match) to an **allowlist** that admits only messages containing the canonical `[CONTRIBUTION EVENT]` header.

Replaces #254 (which only added two more entries to the denylist). The allowlist posture is what we actually want now that all scoreable submissions flow through DApp / dao_client.

## Why now
- **DApp/dao_client transition complete (2026-04-28).** Every scoreable submission emits `[CONTRIBUTION EVENT]`. Free-form Telegram chat is no longer a scoring source — confirmed by survey: of 261 `Pending Review` rows, **0 are free-form** (238 `[CONTRIBUTION EVENT]`, 23 spurious-non-scoreable spread across 5 other tags).
- **Closes a substring-matching false-negative.** A legitimate `[CONTRIBUTION EVENT]` whose description text mentions another bracketed tag (e.g. *"feat(dao): [RETAIL FIELD REPORT EVENT] archive ..."*) was being incorrectly skipped by the prior denylist. Allowlist-first is unambiguous.
- **Preempts future denylist-omission bugs** like the one that landed 19 spurious rows on Scored Chatlogs ([#254 cleanup](https://github.com/TrueSightDAO/tokenomics/pull/254)). New event types added by future dao_client modules now correctly default to *not scored* without requiring a denylist edit.

## Files
- `google_app_scripts/tdg_scoring/grok_scoring_for_telegram_and_whatsapp_logs.gs`
  - `shouldSkipMessage()` — replaced denylist sweep with `if (!message.includes('[CONTRIBUTION EVENT]')) return true`.
  - `SKIP_MESSAGE_STRINGS` — dropped as a runtime constant; retained as a documentation comment listing the event types the DAO has explicitly decided do NOT earn TDGs.

## After-merge ops
1. `clasp push` from `clasp_mirrors/1BHAGZd…` to deploy.
2. The 19 already-spurious rows on Scored Chatlogs were marked `Status=Ignored` in the previous round — no further cleanup needed.

## Test plan
- [x] `shouldSkipMessage("[CONTRIBUTION EVENT]\n- Type: ...")` → `false` (admit)
- [x] `shouldSkipMessage("[STORE ADD EVENT]\n- Shop Name: ...")` → `true` (skip)
- [x] `shouldSkipMessage("free-form chat")` → `true` (skip)
- [x] `shouldSkipMessage("[CONTRIBUTION EVENT] ... [RETAIL FIELD REPORT EVENT] mentioned in body")` → `false` (admit; **was incorrectly skipped before**)
- [ ] Post-deploy: confirm next cron firing scores the 238 `Pending Review` `[CONTRIBUTION EVENT]` rows and ignores the 6 non-`[CONTRIBUTION EVENT]` rows still in the queue.