### PR TITLE
feat(gas): warmup review queue API + signed send handler

### DIFF
--- a/clasp_mirrors/14gKJ0VW49RsSn4S03pgxKXy0sp4Z7Z3Wm1Wj8jQiWW5dj1sFuPnp95sh/WarmupReviewApi.gs
+++ b/clasp_mirrors/14gKJ0VW49RsSn4S03pgxKXy0sp4Z7Z3Wm1Wj8jQiWW5dj1sFuPnp95sh/WarmupReviewApi.gs
@@ -1,0 +1,188 @@
+/**
+ * Read-only API powering dapp/warmup_review.html.
+ *
+ * Returns the queue of warm-up Gmail drafts pending operator review,
+ * joined with Hit List signals (Hosts Circles, City/State, Notes) and
+ * DApp Remarks history count, so the DApp can render a tiered triage
+ * view (red flags / Hosts Circles=Yes badge / clean cohort) without
+ * round-tripping multiple GAS calls.
+ *
+ * Mirrors the local script `market_research/scripts/preview_warmup_drafts.py`
+ * but driven by the 500-char `body_preview` column rather than a full
+ * Gmail draft fetch — same ~12 lint rules apply since most fire on the
+ * first 500 chars (subject, generic_inbox, fallback shop name, body
+ * length, foreign script, generic salutation, placeholder).
+ *
+ * Schema reference: ensure_email_agent_suggestions_sheet.py defines
+ * the canonical Email Agent Drafts header. The `gmail_message_id`
+ * column was added 2026-05-03 and powers the
+ * `https://mail.google.com/.../drafts/<message_id>` deep-link the
+ * DApp uses to jump straight to a draft from mobile.
+ *
+ * Action: ?action=getWarmupReviewQueue (registered in Code.js doGet).
+ */
+
+var WARMUP_DRAFTS_PENDING_STATUS = 'pending_review';
+var WARMUP_DRAFTS_LABEL = 'AI/Warm-up';
+var WARMUP_HOSTS_CIRCLES_HEADER = 'Hosts Circles';
+
+function getWarmupReviewQueue_() {
+  var ss = SpreadsheetApp.openById(HIT_LIST_SPREADSHEET_ID);
+  var draftsSh = getSheetSafe_(ss, SHEET_EMAIL_DRAFTS);
+  if (!draftsSh) {
+    return { drafts: [], counts: { total: 0, with_message_id: 0 } };
+  }
+
+  var draftsValues = draftsSh.getDataRange().getValues();
+  if (draftsValues.length < 2) {
+    return { drafts: [], counts: { total: 0, with_message_id: 0 } };
+  }
+  var draftsHdr = headerMap_(draftsValues[0]);
+  var iStatus = draftsHdr['status'];
+  var iLabel = draftsHdr['gmail_label'];
+  var iEmail = draftsHdr['to_email'];
+  var iShop = draftsHdr['shop_name'];
+  var iStoreKey = draftsHdr['store_key'];
+  var iSubject = draftsHdr['subject'];
+  var iPreview = draftsHdr['body_preview'];
+  var iDraftId = draftsHdr['gmail_draft_id'];
+  var iMsgId = draftsHdr['gmail_message_id'];
+  var iHitRow = draftsHdr['hit_list_row'];
+  var iCreated = draftsHdr['created_at_utc'];
+  var required = ['status', 'gmail_label', 'to_email', 'shop_name', 'subject',
+                  'body_preview', 'gmail_draft_id'];
+  for (var k = 0; k < required.length; k++) {
+    if (draftsHdr[required[k]] === undefined) {
+      throw new Error('Email Agent Drafts missing column: ' + required[k]);
+    }
+  }
+
+  var hitIndex = warmupBuildHitListIndex_(ss);
+  var dappCounts = warmupBuildDappRemarksCounts_(ss);
+
+  var pending = [];
+  var withMsgId = 0;
+  for (var r = 1; r < draftsValues.length; r++) {
+    var row = draftsValues[r];
+    var status = (row[iStatus] || '').toString().trim();
+    if (status !== WARMUP_DRAFTS_PENDING_STATUS) continue;
+    var label = (row[iLabel] || '').toString().trim();
+    if (label !== WARMUP_DRAFTS_LABEL) continue;
+
+    var em = ((row[iEmail] || '').toString().trim() || '').toLowerCase();
+    var shop = (row[iShop] || '').toString().trim();
+    var sk = iStoreKey === undefined ? '' : (row[iStoreKey] || '').toString().trim();
+    var subj = (row[iSubject] || '').toString();
+    var preview = (row[iPreview] || '').toString();
+    var draftId = (row[iDraftId] || '').toString().trim();
+    var msgId = iMsgId === undefined ? '' : (row[iMsgId] || '').toString().trim();
+    var hitRow = iHitRow === undefined ? '' : (row[iHitRow] || '').toString().trim();
+    var createdAt = iCreated === undefined ? '' : (row[iCreated] || '').toString();
+
+    var hit = (em && hitIndex.byEmail[em])
+        || (sk && hitIndex.byStoreKey[sk])
+        || null;
+    var hostsCircles = !!(hit && hit.hostsCircles);
+    var cityState = hit ? hit.cityState : '';
+    var notes = hit ? hit.notes : '';
+    var hasDappHistory = !!dappCounts[shop.toLowerCase()];
+    if (msgId) withMsgId++;
+
+    pending.push({
+      sheet_row: r + 1,
+      to_email: em,
+      shop_name: shop,
+      store_key: sk,
+      city_state: cityState,
+      hit_list_row: hitRow,
+      hit_list_notes_present: !!(notes && notes.length),
+      hosts_circles: hostsCircles,
+      has_dapp_history: hasDappHistory,
+      subject: subj,
+      body_preview: preview,
+      gmail_draft_id: draftId,
+      gmail_message_id: msgId,
+      created_at_utc: createdAt,
+    });
+  }
+
+  return {
+    drafts: pending,
+    counts: {
+      total: pending.length,
+      with_message_id: withMsgId,
+      hit_list_indexed_email: Object.keys(hitIndex.byEmail).length,
+      hit_list_indexed_store: Object.keys(hitIndex.byStoreKey).length,
+      dapp_remarks_indexed: Object.keys(dappCounts).length,
+    },
+    generated_at_utc: new Date().toISOString(),
+  };
+}
+
+function warmupBuildHitListIndex_(ss) {
+  var sh = getSheetSafe_(ss, SHEET_HIT_LIST);
+  if (!sh) return { byEmail: {}, byStoreKey: {} };
+  var values = sh.getDataRange().getValues();
+  if (values.length < 2) return { byEmail: {}, byStoreKey: {} };
+  var hdr = headerMap_(values[0]);
+  var iEmail = hdr['Email'];
+  var iStoreKey = hdr['Store Key'];
+  var iCity = hdr['City'];
+  var iState = hdr['State'];
+  var iNotes = hdr['Notes'];
+  var iAW = hdr[WARMUP_HOSTS_CIRCLES_HEADER];
+
+  var byEmail = {};
+  var byStoreKey = {};
+  for (var r = 1; r < values.length; r++) {
+    var row = values[r];
+    var em = iEmail === undefined ? '' : (row[iEmail] || '').toString().trim().toLowerCase();
+    var sk = iStoreKey === undefined ? '' : (row[iStoreKey] || '').toString().trim();
+    var city = iCity === undefined ? '' : (row[iCity] || '').toString().trim();
+    var state = iState === undefined ? '' : (row[iState] || '').toString().trim();
+    var notes = iNotes === undefined ? '' : (row[iNotes] || '').toString();
+    var aw = iAW === undefined ? '' : (row[iAW] || '').toString().trim();
+    var locale = [city, state].filter(function (x) { return !!x; }).join(', ');
+    var payload = {
+      hostsCircles: warmupYes_(aw),
+      cityState: locale,
+      notes: notes,
+    };
+    if (em && !byEmail[em]) byEmail[em] = payload;
+    if (sk && !byStoreKey[sk]) byStoreKey[sk] = payload;
+  }
+  return { byEmail: byEmail, byStoreKey: byStoreKey };
+}
+
+function warmupBuildDappRemarksCounts_(ss) {
+  var sh = getSheetSafe_(ss, SHEET_DAPP_REMARKS);
+  if (!sh) return {};
+  var values = sh.getDataRange().getValues();
+  if (values.length < 2) return {};
+  var hdr = headerMap_(values[0]);
+  var iShop = hdr['Shop Name'];
+  if (iShop === undefined) return {};
+  var counts = {};
+  for (var r = 1; r < values.length; r++) {
+    var sn = (values[r][iShop] || '').toString().trim().toLowerCase();
+    if (!sn) continue;
+    counts[sn] = (counts[sn] || 0) + 1;
+  }
+  return counts;
+}
+
+/**
+ * Hit List Hosts Circles column stores descriptive variants like
+ * 'Yes (sound bath)' / 'Yes (sound healing, breathwork)' alongside
+ * 'Not detected' / blank. Treat any value whose first token (or
+ * pre-paren token) is 'yes' as a positive signal.
+ */
+function warmupYes_(s) {
+  var v = (s || '').toString().trim().toLowerCase();
+  if (!v) return false;
+  if (v === 'y' || v === 'true' || v === '1') return true;
+  var firstWord = v.split(/\s+/)[0];
+  if (firstWord === 'yes') return true;
+  var beforeParen = v.split('(')[0].replace(/\s+$/, '');
+  return beforeParen === 'yes';
+}

