### PR TITLE
feat(agroverse-qr): include shipping/tracking in unassigned-stripe-sessions list

### DIFF
--- a/google_app_scripts/_clasp_default/Version.gs
+++ b/google_app_scripts/_clasp_default/Version.gs
@@ -19,6 +19,7 @@ var CLASP_MIRROR_LAST_CLASP_PUSH_UTC = '2026-04-28T19:00:00Z';
  * Newest first. Keep lines short; link PRs/commits in git instead of pasting secrets.
  */
 var CLASP_MIRROR_CHANGELOG =
+  '2026-04-29 — qr_code_web_service.listUnassignedStripeSessions_: include shipping_provider (col M) and tracking_number (col N) per item so the DApp update_qr_code page can prefill those fields when an operator picks a session, without a second round trip.\n' +
   '2026-04-29 — qr_code_web_service.processBatch: per-email try/catch + SpreadsheetApp.flush() + read-back verification of column M; alert email to garyjob@agroverse.shop on any failure; re-throw at end so the trigger run is logged as failed (catches the silent-overwrite case where setValue succeeds but the cell stays empty due to ARRAYFORMULA / data validation / protected range on column M).\n' +
   '2026-04-28 — find_nearby_stores: fix applyHitListAuAvFormulasToRow_ getRange args (was treating 4th arg as endCol; now correctly numRows=1, numCols=2). Caused "data has 1 but range has 526" on every addNewStore + retail-field-report status update. Hit List row still landed because appendRow runs first; only the AU/AV formula write threw.\n' +
   '2026-04-28 — find_nearby_stores: parseRetailFieldReportText_ now strips leading `- ` bullet so dao_client `update_store` payloads (`- Label: Value`) parse the same as the DApp page (`Label: Value`). Same logic the sibling store-add parser already had.\n' +

--- a/google_app_scripts/agroverse_qr_codes/qr_code_web_service.gs
+++ b/google_app_scripts/agroverse_qr_codes/qr_code_web_service.gs
@@ -109,8 +109,10 @@ function doOptionsWebLedger_(e) {
  * - 'list_with_members=true' query parameter to return QR codes with details where column D is NOT 'SOLD'.
  * - 'lookup=true&qr_code=...' returns ledger details plus stripe_session_id and tracking_number when a row
  *   in 'Stripe Social Media Checkout ID' has column P equal to the QR code (Session in C, Shipping M, Tracking N; newest row wins).
- * - 'list_unassigned_stripe_sessions=true' returns { items: [{ stripe_session_id }] } for rows with Session in C
- *   and column P blank; optional 'for_qr_code' also returns sessions already linked to that QR in P (for DApp prefill).
+ * - 'list_unassigned_stripe_sessions=true' returns { items: [{ stripe_session_id, shipping_provider, tracking_number }] }
+ *   for rows with Session in C and column P blank; optional 'for_qr_code' also returns sessions already linked to that
+ *   QR in P (for DApp prefill). shipping_provider (col M) and tracking_number (col N) are included so the DApp /
+ *   dao_client can prefill those fields when an operator picks a session, without a second round trip.
  * - 'list_contributor_names=true' returns { status, names: string[] } from **Contributors Digital Signatures** (batch QR manager dropdown).
  *
  * @param {Object} e Event object containing parameters.
@@ -413,7 +415,14 @@ function listUnassignedStripeSessions_(spreadsheet, forQrCodeRaw) {
     if (seen[session]) continue;
 
     seen[session] = true;
-    items.push({ stripe_session_id: session });
+    // Include shipping_provider (col M = idx 10) and tracking_number (col N
+    // = idx 11) per item so the DApp / dao_client can prefill those fields
+    // when an operator picks a session, without an extra round trip.
+    items.push({
+      stripe_session_id: session,
+      shipping_provider: (range[r][10] || '').toString().trim(),
+      tracking_number: (range[r][11] || '').toString().trim(),
+    });
   }
 
   return createCORSResponse({


### PR DESCRIPTION
## Why

The DApp \`update_qr_code.html\` page (and any dao_client caller) needs the \`shipping_provider\` and \`tracking_number\` for a Stripe session so it can prefill those fields when an operator picks a session from the dropdown.

Currently \`listUnassignedStripeSessions_\` returns only:

\`\`\`json
{ \"items\": [{ \"stripe_session_id\": \"cs_live_...\" }] }
\`\`\`

even though the function already reads \`range[r][10]\` (column M, shipping provider) and \`range[r][11]\` (column N, tracking number) when scanning the Stripe sheet — the data is on the row, just dropped on the floor.

## What

Add both fields per item:

\`\`\`json
{ \"items\": [{
  \"stripe_session_id\": \"cs_live_...\",
  \"shipping_provider\": \"USPS Priority Mail - USPS\",
  \"tracking_number\": \"9405511899560123456789\"
}] }
\`\`\`

No new endpoint, no extra round-trips, no schema change. Pure read-amplification of data already loaded into the function's range scan.

## How surfaced

Operator opened \`update_qr_code.html\` for a QR with no column Z linked yet (\`2024OSCAR_20260121_12\`). All three fields rendered empty, expected. Picking a Stripe session from the dropdown populated only the session ID — Tracking number stayed empty even though the chosen session had a tracking number on its Stripe row. Root cause was on both sides: GAS doesn't return the data, and the JS doesn't have an onSelect handler to act on it. This PR fixes the GAS side.

## Companion PRs

- DApp wiring: TrueSightDAO/dapp#TBD (consumes the new fields)
- dao_client: TrueSightDAO/dao_client#TBD (\`lookup_qr_code\` CLI inspector)

## Test plan

- [ ] \`clasp push\` to project \`1MnAsIQAxcSfZO_hALOtMFJ4y1k4OnqeXKMwYs6xev600rPNUYepqcXsT\` (admin@truesight.me).
- [ ] \`curl -L \"<exec>?list_unassigned_stripe_sessions=true&for_qr_code=<known-linked-qr>\" | jq '.items[0]'\` → returns all three fields.
- [ ] Open \`update_qr_code.html\` (after dapp PR merges), pick any session → Shipping Provider + Tracking number populate from the picked session's Stripe row.