### PR TITLE
feat(agroverse-qr): processBatch error visibility + alert email

### DIFF
--- a/google_app_scripts/_clasp_default/Version.gs
+++ b/google_app_scripts/_clasp_default/Version.gs
@@ -19,6 +19,7 @@ var CLASP_MIRROR_LAST_CLASP_PUSH_UTC = '2026-04-28T19:00:00Z';
  * Newest first. Keep lines short; link PRs/commits in git instead of pasting secrets.
  */
 var CLASP_MIRROR_CHANGELOG =
+  '2026-04-29 — qr_code_web_service.processBatch: per-email try/catch + SpreadsheetApp.flush() + read-back verification of column M; alert email to garyjob@agroverse.shop on any failure; re-throw at end so the trigger run is logged as failed (catches the silent-overwrite case where setValue succeeds but the cell stays empty due to ARRAYFORMULA / data validation / protected range on column M).\n' +
   '2026-04-28 — find_nearby_stores: fix applyHitListAuAvFormulasToRow_ getRange args (was treating 4th arg as endCol; now correctly numRows=1, numCols=2). Caused "data has 1 but range has 526" on every addNewStore + retail-field-report status update. Hit List row still landed because appendRow runs first; only the AU/AV formula write threw.\n' +
   '2026-04-28 — find_nearby_stores: parseRetailFieldReportText_ now strips leading `- ` bullet so dao_client `update_store` payloads (`- Label: Value`) parse the same as the DApp page (`Label: Value`). Same logic the sibling store-add parser already had.\n' +
   '2026-04-28 — find_nearby_stores: async [STORE ADD EVENT] scanner — Telegram Chat Logs → Hit List row + Store Adds dedup log (1qbZZhf-…, gid 1208101506). Reuses existing addNewStore() for the Hit List write.\n' +

--- a/google_app_scripts/agroverse_qr_codes/qr_code_web_service.gs
+++ b/google_app_scripts/agroverse_qr_codes/qr_code_web_service.gs
@@ -1726,6 +1726,7 @@ const TEST_QR_CODE = "2025BF_20250521_PROPANE_1"; // QR code for testing
 const EMAIL_COLUMN = 12; // Column L (1-based index)
 const TIMESTAMP_COLUMN = 13; // Column M (1-based index)
 const QR_CODE_COLUMN = 1; // Column A (1-based index)