--- a/clasp_mirrors/14gKJ0VW49RsSn4S03pgxKXy0sp4Z7Z3Wm1Wj8jQiWW5dj1sFuPnp95sh/WarmupSendHandler.gs
+++ b/clasp_mirrors/14gKJ0VW49RsSn4S03pgxKXy0sp4Z7Z3Wm1Wj8jQiWW5dj1sFuPnp95sh/WarmupSendHandler.gs
@@ -1,0 +1,292 @@
+/**
+ * Process [WARMUP SEND EVENT] rows from "Telegram Chat Logs" and send the
+ * matching Gmail draft. Same dispatch shape as DappPermissionChangeHandler
+ * (1m8IZPs1…) but lives in the holistic_hit_list_store_history project
+ * because GmailApp.send() runs as the script owner and that's where
+ * EmailAgentDrafts.gs already creates drafts via GmailApp.
+ *
+ * Triggers:
+ * - Edgar /submit_contribution dispatcher fires
+ *   doGet(?action=apply_warmup_send) on the storesHitList deployment URL
+ *   after every successful [WARMUP SEND EVENT] persist on Telegram Chat
+ *   Logs. Edgar's WebhookTriggerWorker only forwards `action` (no secret),
+ *   matching the convention of every other dispatch handler. The Apps
+ *   Script deployment URL itself is the access token (functionally
+ *   unguessable); real authorization is the per-event RSA signature
+ *   verified by Edgar before logging + the active-membership check in
+ *   applyPendingWarmupSends_. Even if the URL leaks, an attacker can
+ *   only force-process events that are already on Telegram Chat Logs
+ *   with valid signatures, and processing is idempotent because Gmail
+ *   only sends a draft once (the second attempt finds no draft).
+ * - Manual: applyWarmupSendNow() from the Apps Script editor.
+ */
+
+var WARMUP_SEND_EVENT_TAG = '[WARMUP SEND EVENT]';
+var WARMUP_TELEGRAM_SPREADSHEET_ID = '1qbZZhf-_7xzmDTriaJVWj6OZshyQsFkdsAV8-pyzASQ';
+var WARMUP_TELEGRAM_SHEET_NAME = 'Telegram Chat Logs';
+var WARMUP_AUDIT_SHEET_NAME = 'Warmup Sends';
+var WARMUP_OFFCHAIN_SPREADSHEET_ID = '1GE7PUq-UT6x2rBN-Q2ksogbWpgyuh2SaxJyG_uEK6PU';
+var WARMUP_SIGS_SHEET_NAME = 'Contributors Digital Signatures';
+
+// Telegram Chat Logs column layout (matches DappPermissionChangeHandler).
+var WARMUP_TELEGRAM_TEXT_COL_INDEX = 6;       // 0-based — col G holds the event text
+var WARMUP_TELEGRAM_UPDATE_ID_COL_INDEX = 0;  // 0-based — col A is Telegram Update ID
+
+var WARMUP_AUDIT_HEADERS = [
+  'Telegram Update ID',
+  'Submitted At UTC',
+  'Actor Public Key',
+  'Actor Name',
+  'Is Active Member',
+  'Draft ID',
+  'Recipient',
+  'Subject',
+  'Status',
+  'Sent Message ID',
+  'Notes',
+  'Processed At UTC',
+];
+
+/** Manual entry point for editor smoke testing. */
+function applyWarmupSendNow() {
+  var result = applyPendingWarmupSends_({ trigger: 'manual' });
+  Logger.log(JSON.stringify(result, null, 2));
+  return result;
+}
+
+/**
+ * doGet-routed entry. Registered in Code.js as
+ * action === 'apply_warmup_send'. Returns JSON envelope to the caller
+ * (Edgar's WebhookTriggerWorker, or operator curl).
+ */
+function handleApplyWarmupSendRequest_() {
+  try {
+    var result = applyPendingWarmupSends_({ trigger: 'edgar_webhook' });
+    return ContentService
+        .createTextOutput(JSON.stringify({ ok: true, data: result }))
+        .setMimeType(ContentService.MimeType.JSON);
+  } catch (err) {
+    Logger.log('handleApplyWarmupSendRequest_ failed: ' + err);
+    return ContentService
+        .createTextOutput(JSON.stringify({ ok: false, error: String(err) }))
+        .setMimeType(ContentService.MimeType.JSON);
+  }
+}
+
+/**
+ * Core: scan Telegram Chat Logs for unprocessed [WARMUP SEND EVENT]
+ * rows, verify signer is an active contributor, send the matching Gmail
+ * draft, append outcome to the Warmup Sends audit tab.
+ */
+function applyPendingWarmupSends_(opts) {
+  var o = opts || {};
+  var telegramSs = SpreadsheetApp.openById(WARMUP_TELEGRAM_SPREADSHEET_ID);
+  var telegramWs = telegramSs.getSheetByName(WARMUP_TELEGRAM_SHEET_NAME);
+  if (!telegramWs) {
+    throw new Error('Missing sheet: ' + WARMUP_TELEGRAM_SHEET_NAME);
+  }
+  var auditWs = ensureWarmupAuditSheet_(telegramSs);
+  var seenUpdateIds = warmupReadProcessedUpdateIds_(auditWs);
+
+  var lastRow = telegramWs.getLastRow();
+  if (lastRow < 2) {
+    return { trigger: o.trigger, processed: 0, skipped: 0, reason: 'empty_log' };
+  }
+  var lastCol = Math.max(
+      WARMUP_TELEGRAM_TEXT_COL_INDEX,
+      WARMUP_TELEGRAM_UPDATE_ID_COL_INDEX) + 1;
+  var data = telegramWs.getRange(2, 1, lastRow - 1, lastCol).getValues();
+
+  var offchainSs = SpreadsheetApp.openById(WARMUP_OFFCHAIN_SPREADSHEET_ID);
+  var sigByPublicKey = warmupReadActiveSignaturesByPublicKey_(offchainSs);
+
+  var processed = 0;
+  var skipped = 0;
+  var newRows = [];
+  for (var i = 0; i < data.length; i++) {
+    var row = data[i];
+    var text = String(row[WARMUP_TELEGRAM_TEXT_COL_INDEX] || '');
+    if (!text || text.indexOf(WARMUP_SEND_EVENT_TAG) < 0) continue;
+
+    var updateId = String(row[WARMUP_TELEGRAM_UPDATE_ID_COL_INDEX] || '').trim();
+    if (!updateId) continue;
+    var prior = seenUpdateIds[updateId];
+    // Terminal statuses — never reprocess.
+    if (prior === 'sent' || prior === 'unauthorized' ||
+        prior === 'invalid_payload' || prior === 'not_found_in_gmail') {
+      skipped++;
+      continue;
+    }
+
+    var parsed = parseWarmupSendEvent_(text);
+    var publicKey = parsed.publicKey || '';
+    var sigEntry = sigByPublicKey[publicKey] || null;
+    var actorName = sigEntry ? sigEntry.name : '(unknown)';
+    var isActive = !!sigEntry;
+
+    var rowOut = {
+      updateId: updateId,
+      submittedAt: parsed.submittedAt || '',
+      publicKey: warmupTruncateKey_(publicKey),
+      actorName: actorName,
+      isActive: isActive ? 'YES' : 'NO',
+      draftId: parsed.draftId || '',
+      recipient: parsed.toEmail || '',
+      subject: parsed.subject || '',
+      status: '',
+      sentMessageId: '',
+      notes: '',
+      processedAt: new Date().toISOString(),
+    };
+
+    if (parsed.error) {
+      rowOut.status = 'invalid_payload';
+      rowOut.notes = parsed.error;
+      newRows.push(warmupAuditRowFromObject_(rowOut));
+      continue;
+    }
+    if (!isActive) {
+      rowOut.status = 'unauthorized';
+      rowOut.notes = 'Public key not ACTIVE in Contributors Digital Signatures.';
+      newRows.push(warmupAuditRowFromObject_(rowOut));
+      continue;
+    }
+
+    var sendResult = warmupSendDraftById_(parsed.draftId);
+    rowOut.status = sendResult.status;
+    rowOut.sentMessageId = sendResult.messageId || '';
+    rowOut.notes = sendResult.notes || '';
+    newRows.push(warmupAuditRowFromObject_(rowOut));
+    if (sendResult.status === 'sent') {
+      processed++;
+    }
+  }
+
+  if (newRows.length) {
+    auditWs.getRange(auditWs.getLastRow() + 1, 1, newRows.length, WARMUP_AUDIT_HEADERS.length)
+        .setValues(newRows);
+  }
+
+  return {
+    trigger: o.trigger,
+    processed: processed,
+    skipped: skipped,
+    appended_rows: newRows.length,
+  };
+}
+
+function warmupSendDraftById_(draftId) {
+  if (!draftId) {
+    return { status: 'invalid_payload', notes: 'Missing draft_id' };
+  }
+  try {
+    var draft = GmailApp.getDraft(draftId);
+    if (!draft) {
+      return { status: 'not_found_in_gmail',
+               notes: 'GmailApp.getDraft returned null — already sent or discarded.' };
+    }
+    var sentMsg = draft.send();
+    var msgId = sentMsg && sentMsg.getId ? sentMsg.getId() : '';
+    return { status: 'sent', messageId: msgId };
+  } catch (err) {
+    var msg = String(err && err.message || err);
+    if (msg.indexOf('not found') !== -1 || msg.indexOf('Invalid') !== -1) {
+      return { status: 'not_found_in_gmail', notes: msg };
+    }
+    return { status: 'failed_send', notes: msg };
+  }
+}
+
+function ensureWarmupAuditSheet_(ss) {
+  var ws = ss.getSheetByName(WARMUP_AUDIT_SHEET_NAME);
+  if (!ws) {
+    ws = ss.insertSheet(WARMUP_AUDIT_SHEET_NAME);
+    ws.getRange(1, 1, 1, WARMUP_AUDIT_HEADERS.length).setValues([WARMUP_AUDIT_HEADERS]);
+    ws.getRange(1, 1, 1, WARMUP_AUDIT_HEADERS.length).setFontWeight('bold');
+    ws.setFrozenRows(1);
+    return ws;
+  }
+  var lastCol = Math.max(1, ws.getLastColumn());
+  var existing = ws.getRange(1, 1, 1, lastCol).getValues()[0];
+  if (existing.length < WARMUP_AUDIT_HEADERS.length) {
+    var startCol = existing.length + 1;
+    var missing = WARMUP_AUDIT_HEADERS.slice(existing.length);
+    ws.getRange(1, startCol, 1, missing.length).setValues([missing]);
+    ws.getRange(1, startCol, 1, missing.length).setFontWeight('bold');
+  }
+  return ws;
+}
+
+function warmupReadProcessedUpdateIds_(auditWs) {
+  var last = auditWs.getLastRow();
+  if (last < 2) return {};
+  var data = auditWs.getRange(2, 1, last - 1, WARMUP_AUDIT_HEADERS.length).getValues();
+  var out = {};
+  data.forEach(function (r) {
+    var u = String(r[0] || '').trim();
+    var status = String(r[8] || '').trim().toLowerCase();
+    if (u) out[u] = status;
+  });
+  return out;
+}
+
+function warmupReadActiveSignaturesByPublicKey_(ss) {
+  var ws = ss.getSheetByName(WARMUP_SIGS_SHEET_NAME);
+  if (!ws) return {};
+  var last = ws.getLastRow();
+  if (last < 2) return {};
+  var data = ws.getRange(2, 1, last - 1, 8).getValues();
+  var out = {};
+  data.forEach(function (r) {
+    var name = String(r[0] || '').trim();
+    var status = String(r[3] || '').trim().toUpperCase();
+    var key = String(r[4] || '').trim();
+    if (!name || !key || status !== 'ACTIVE') return;
+    out[key] = { name: name };
+  });
+  return out;
+}
+
+function parseWarmupSendEvent_(text) {
+  var lines = String(text).split('\n').map(function (s) { return s.trim(); });
+  if (!lines.length || lines[0].indexOf(WARMUP_SEND_EVENT_TAG) < 0) {
+    return { error: 'Missing event tag.' };
+  }
+  function pluck(prefix) {
+    var m = lines.find(function (l) { return l.indexOf(prefix) === 0; });
+    return m ? m.substring(prefix.length).trim() : '';
+  }
+  var draftId = pluck('- Draft ID:');
+  var toEmail = pluck('- Recipient:');
+  var subject = pluck('- Subject:');
+  var submittedAt = pluck('- Submitted At:');
+
+  var pkMatch = text.match(/My Digital Signature:\s*([\s\S]*?)(?:\n\s*Request Transaction ID:|This submission was generated using|$)/i);
+  var publicKey = pkMatch ? pkMatch[1].trim() : '';
+
+  if (!draftId) return { error: 'Missing - Draft ID: line.' };
+  if (!submittedAt) return { error: 'Missing - Submitted At: line.' };
+  if (!publicKey) return { error: 'Missing My Digital Signature: footer.' };
+
+  return {
+    draftId: draftId,
+    toEmail: toEmail,
+    subject: subject,
+    submittedAt: submittedAt,
+    publicKey: publicKey,
+  };
+}
+
+function warmupTruncateKey_(k) {
+  var s = String(k || '');
+  if (s.length <= 60) return s;
+  return s.substring(0, 60) + '…';
+}
+
+function warmupAuditRowFromObject_(o) {
+  return [
+    o.updateId, o.submittedAt, o.publicKey, o.actorName, o.isActive,
+    o.draftId, o.recipient, o.subject,
+    o.status, o.sentMessageId, o.notes, o.processedAt,
+  ];
+}

--- a/google_app_scripts/holistic_hit_list_store_history/store_interaction_history_api.gs
+++ b/google_app_scripts/holistic_hit_list_store_history/store_interaction_history_api.gs
@@ -837,8 +837,21 @@ function doGet(e) {
       return success_(hitListPipelineSummary_());
     }
 
+    if (action === 'getWarmupReviewQueue') {
+      // Read-only triage queue powering dapp/warmup_review.html.
+      // Implementation: warmup_review_api.gs (clasp_mirrors/.../WarmupReviewApi.gs).
+      return success_(getWarmupReviewQueue_());
+    }
+
+    if (action === 'apply_warmup_send') {
+      // Edgar webhook entry — fires after Edgar persists a [WARMUP SEND EVENT]
+      // to Telegram Chat Logs. Returns its own JSON envelope (avoid double-wrap).
+      // Implementation: warmup_send_handler.gs (clasp_mirrors/.../WarmupSendHandler.gs).
+      return handleApplyWarmupSendRequest_();
+    }
+
     return error_(
-      'Unknown action. Use suggestStores, getStoreHistory, listStoresByFilter, or listStatusSummary.',
+      'Unknown action. Use suggestStores, getStoreHistory, listStoresByFilter, listStatusSummary, getWarmupReviewQueue, or apply_warmup_send.',
       400
     );
   } catch (err) {

--- a/google_app_scripts/holistic_hit_list_store_history/warmup_review_api.gs
+++ b/google_app_scripts/holistic_hit_list_store_history/warmup_review_api.gs
@@ -1,0 +1,188 @@
+/**
+ * Read-only API powering dapp/warmup_review.html.
+ *
+ * Returns the queue of warm-up Gmail drafts pending operator review,
+ * joined with Hit List signals (Hosts Circles, City/State, Notes) and
+ * DApp Remarks history count, so the DApp can render a tiered triage
+ * view (red flags / Hosts Circles=Yes badge / clean cohort) without
+ * round-tripping multiple GAS calls.
+ *
+ * Mirrors the local script `market_research/scripts/preview_warmup_drafts.py`
+ * but driven by the 500-char `body_preview` column rather than a full
+ * Gmail draft fetch — same ~12 lint rules apply since most fire on the
+ * first 500 chars (subject, generic_inbox, fallback shop name, body
+ * length, foreign script, generic salutation, placeholder).
+ *
+ * Schema reference: ensure_email_agent_suggestions_sheet.py defines
+ * the canonical Email Agent Drafts header. The `gmail_message_id`
+ * column was added 2026-05-03 and powers the
+ * `https://mail.google.com/.../drafts/<message_id>` deep-link the
+ * DApp uses to jump straight to a draft from mobile.
+ *
+ * Action: ?action=getWarmupReviewQueue (registered in Code.js doGet).
+ */
+
+var WARMUP_DRAFTS_PENDING_STATUS = 'pending_review';
+var WARMUP_DRAFTS_LABEL = 'AI/Warm-up';
+var WARMUP_HOSTS_CIRCLES_HEADER = 'Hosts Circles';
+
+function getWarmupReviewQueue_() {
+  var ss = SpreadsheetApp.openById(HIT_LIST_SPREADSHEET_ID);
+  var draftsSh = getSheetSafe_(ss, SHEET_EMAIL_DRAFTS);
+  if (!draftsSh) {
+    return { drafts: [], counts: { total: 0, with_message_id: 0 } };
+  }
+
+  var draftsValues = draftsSh.getDataRange().getValues();
+  if (draftsValues.length < 2) {
+    return { drafts: [], counts: { total: 0, with_message_id: 0 } };
+  }
+  var draftsHdr = headerMap_(draftsValues[0]);
+  var iStatus = draftsHdr['status'];
+  var iLabel = draftsHdr['gmail_label'];
+  var iEmail = draftsHdr['to_email'];
+  var iShop = draftsHdr['shop_name'];
+  var iStoreKey = draftsHdr['store_key'];
+  var iSubject = draftsHdr['subject'];
+  var iPreview = draftsHdr['body_preview'];
+  var iDraftId = draftsHdr['gmail_draft_id'];
+  var iMsgId = draftsHdr['gmail_message_id'];
+  var iHitRow = draftsHdr['hit_list_row'];
+  var iCreated = draftsHdr['created_at_utc'];
+  var required = ['status', 'gmail_label', 'to_email', 'shop_name', 'subject',
+                  'body_preview', 'gmail_draft_id'];
+  for (var k = 0; k < required.length; k++) {
+    if (draftsHdr[required[k]] === undefined) {
+      throw new Error('Email Agent Drafts missing column: ' + required[k]);
+    }
+  }
+
+  var hitIndex = warmupBuildHitListIndex_(ss);
+  var dappCounts = warmupBuildDappRemarksCounts_(ss);
+
+  var pending = [];
+  var withMsgId = 0;
+  for (var r = 1; r < draftsValues.length; r++) {
+    var row = draftsValues[r];
+    var status = (row[iStatus] || '').toString().trim();
+    if (status !== WARMUP_DRAFTS_PENDING_STATUS) continue;
+    var label = (row[iLabel] || '').toString().trim();
+    if (label !== WARMUP_DRAFTS_LABEL) continue;
+
+    var em = ((row[iEmail] || '').toString().trim() || '').toLowerCase();
+    var shop = (row[iShop] || '').toString().trim();
+    var sk = iStoreKey === undefined ? '' : (row[iStoreKey] || '').toString().trim();
+    var subj = (row[iSubject] || '').toString();
+    var preview = (row[iPreview] || '').toString();
+    var draftId = (row[iDraftId] || '').toString().trim();
+    var msgId = iMsgId === undefined ? '' : (row[iMsgId] || '').toString().trim();
+    var hitRow = iHitRow === undefined ? '' : (row[iHitRow] || '').toString().trim();
+    var createdAt = iCreated === undefined ? '' : (row[iCreated] || '').toString();
+
+    var hit = (em && hitIndex.byEmail[em])
+        || (sk && hitIndex.byStoreKey[sk])
+        || null;
+    var hostsCircles = !!(hit && hit.hostsCircles);
+    var cityState = hit ? hit.cityState : '';
+    var notes = hit ? hit.notes : '';
+    var hasDappHistory = !!dappCounts[shop.toLowerCase()];
+    if (msgId) withMsgId++;
+
+    pending.push({
+      sheet_row: r + 1,
+      to_email: em,
+      shop_name: shop,
+      store_key: sk,
+      city_state: cityState,
+      hit_list_row: hitRow,
+      hit_list_notes_present: !!(notes && notes.length),
+      hosts_circles: hostsCircles,
+      has_dapp_history: hasDappHistory,
+      subject: subj,
+      body_preview: preview,
+      gmail_draft_id: draftId,
+      gmail_message_id: msgId,
+      created_at_utc: createdAt,
+    });
+  }
+
+  return {
+    drafts: pending,
+    counts: {
+      total: pending.length,
+      with_message_id: withMsgId,
+      hit_list_indexed_email: Object.keys(hitIndex.byEmail).length,
+      hit_list_indexed_store: Object.keys(hitIndex.byStoreKey).length,
+      dapp_remarks_indexed: Object.keys(dappCounts).length,
+    },
+    generated_at_utc: new Date().toISOString(),
+  };
+}
+
+function warmupBuildHitListIndex_(ss) {
+  var sh = getSheetSafe_(ss, SHEET_HIT_LIST);
+  if (!sh) return { byEmail: {}, byStoreKey: {} };
+  var values = sh.getDataRange().getValues();
+  if (values.length < 2) return { byEmail: {}, byStoreKey: {} };
+  var hdr = headerMap_(values[0]);
+  var iEmail = hdr['Email'];
+  var iStoreKey = hdr['Store Key'];
+  var iCity = hdr['City'];
+  var iState = hdr['State'];
+  var iNotes = hdr['Notes'];
+  var iAW = hdr[WARMUP_HOSTS_CIRCLES_HEADER];
+
+  var byEmail = {};
+  var byStoreKey = {};
+  for (var r = 1; r < values.length; r++) {
+    var row = values[r];
+    var em = iEmail === undefined ? '' : (row[iEmail] || '').toString().trim().toLowerCase();
+    var sk = iStoreKey === undefined ? '' : (row[iStoreKey] || '').toString().trim();
+    var city = iCity === undefined ? '' : (row[iCity] || '').toString().trim();
+    var state = iState === undefined ? '' : (row[iState] || '').toString().trim();
+    var notes = iNotes === undefined ? '' : (row[iNotes] || '').toString();
+    var aw = iAW === undefined ? '' : (row[iAW] || '').toString().trim();
+    var locale = [city, state].filter(function (x) { return !!x; }).join(', ');
+    var payload = {
+      hostsCircles: warmupYes_(aw),
+      cityState: locale,
+      notes: notes,
+    };
+    if (em && !byEmail[em]) byEmail[em] = payload;
+    if (sk && !byStoreKey[sk]) byStoreKey[sk] = payload;
+  }
+  return { byEmail: byEmail, byStoreKey: byStoreKey };
+}
+
+function warmupBuildDappRemarksCounts_(ss) {
+  var sh = getSheetSafe_(ss, SHEET_DAPP_REMARKS);
+  if (!sh) return {};
+  var values = sh.getDataRange().getValues();
+  if (values.length < 2) return {};
+  var hdr = headerMap_(values[0]);
+  var iShop = hdr['Shop Name'];
+  if (iShop === undefined) return {};
+  var counts = {};
+  for (var r = 1; r < values.length; r++) {
+    var sn = (values[r][iShop] || '').toString().trim().toLowerCase();
+    if (!sn) continue;
+    counts[sn] = (counts[sn] || 0) + 1;
+  }
+  return counts;
+}
+
+/**
+ * Hit List Hosts Circles column stores descriptive variants like
+ * 'Yes (sound bath)' / 'Yes (sound healing, breathwork)' alongside
+ * 'Not detected' / blank. Treat any value whose first token (or
+ * pre-paren token) is 'yes' as a positive signal.
+ */
+function warmupYes_(s) {
+  var v = (s || '').toString().trim().toLowerCase();
+  if (!v) return false;
+  if (v === 'y' || v === 'true' || v === '1') return true;
+  var firstWord = v.split(/\s+/)[0];
+  if (firstWord === 'yes') return true;
+  var beforeParen = v.split('(')[0].replace(/\s+$/, '');
+  return beforeParen === 'yes';
+}

--- a/google_app_scripts/holistic_hit_list_store_history/warmup_send_handler.gs
+++ b/google_app_scripts/holistic_hit_list_store_history/warmup_send_handler.gs
@@ -1,0 +1,292 @@
+/**
+ * Process [WARMUP SEND EVENT] rows from "Telegram Chat Logs" and send the
+ * matching Gmail draft. Same dispatch shape as DappPermissionChangeHandler
+ * (1m8IZPs1…) but lives in the holistic_hit_list_store_history project
+ * because GmailApp.send() runs as the script owner and that's where
+ * EmailAgentDrafts.gs already creates drafts via GmailApp.
+ *
+ * Triggers:
+ * - Edgar /submit_contribution dispatcher fires
+ *   doGet(?action=apply_warmup_send) on the storesHitList deployment URL
+ *   after every successful [WARMUP SEND EVENT] persist on Telegram Chat
+ *   Logs. Edgar's WebhookTriggerWorker only forwards `action` (no secret),
+ *   matching the convention of every other dispatch handler. The Apps
+ *   Script deployment URL itself is the access token (functionally
+ *   unguessable); real authorization is the per-event RSA signature
+ *   verified by Edgar before logging + the active-membership check in
+ *   applyPendingWarmupSends_. Even if the URL leaks, an attacker can
+ *   only force-process events that are already on Telegram Chat Logs
+ *   with valid signatures, and processing is idempotent because Gmail
+ *   only sends a draft once (the second attempt finds no draft).
+ * - Manual: applyWarmupSendNow() from the Apps Script editor.
+ */
+
+var WARMUP_SEND_EVENT_TAG = '[WARMUP SEND EVENT]';
+var WARMUP_TELEGRAM_SPREADSHEET_ID = '1qbZZhf-_7xzmDTriaJVWj6OZshyQsFkdsAV8-pyzASQ';
+var WARMUP_TELEGRAM_SHEET_NAME = 'Telegram Chat Logs';
+var WARMUP_AUDIT_SHEET_NAME = 'Warmup Sends';
+var WARMUP_OFFCHAIN_SPREADSHEET_ID = '1GE7PUq-UT6x2rBN-Q2ksogbWpgyuh2SaxJyG_uEK6PU';
+var WARMUP_SIGS_SHEET_NAME = 'Contributors Digital Signatures';
+
+// Telegram Chat Logs column layout (matches DappPermissionChangeHandler).
+var WARMUP_TELEGRAM_TEXT_COL_INDEX = 6;       // 0-based — col G holds the event text
+var WARMUP_TELEGRAM_UPDATE_ID_COL_INDEX = 0;  // 0-based — col A is Telegram Update ID
+
+var WARMUP_AUDIT_HEADERS = [
+  'Telegram Update ID',
+  'Submitted At UTC',
+  'Actor Public Key',
+  'Actor Name',
+  'Is Active Member',
+  'Draft ID',
+  'Recipient',
+  'Subject',
+  'Status',
+  'Sent Message ID',
+  'Notes',
+  'Processed At UTC',
+];
+
+/** Manual entry point for editor smoke testing. */
+function applyWarmupSendNow() {
+  var result = applyPendingWarmupSends_({ trigger: 'manual' });
+  Logger.log(JSON.stringify(result, null, 2));
+  return result;
+}
+
+/**
+ * doGet-routed entry. Registered in Code.js as
+ * action === 'apply_warmup_send'. Returns JSON envelope to the caller
+ * (Edgar's WebhookTriggerWorker, or operator curl).
+ */
+function handleApplyWarmupSendRequest_() {
+  try {
+    var result = applyPendingWarmupSends_({ trigger: 'edgar_webhook' });
+    return ContentService
+        .createTextOutput(JSON.stringify({ ok: true, data: result }))
+        .setMimeType(ContentService.MimeType.JSON);
+  } catch (err) {
+    Logger.log('handleApplyWarmupSendRequest_ failed: ' + err);
+    return ContentService
+        .createTextOutput(JSON.stringify({ ok: false, error: String(err) }))
+        .setMimeType(ContentService.MimeType.JSON);
+  }
+}
+
+/**
+ * Core: scan Telegram Chat Logs for unprocessed [WARMUP SEND EVENT]
+ * rows, verify signer is an active contributor, send the matching Gmail
+ * draft, append outcome to the Warmup Sends audit tab.
+ */
+function applyPendingWarmupSends_(opts) {
+  var o = opts || {};
+  var telegramSs = SpreadsheetApp.openById(WARMUP_TELEGRAM_SPREADSHEET_ID);
+  var telegramWs = telegramSs.getSheetByName(WARMUP_TELEGRAM_SHEET_NAME);
+  if (!telegramWs) {
+    throw new Error('Missing sheet: ' + WARMUP_TELEGRAM_SHEET_NAME);
+  }
+  var auditWs = ensureWarmupAuditSheet_(telegramSs);
+  var seenUpdateIds = warmupReadProcessedUpdateIds_(auditWs);
+
+  var lastRow = telegramWs.getLastRow();
+  if (lastRow < 2) {
+    return { trigger: o.trigger, processed: 0, skipped: 0, reason: 'empty_log' };
+  }
+  var lastCol = Math.max(
+      WARMUP_TELEGRAM_TEXT_COL_INDEX,
+      WARMUP_TELEGRAM_UPDATE_ID_COL_INDEX) + 1;
+  var data = telegramWs.getRange(2, 1, lastRow - 1, lastCol).getValues();
+
+  var offchainSs = SpreadsheetApp.openById(WARMUP_OFFCHAIN_SPREADSHEET_ID);
+  var sigByPublicKey = warmupReadActiveSignaturesByPublicKey_(offchainSs);
+
+  var processed = 0;
+  var skipped = 0;
+  var newRows = [];
+  for (var i = 0; i < data.length; i++) {
+    var row = data[i];
+    var text = String(row[WARMUP_TELEGRAM_TEXT_COL_INDEX] || '');
+    if (!text || text.indexOf(WARMUP_SEND_EVENT_TAG) < 0) continue;
+
+    var updateId = String(row[WARMUP_TELEGRAM_UPDATE_ID_COL_INDEX] || '').trim();
+    if (!updateId) continue;
+    var prior = seenUpdateIds[updateId];
+    // Terminal statuses — never reprocess.
+    if (prior === 'sent' || prior === 'unauthorized' ||
+        prior === 'invalid_payload' || prior === 'not_found_in_gmail') {
+      skipped++;
+      continue;
+    }
+
+    var parsed = parseWarmupSendEvent_(text);
+    var publicKey = parsed.publicKey || '';
+    var sigEntry = sigByPublicKey[publicKey] || null;
+    var actorName = sigEntry ? sigEntry.name : '(unknown)';
+    var isActive = !!sigEntry;
+
+    var rowOut = {
+      updateId: updateId,
+      submittedAt: parsed.submittedAt || '',
+      publicKey: warmupTruncateKey_(publicKey),
+      actorName: actorName,
+      isActive: isActive ? 'YES' : 'NO',
+      draftId: parsed.draftId || '',
+      recipient: parsed.toEmail || '',
+      subject: parsed.subject || '',
+      status: '',
+      sentMessageId: '',
+      notes: '',
+      processedAt: new Date().toISOString(),
+    };
+
+    if (parsed.error) {
+      rowOut.status = 'invalid_payload';
+      rowOut.notes = parsed.error;
+      newRows.push(warmupAuditRowFromObject_(rowOut));
+      continue;
+    }
+    if (!isActive) {
+      rowOut.status = 'unauthorized';
+      rowOut.notes = 'Public key not ACTIVE in Contributors Digital Signatures.';
+      newRows.push(warmupAuditRowFromObject_(rowOut));
+      continue;
+    }
+
+    var sendResult = warmupSendDraftById_(parsed.draftId);
+    rowOut.status = sendResult.status;
+    rowOut.sentMessageId = sendResult.messageId || '';
+    rowOut.notes = sendResult.notes || '';
+    newRows.push(warmupAuditRowFromObject_(rowOut));
+    if (sendResult.status === 'sent') {
+      processed++;
+    }
+  }
+
+  if (newRows.length) {
+    auditWs.getRange(auditWs.getLastRow() + 1, 1, newRows.length, WARMUP_AUDIT_HEADERS.length)
+        .setValues(newRows);
+  }
+
+  return {
+    trigger: o.trigger,
+    processed: processed,
+    skipped: skipped,
+    appended_rows: newRows.length,
+  };
+}
+
+function warmupSendDraftById_(draftId) {
+  if (!draftId) {
+    return { status: 'invalid_payload', notes: 'Missing draft_id' };
+  }
+  try {
+    var draft = GmailApp.getDraft(draftId);
+    if (!draft) {
+      return { status: 'not_found_in_gmail',
+               notes: 'GmailApp.getDraft returned null — already sent or discarded.' };
+    }
+    var sentMsg = draft.send();
+    var msgId = sentMsg && sentMsg.getId ? sentMsg.getId() : '';
+    return { status: 'sent', messageId: msgId };
+  } catch (err) {
+    var msg = String(err && err.message || err);
+    if (msg.indexOf('not found') !== -1 || msg.indexOf('Invalid') !== -1) {
+      return { status: 'not_found_in_gmail', notes: msg };
+    }
+    return { status: 'failed_send', notes: msg };
+  }
+}
+
+function ensureWarmupAuditSheet_(ss) {
+  var ws = ss.getSheetByName(WARMUP_AUDIT_SHEET_NAME);
+  if (!ws) {
+    ws = ss.insertSheet(WARMUP_AUDIT_SHEET_NAME);
+    ws.getRange(1, 1, 1, WARMUP_AUDIT_HEADERS.length).setValues([WARMUP_AUDIT_HEADERS]);
+    ws.getRange(1, 1, 1, WARMUP_AUDIT_HEADERS.length).setFontWeight('bold');
+    ws.setFrozenRows(1);
+    return ws;
+  }
+  var lastCol = Math.max(1, ws.getLastColumn());
+  var existing = ws.getRange(1, 1, 1, lastCol).getValues()[0];
+  if (existing.length < WARMUP_AUDIT_HEADERS.length) {
+    var startCol = existing.length + 1;
+    var missing = WARMUP_AUDIT_HEADERS.slice(existing.length);
+    ws.getRange(1, startCol, 1, missing.length).setValues([missing]);
+    ws.getRange(1, startCol, 1, missing.length).setFontWeight('bold');
+  }
+  return ws;
+}
+
+function warmupReadProcessedUpdateIds_(auditWs) {
+  var last = auditWs.getLastRow();
+  if (last < 2) return {};
+  var data = auditWs.getRange(2, 1, last - 1, WARMUP_AUDIT_HEADERS.length).getValues();
+  var out = {};
+  data.forEach(function (r) {
+    var u = String(r[0] || '').trim();
+    var status = String(r[8] || '').trim().toLowerCase();
+    if (u) out[u] = status;
+  });
+  return out;
+}
+
+function warmupReadActiveSignaturesByPublicKey_(ss) {
+  var ws = ss.getSheetByName(WARMUP_SIGS_SHEET_NAME);
+  if (!ws) return {};
+  var last = ws.getLastRow();
+  if (last < 2) return {};
+  var data = ws.getRange(2, 1, last - 1, 8).getValues();
+  var out = {};
+  data.forEach(function (r) {
+    var name = String(r[0] || '').trim();
+    var status = String(r[3] || '').trim().toUpperCase();
+    var key = String(r[4] || '').trim();
+    if (!name || !key || status !== 'ACTIVE') return;
+    out[key] = { name: name };
+  });
+  return out;
+}
+
+function parseWarmupSendEvent_(text) {
+  var lines = String(text).split('\n').map(function (s) { return s.trim(); });
+  if (!lines.length || lines[0].indexOf(WARMUP_SEND_EVENT_TAG) < 0) {
+    return { error: 'Missing event tag.' };
+  }
+  function pluck(prefix) {
+    var m = lines.find(function (l) { return l.indexOf(prefix) === 0; });
+    return m ? m.substring(prefix.length).trim() : '';
+  }
+  var draftId = pluck('- Draft ID:');
+  var toEmail = pluck('- Recipient:');
+  var subject = pluck('- Subject:');
+  var submittedAt = pluck('- Submitted At:');
+
+  var pkMatch = text.match(/My Digital Signature:\s*([\s\S]*?)(?:\n\s*Request Transaction ID:|This submission was generated using|$)/i);
+  var publicKey = pkMatch ? pkMatch[1].trim() : '';
+
+  if (!draftId) return { error: 'Missing - Draft ID: line.' };
+  if (!submittedAt) return { error: 'Missing - Submitted At: line.' };
+  if (!publicKey) return { error: 'Missing My Digital Signature: footer.' };
+
+  return {
+    draftId: draftId,
+    toEmail: toEmail,
+    subject: subject,
+    submittedAt: submittedAt,
+    publicKey: publicKey,
+  };
+}
+
+function warmupTruncateKey_(k) {
+  var s = String(k || '');
+  if (s.length <= 60) return s;
+  return s.substring(0, 60) + '…';
+}
+
+function warmupAuditRowFromObject_(o) {
+  return [
+    o.updateId, o.submittedAt, o.publicKey, o.actorName, o.isActive,
+    o.draftId, o.recipient, o.subject,
+    o.status, o.sentMessageId, o.notes, o.processedAt,
+  ];
+}


### PR DESCRIPTION
## Summary
Two new GAS files in the **holistic_hit_list_store_history** Apps Script (script \`14gKJ0VW…\`, deployment \`AKfycbwoBqZnDS4JRRdFkxSXdlGt…\`) powering the new mobile triage view at \`dapp/warmup_review.html\`.

### \`WarmupReviewApi.gs\` (read-only)
\`?action=getWarmupReviewQueue\` — returns one JSON envelope joining:
- \`Email Agent Drafts\` rows where \`status=pending_review\` AND \`gmail_label=AI/Warm-up\`
- Hit List context (Hosts Circles, City/State, Notes) — joined by email or store_key
- DApp Remarks count per shop name (cold-first-touch flag)

### \`WarmupSendHandler.gs\` (write — signed send)
\`?action=apply_warmup_send\` — Edgar webhook entry. Scans Telegram Chat Logs for unprocessed \`[WARMUP SEND EVENT]\` rows; verifies the signer's public key is **ACTIVE** in Contributors Digital Signatures; parses \`draft_id\`; calls \`GmailApp.getDraft(id).send()\` (runs as script owner → ships from operator's Gmail). Outcomes logged to a new **Warmup Sends** audit tab on the Telegram-compilation spreadsheet, idempotent on both Telegram Update IDs and Gmail's own draft state.

### \`store_interaction_history_api.gs\` (canonical doGet)
Adds two new dispatcher branches that delegate to the new files.

## Repo conventions
\`.js\` files in \`clasp_mirrors/\` are gitignored — \`Code.js\` was clasp-pushed and deployed at v21. The reference \`.gs\` copies in \`google_app_scripts/holistic_hit_list_store_history/\` are the source of truth for git review.

## Verified live (2026-05-03)
\`\`\`
$ curl -sL '<DEPLOYMENT>/exec?action=getWarmupReviewQueue' | jq '.data.counts'
{
  "total": 77,
  "with_message_id": 76,
  "hit_list_indexed_email": 121,
  "hit_list_indexed_store": 665,
  "dapp_remarks_indexed": 626
}

$ curl -sL '<DEPLOYMENT>/exec?action=apply_warmup_send'
{"ok":true,"data":{"trigger":"edgar_webhook","processed":0,"skipped":0,"appended_rows":0}}
\`\`\`

## Companion PRs
- treasury-cache (\`warmup.send\` permission) #4 — merged
- go_to_market (\`gmail_message_id\` persistence) [#107](https://github.com/TrueSightDAO/go_to_market/pull/107) — merged
- sentiment_importer (Edgar \`[WARMUP SEND EVENT]\` dispatcher)
- dapp (\`warmup_review.html\` mobile page)

## Test plan
- [x] \`getWarmupReviewQueue\` returns expected drafts on live data.
- [x] \`apply_warmup_send\` dry-run on empty queue returns \`processed: 0\`.
- [ ] End-to-end smoke test from DApp page on phone (after sentiment_importer + dapp PRs ship).