+const PROCESS_BATCH_ALERT_RECIPIENT = 'garyjob@agroverse.shop';
 
 /**
  * Tester method to manually test email sending with a sample QR code
@@ -1737,6 +1738,18 @@ function testSendEmail() {
 /**
  * Processes all records with valid email in column L and no sent date in column M.
  * Groups rows by email address so owners who bought multiple items receive one consolidated email.
+ *
+ * Failure handling:
+ *   - Each per-email send is wrapped in try/catch so one user's failure does not abort
+ *     the rest of the batch.
+ *   - After setValue, SpreadsheetApp.flush() forces the write, then we read the cell
+ *     back. If the read returns empty, something silently overwrote the stamp (e.g. an
+ *     ARRAYFORMULA in M1 re-spilling, strict data validation, or a protected-range
+ *     overlay). That counts as a failure for this email — the row will be re-sent next
+ *     run, and we surface the cause now.
+ *   - If any failures occur, an alert email is sent to PROCESS_BATCH_ALERT_RECIPIENT
+ *     and processBatch re-throws at the end so GAS marks the trigger run as failed
+ *     (this also fires the standard "Notify me on trigger failure" email if enabled).
  */
 function processBatch() {
   const sheet = SpreadsheetApp.openByUrl(SUBSCRIPTION_NOTIFICATION_WORKBOOK_URL).getSheetByName(SHEET_NAME);
@@ -1760,6 +1773,10 @@ function processBatch() {
   const doc = DocumentApp.openById(GOOGLE_DOC_ID);
   const subject = doc.getName();
 
+  const failures = [];
+  let sentCount = 0;
+  let stampedCount = 0;
+
   for (const email in pendingByEmail) {
     const items = pendingByEmail[email];
     let body = doc.getBody().getText();
@@ -1772,12 +1789,92 @@ function processBatch() {
     body = body.replace('{{TRACKING_LINK}}', trackingLinksHtml);
     const htmlBody = HtmlService.createHtmlOutput(body.replace(/\n/g, '<br>')).getContent();
 
-    MailApp.sendEmail({ to: email, subject, htmlBody });
+    const rowsForEmail = items.map(item => item.rowIndex + 1);
 
-    // Stamp column M for every row included in this send
-    for (const item of items) {
-      sheet.getRange(item.rowIndex + 1, TIMESTAMP_COLUMN).setValue(now);
+    try {
+      MailApp.sendEmail({ to: email, subject, htmlBody });
+      sentCount += 1;
+
+      // Stamp column M for every row included in this send
+      for (const item of items) {
+        sheet.getRange(item.rowIndex + 1, TIMESTAMP_COLUMN).setValue(now);
+      }
+      // Force the writes to flush before we read them back
+      SpreadsheetApp.flush();
+
+      // Verify each stamp actually persisted. setValue can succeed but the cell
+      // can still come back empty if column M is driven by a formula, has strict
+      // data validation, or sits under a protected range — none of which raise
+      // an exception. This is the most common silent-failure mode.
+      const unstampedRows = [];
+      for (const item of items) {
+        const verify = sheet.getRange(item.rowIndex + 1, TIMESTAMP_COLUMN).getValue();
+        if (!verify) {
+          unstampedRows.push(item.rowIndex + 1);
+        } else {
+          stampedCount += 1;
+        }
+      }
+      if (unstampedRows.length > 0) {
+        throw new Error(
+          'Stamp verification failed for row(s) ' + unstampedRows.join(', ') +
+          '. Column M came back empty after setValue + flush. Likely cause: ' +
+          '(a) ARRAYFORMULA / formula in M1 re-spilling and overwriting the write, ' +
+          '(b) strict data validation on column M rejecting Date input, ' +
+          '(c) protected range on column M restricting this script\'s identity. ' +
+          'Email already sent — these rows will be re-sent next run until M is populated.'
+        );
+      }
+    } catch (e) {
+      const stack = (e && e.stack) ? e.stack : '(no stack)';
+      const msg = 'processBatch failure for ' + email + ' (rows: ' + rowsForEmail.join(', ') + '): ' + e;
+      Logger.log(msg + '\nStack:\n' + stack);
+      failures.push({ email: email, rows: rowsForEmail, error: String(e), stack: stack });
     }
+  }
+
+  Logger.log(
+    'processBatch summary: sent=' + sentCount +
+    ', stamped=' + stampedCount +
+    ', failures=' + failures.length
+  );
+
+  if (failures.length > 0) {
+    sendProcessBatchAlert_(failures, sentCount, stampedCount);
+    throw new Error(
+      'processBatch encountered ' + failures.length + ' failure(s). ' +
+      'See alert email at ' + PROCESS_BATCH_ALERT_RECIPIENT +
+      ' and the Apps Script Executions log for details.'
+    );
+  }
+}
+
+/**
+ * Send a detailed failure report when processBatch hits one or more errors.
+ * Best-effort: a failure to send the alert itself is logged but does not block.
+ */
+function sendProcessBatchAlert_(failures, sentCount, stampedCount) {
+  const summary =
+    'processBatch onboarding email delivery had failures.\n\n' +
+    'Sent successfully:  ' + sentCount + '\n' +
+    'Stamped (col M):    ' + stampedCount + '\n' +
+    'Failed:             ' + failures.length + '\n' +
+    'Sheet:              ' + SUBSCRIPTION_NOTIFICATION_WORKBOOK_URL + '\n\n' +
+    '=== Failures ===\n\n' +
+    failures.map(function(f, idx) {
+      return '#' + (idx + 1) + ' — ' + f.email + ' (rows: ' + f.rows.join(', ') + ')\n' +
+             'Error: ' + f.error + '\n\n' +
+             'Stack:\n' + f.stack;
+    }).join('\n\n---\n\n');
+
+  try {
+    MailApp.sendEmail({
+      to: PROCESS_BATCH_ALERT_RECIPIENT,
+      subject: '[ALERT] processBatch — ' + failures.length + ' onboarding failure(s)',
+      body: summary,
+    });
+  } catch (alertErr) {
+    Logger.log('sendProcessBatchAlert_ failed to deliver: ' + alertErr);
   }
 }
 


### PR DESCRIPTION
## The bug we couldn't see

`processBatch()` (the cron-driven onboarding email sender) silently swallowed failures. Concrete symptom from today:

- `MailApp.sendEmail` succeeded → buyer got the welcome email.
- `sheet.getRange(...).setValue(now)` ran, didn't throw.
- But column M came back **empty** on the next trigger read.
- Same row picked up again → same buyer re-emailed.
- No alert anywhere. The Executions tab showed green runs.

The "didn't throw but cell is empty" class of failure is the nasty one. It happens when:
- An `=ARRAYFORMULA(...)` in M1 re-spills and overwrites the manual write.
- Column M has strict data validation that rejects Date input.
- A protected range on column M restricts this script's identity even though the workbook says "Editor."

None of those raise an exception on `setValue`. The current code has no way to notice.

## What this PR does

Three layers of observability:

### 1. Per-email try/catch
One user's failure no longer aborts subsequent users in the batch.

### 2. `SpreadsheetApp.flush()` + read-back verification
After every `setValue`, force the write to flush, then read column M back. If empty, raise an explicit error:

```
Stamp verification failed for row(s) 437, 438. Column M came back empty
after setValue + flush. Likely cause: (a) ARRAYFORMULA / formula in M1
re-spilling and overwriting the write, (b) strict data validation on
column M rejecting Date input, (c) protected range on column M restricting
this script's identity. Email already sent — these rows will be re-sent
next run until M is populated.
```

This is the layer that would have caught today's silent-overwrite incident on the first run instead of after N duplicate emails.

### 3. Alert email + trigger-level failure
- Every failure aggregated into a single summary email to `garyjob@agroverse.shop` (rows + error + stack per failure).
- `processBatch` re-throws at the end if any failures occurred. GAS marks the run failed in the Executions tab and fires the standard "Notify me on trigger failure" email automatically.

`Logger.log` summary on every run (`sent=X, stamped=Y, failures=Z`) so even green runs are diagnosable from the Executions log.

## Deploy

Source-of-truth lives at `google_app_scripts/agroverse_qr_codes/qr_code_web_service.gs`. After merge, run `clasp push` from `clasp_mirrors/1MnAsIQAxcSfZO_hALOtMFJ4y1k4OnqeXKMwYs6xev600rPNUYepqcXsT/` (the admin@truesight.me project) to deploy. No schema or trigger changes required.

## Test plan

- [ ] `clasp push` to the admin@truesight.me project.
- [ ] Run `processBatch` manually with no pending rows → green, summary line in log: `sent=0, stamped=0, failures=0`.
- [ ] Run `processBatch` with one valid pending row → email goes out, M gets stamped, summary `sent=1, stamped=1, failures=0`.
- [ ] To validate the silent-overwrite path: temporarily put `=ARRAYFORMULA(IF(L:L="","",""))` in M1, run `processBatch` against a pending row → email goes out, alert email lands at `garyjob@agroverse.shop` naming row N, Executions tab marks the run failed, error message names the three likely causes. Then remove the formula.