### PR TITLE
feat(gas): warmup queue accepts ?label= + sent-draft filtering

### DIFF
--- a/clasp_mirrors/14gKJ0VW49RsSn4S03pgxKXy0sp4Z7Z3Wm1Wj8jQiWW5dj1sFuPnp95sh/WarmupReviewApi.gs
+++ b/clasp_mirrors/14gKJ0VW49RsSn4S03pgxKXy0sp4Z7Z3Wm1Wj8jQiWW5dj1sFuPnp95sh/WarmupReviewApi.gs
@@ -23,14 +23,26 @@
  */
 
 var WARMUP_DRAFTS_PENDING_STATUS = 'pending_review';
-var WARMUP_DRAFTS_LABEL = 'AI/Warm-up';
+var WARMUP_DEFAULT_LABEL = 'AI/Warm-up';
+var WARMUP_FOLLOWUP_LABEL = 'AI/Follow-up';
+var WARMUP_ALLOWED_LABELS = [WARMUP_DEFAULT_LABEL, WARMUP_FOLLOWUP_LABEL];
 var WARMUP_HOSTS_CIRCLES_HEADER = 'Hosts Circles';
 
-function getWarmupReviewQueue_() {
+/**
+ * Read-only triage queue for outbound drafts (warm-ups OR follow-ups).
+ * `label` selects which Gmail label / cohort to query — defaults to
+ * AI/Warm-up; pass AI/Follow-up to get the manager-follow-up cohort.
+ * Unknown values fall back to the default to keep the API forgiving.
+ */
+function getWarmupReviewQueue_(label) {
+  var requestedLabel = String(label || '').trim() || WARMUP_DEFAULT_LABEL;
+  if (WARMUP_ALLOWED_LABELS.indexOf(requestedLabel) === -1) {
+    requestedLabel = WARMUP_DEFAULT_LABEL;
+  }
   var ss = SpreadsheetApp.openById(HIT_LIST_SPREADSHEET_ID);
   var draftsSh = getSheetSafe_(ss, SHEET_EMAIL_DRAFTS);
   if (!draftsSh) {
-    return { drafts: [], counts: { total: 0, with_message_id: 0 } };
+    return { drafts: [], counts: { total: 0, with_message_id: 0 }, label: requestedLabel };
   }
 
   var draftsValues = draftsSh.getDataRange().getValues();
@@ -60,14 +72,38 @@ function getWarmupReviewQueue_() {
   var hitIndex = warmupBuildHitListIndex_(ss);
   var dappCounts = warmupBuildDappRemarksCounts_(ss);
 
+  // Filter out drafts that have already been sent. Three OR'd defenses:
+  //
+  //   1. GmailApp.getDrafts() — most current. If a draft id is no longer
+  //      in the operator's Gmail (sent OR deleted), hide it. Cheap: one
+  //      GmailApp call covers the whole batch.
+  //   2. "Warmup Sends" audit tab — DApp-side sends land here when
+  //      WarmupSendHandler.gs successfully ships a [WARMUP SEND EVENT].
+  //      Catches drafts whose Gmail-side state may not have flipped yet.
+  //   3. "Email Agent Follow Up" tab on the Hit List spreadsheet —
+  //      populated by sync_email_agent_followup.py (cron / manual).
+  //      Catches manual Gmail sends after sync runs. Joins on
+  //      gmail_message_id (stable across the draft → sent label flip).
+  //
+  // Sheet rows stuck at status='pending_review' that look sent on any
+  // of these get hidden. The next suggest_warmup_prospect_drafts.py
+  // cron tick reconciles them to 'discarded' on the source-of-truth
+  // sheet using the operator's local OAuth.
+  var liveDraftIds = warmupGetLiveDraftIdSet_();
+  var sentDraftIds = warmupReadSentDraftIds_();
+  var sentMessageIds = warmupReadSentMessageIds_(ss);
+
   var pending = [];
   var withMsgId = 0;
+  var skippedNotInGmail = 0;
+  var skippedSentDApp = 0;
+  var skippedSentManual = 0;
   for (var r = 1; r < draftsValues.length; r++) {
     var row = draftsValues[r];
     var status = (row[iStatus] || '').toString().trim();
     if (status !== WARMUP_DRAFTS_PENDING_STATUS) continue;
-    var label = (row[iLabel] || '').toString().trim();
-    if (label !== WARMUP_DRAFTS_LABEL) continue;
+    var rowLabel = (row[iLabel] || '').toString().trim();
+    if (rowLabel !== requestedLabel) continue;
 
     var em = ((row[iEmail] || '').toString().trim() || '').toLowerCase();
     var shop = (row[iShop] || '').toString().trim();
@@ -78,6 +114,19 @@ function getWarmupReviewQueue_() {
     var msgId = iMsgId === undefined ? '' : (row[iMsgId] || '').toString().trim();
     var hitRow = iHitRow === undefined ? '' : (row[iHitRow] || '').toString().trim();
     var createdAt = iCreated === undefined ? '' : (row[iCreated] || '').toString();
+
+    if (draftId && !liveDraftIds[draftId]) {
+      skippedNotInGmail++;
+      continue;
+    }
+    if (draftId && sentDraftIds[draftId]) {
+      skippedSentDApp++;
+      continue;
+    }
+    if (msgId && sentMessageIds[msgId]) {
+      skippedSentManual++;
+      continue;
+    }
 
     var hit = (em && hitIndex.byEmail[em])
         || (sk && hitIndex.byStoreKey[sk])
@@ -108,9 +157,16 @@ function getWarmupReviewQueue_() {
 
   return {
     drafts: pending,
+    label: requestedLabel,
     counts: {
       total: pending.length,
+      skipped_not_in_gmail: skippedNotInGmail,
+      skipped_sent_via_dapp: skippedSentDApp,
+      skipped_sent_via_gmail: skippedSentManual,
       with_message_id: withMsgId,
+      live_gmail_drafts: Object.keys(liveDraftIds).length,
+      sent_audit_indexed: Object.keys(sentDraftIds).length,
+      followup_log_indexed: Object.keys(sentMessageIds).length,
       hit_list_indexed_email: Object.keys(hitIndex.byEmail).length,
       hit_list_indexed_store: Object.keys(hitIndex.byStoreKey).length,
       dapp_remarks_indexed: Object.keys(dappCounts).length,
@@ -118,6 +174,88 @@ function getWarmupReviewQueue_() {
     generated_at_utc: new Date().toISOString(),
   };
 }
+
+/**
+ * One bulk GmailApp.getDrafts() call → set of currently-alive draft ids.
+ * Returns an object keyed by draft id (used as a Set surrogate). Empty
+ * object on error so callers don't blow up — they fall through to the
+ * sheet-based filters below. Runs as the GAS script owner so the
+ * Gmail-side draft list reflects whatever account that owner is.
+ */
+function warmupGetLiveDraftIdSet_() {
+  try {
+    var drafts = GmailApp.getDrafts();
+    var out = {};
+    for (var i = 0; i < drafts.length; i++) {
+      var id = drafts[i].getId();
+      if (id) out[id] = true;
+    }
+    return out;
+  } catch (err) {
+    Logger.log('warmupGetLiveDraftIdSet_ failed: ' + err);
+    return {};
+  }
+}
+
+/**
+ * Set of draft ids that the WarmupSendHandler has successfully shipped.
+ * Lives on the "Warmup Sends" audit tab of the Telegram-compilation
+ * spreadsheet (1qbZZhf-…). Status column = col 9 (1-based); only 'sent'
+ * rows count as terminal-sent. Returns an object keyed by draft id
+ * (used as a Set surrogate) — empty object on error / sheet missing.
+ */
+function warmupReadSentDraftIds_() {
+  try {
+    var ss = SpreadsheetApp.openById('1qbZZhf-_7xzmDTriaJVWj6OZshyQsFkdsAV8-pyzASQ');
+    var ws = ss.getSheetByName('Warmup Sends');
+    if (!ws) return {};
+    var last = ws.getLastRow();
+    if (last < 2) return {};
+    // Columns A..L per WARMUP_AUDIT_HEADERS (warmup_send_handler.gs).
+    var data = ws.getRange(2, 1, last - 1, 12).getValues();
+    var out = {};
+    for (var i = 0; i < data.length; i++) {
+      var draftId = String(data[i][5] || '').trim();   // col F (1-based 6) — Draft ID
+      var status = String(data[i][8] || '').trim().toLowerCase();  // col I — Status
+      if (draftId && status === 'sent') out[draftId] = true;
+    }
+    return out;
+  } catch (err) {
+    Logger.log('warmupReadSentDraftIds_ failed: ' + err);
+    return {};
+  }
+}
+
+/**
+ * Set of message ids that have been logged as sent in the "Email Agent
+ * Follow Up" tab on the Hit List spreadsheet — populated by
+ * sync_email_agent_followup.py (cron / manual). Catches manual Gmail
+ * sends after the operator runs sync. Joins on gmail_message_id, which
+ * is stable across the draft → sent label flip.
+ */
+function warmupReadSentMessageIds_(ss) {
+  try {
+    var ws = ss.getSheetByName('Email Agent Follow Up');
+    if (!ws) return {};
+    var values = ws.getDataRange().getValues();
+    if (values.length < 2) return {};
+    var hdr = headerMap_(values[0]);
+    // Column name varies across schema generations — check both.
+    var idx = hdr['message_id'];
+    if (idx === undefined) idx = hdr['gmail_message_id'];
+    if (idx === undefined) return {};
+    var out = {};
+    for (var i = 1; i < values.length; i++) {
+      var mid = String(values[i][idx] || '').trim();
+      if (mid) out[mid] = true;
+    }
+    return out;
+  } catch (err) {
+    Logger.log('warmupReadSentMessageIds_ failed: ' + err);
+    return {};
+  }
+}
+
 
 function warmupBuildHitListIndex_(ss) {
   var sh = getSheetSafe_(ss, SHEET_HIT_LIST);

--- a/google_app_scripts/holistic_hit_list_store_history/store_interaction_history_api.gs
+++ b/google_app_scripts/holistic_hit_list_store_history/store_interaction_history_api.gs
@@ -839,8 +839,12 @@ function doGet(e) {
 
     if (action === 'getWarmupReviewQueue') {
       // Read-only triage queue powering dapp/warmup_review.html.
+      // Optional ?label= filters by Gmail label cohort:
+      //   AI/Warm-up   (default — first-touch warm-ups)
+      //   AI/Follow-up (manager follow-ups to replied prospects)
       // Implementation: warmup_review_api.gs (clasp_mirrors/.../WarmupReviewApi.gs).
-      return success_(getWarmupReviewQueue_());
+      var lbl = (e.parameter.label || '').toString();
+      return success_(getWarmupReviewQueue_(lbl));
     }
 
     if (action === 'apply_warmup_send') {

--- a/google_app_scripts/holistic_hit_list_store_history/warmup_review_api.gs
+++ b/google_app_scripts/holistic_hit_list_store_history/warmup_review_api.gs
@@ -23,14 +23,26 @@
  */
 
 var WARMUP_DRAFTS_PENDING_STATUS = 'pending_review';
-var WARMUP_DRAFTS_LABEL = 'AI/Warm-up';
+var WARMUP_DEFAULT_LABEL = 'AI/Warm-up';
+var WARMUP_FOLLOWUP_LABEL = 'AI/Follow-up';
+var WARMUP_ALLOWED_LABELS = [WARMUP_DEFAULT_LABEL, WARMUP_FOLLOWUP_LABEL];
 var WARMUP_HOSTS_CIRCLES_HEADER = 'Hosts Circles';
 
-function getWarmupReviewQueue_() {
+/**
+ * Read-only triage queue for outbound drafts (warm-ups OR follow-ups).
+ * `label` selects which Gmail label / cohort to query — defaults to
+ * AI/Warm-up; pass AI/Follow-up to get the manager-follow-up cohort.
+ * Unknown values fall back to the default to keep the API forgiving.
+ */
+function getWarmupReviewQueue_(label) {
+  var requestedLabel = String(label || '').trim() || WARMUP_DEFAULT_LABEL;
+  if (WARMUP_ALLOWED_LABELS.indexOf(requestedLabel) === -1) {
+    requestedLabel = WARMUP_DEFAULT_LABEL;
+  }
   var ss = SpreadsheetApp.openById(HIT_LIST_SPREADSHEET_ID);
   var draftsSh = getSheetSafe_(ss, SHEET_EMAIL_DRAFTS);
   if (!draftsSh) {
-    return { drafts: [], counts: { total: 0, with_message_id: 0 } };
+    return { drafts: [], counts: { total: 0, with_message_id: 0 }, label: requestedLabel };
   }
 
   var draftsValues = draftsSh.getDataRange().getValues();
@@ -60,14 +72,38 @@ function getWarmupReviewQueue_() {
   var hitIndex = warmupBuildHitListIndex_(ss);
   var dappCounts = warmupBuildDappRemarksCounts_(ss);
 
+  // Filter out drafts that have already been sent. Three OR'd defenses:
+  //
+  //   1. GmailApp.getDrafts() — most current. If a draft id is no longer
+  //      in the operator's Gmail (sent OR deleted), hide it. Cheap: one
+  //      GmailApp call covers the whole batch.
+  //   2. "Warmup Sends" audit tab — DApp-side sends land here when
+  //      WarmupSendHandler.gs successfully ships a [WARMUP SEND EVENT].
+  //      Catches drafts whose Gmail-side state may not have flipped yet.
+  //   3. "Email Agent Follow Up" tab on the Hit List spreadsheet —
+  //      populated by sync_email_agent_followup.py (cron / manual).
+  //      Catches manual Gmail sends after sync runs. Joins on
+  //      gmail_message_id (stable across the draft → sent label flip).
+  //
+  // Sheet rows stuck at status='pending_review' that look sent on any
+  // of these get hidden. The next suggest_warmup_prospect_drafts.py
+  // cron tick reconciles them to 'discarded' on the source-of-truth
+  // sheet using the operator's local OAuth.
+  var liveDraftIds = warmupGetLiveDraftIdSet_();
+  var sentDraftIds = warmupReadSentDraftIds_();
+  var sentMessageIds = warmupReadSentMessageIds_(ss);
+
   var pending = [];
   var withMsgId = 0;
+  var skippedNotInGmail = 0;
+  var skippedSentDApp = 0;
+  var skippedSentManual = 0;
   for (var r = 1; r < draftsValues.length; r++) {
     var row = draftsValues[r];
     var status = (row[iStatus] || '').toString().trim();
     if (status !== WARMUP_DRAFTS_PENDING_STATUS) continue;
-    var label = (row[iLabel] || '').toString().trim();
-    if (label !== WARMUP_DRAFTS_LABEL) continue;
+    var rowLabel = (row[iLabel] || '').toString().trim();
+    if (rowLabel !== requestedLabel) continue;
 
     var em = ((row[iEmail] || '').toString().trim() || '').toLowerCase();
     var shop = (row[iShop] || '').toString().trim();
@@ -78,6 +114,19 @@ function getWarmupReviewQueue_() {
     var msgId = iMsgId === undefined ? '' : (row[iMsgId] || '').toString().trim();
     var hitRow = iHitRow === undefined ? '' : (row[iHitRow] || '').toString().trim();
     var createdAt = iCreated === undefined ? '' : (row[iCreated] || '').toString();
+
+    if (draftId && !liveDraftIds[draftId]) {
+      skippedNotInGmail++;
+      continue;
+    }
+    if (draftId && sentDraftIds[draftId]) {
+      skippedSentDApp++;
+      continue;
+    }
+    if (msgId && sentMessageIds[msgId]) {
+      skippedSentManual++;
+      continue;
+    }
 
     var hit = (em && hitIndex.byEmail[em])
         || (sk && hitIndex.byStoreKey[sk])
@@ -108,9 +157,16 @@ function getWarmupReviewQueue_() {
 
   return {
     drafts: pending,
+    label: requestedLabel,
     counts: {
       total: pending.length,
+      skipped_not_in_gmail: skippedNotInGmail,
+      skipped_sent_via_dapp: skippedSentDApp,
+      skipped_sent_via_gmail: skippedSentManual,
       with_message_id: withMsgId,
+      live_gmail_drafts: Object.keys(liveDraftIds).length,
+      sent_audit_indexed: Object.keys(sentDraftIds).length,
+      followup_log_indexed: Object.keys(sentMessageIds).length,
       hit_list_indexed_email: Object.keys(hitIndex.byEmail).length,
       hit_list_indexed_store: Object.keys(hitIndex.byStoreKey).length,
       dapp_remarks_indexed: Object.keys(dappCounts).length,
@@ -118,6 +174,88 @@ function getWarmupReviewQueue_() {
     generated_at_utc: new Date().toISOString(),
   };
 }
+
+/**
+ * One bulk GmailApp.getDrafts() call → set of currently-alive draft ids.
+ * Returns an object keyed by draft id (used as a Set surrogate). Empty
+ * object on error so callers don't blow up — they fall through to the
+ * sheet-based filters below. Runs as the GAS script owner so the
+ * Gmail-side draft list reflects whatever account that owner is.
+ */
+function warmupGetLiveDraftIdSet_() {
+  try {
+    var drafts = GmailApp.getDrafts();
+    var out = {};
+    for (var i = 0; i < drafts.length; i++) {
+      var id = drafts[i].getId();
+      if (id) out[id] = true;
+    }
+    return out;
+  } catch (err) {
+    Logger.log('warmupGetLiveDraftIdSet_ failed: ' + err);
+    return {};
+  }
+}
+
+/**
+ * Set of draft ids that the WarmupSendHandler has successfully shipped.
+ * Lives on the "Warmup Sends" audit tab of the Telegram-compilation
+ * spreadsheet (1qbZZhf-…). Status column = col 9 (1-based); only 'sent'
+ * rows count as terminal-sent. Returns an object keyed by draft id
+ * (used as a Set surrogate) — empty object on error / sheet missing.
+ */
+function warmupReadSentDraftIds_() {
+  try {
+    var ss = SpreadsheetApp.openById('1qbZZhf-_7xzmDTriaJVWj6OZshyQsFkdsAV8-pyzASQ');
+    var ws = ss.getSheetByName('Warmup Sends');
+    if (!ws) return {};
+    var last = ws.getLastRow();
+    if (last < 2) return {};
+    // Columns A..L per WARMUP_AUDIT_HEADERS (warmup_send_handler.gs).
+    var data = ws.getRange(2, 1, last - 1, 12).getValues();
+    var out = {};
+    for (var i = 0; i < data.length; i++) {
+      var draftId = String(data[i][5] || '').trim();   // col F (1-based 6) — Draft ID
+      var status = String(data[i][8] || '').trim().toLowerCase();  // col I — Status
+      if (draftId && status === 'sent') out[draftId] = true;
+    }
+    return out;
+  } catch (err) {
+    Logger.log('warmupReadSentDraftIds_ failed: ' + err);
+    return {};
+  }
+}
+
+/**
+ * Set of message ids that have been logged as sent in the "Email Agent
+ * Follow Up" tab on the Hit List spreadsheet — populated by
+ * sync_email_agent_followup.py (cron / manual). Catches manual Gmail
+ * sends after the operator runs sync. Joins on gmail_message_id, which
+ * is stable across the draft → sent label flip.
+ */
+function warmupReadSentMessageIds_(ss) {
+  try {
+    var ws = ss.getSheetByName('Email Agent Follow Up');
+    if (!ws) return {};
+    var values = ws.getDataRange().getValues();
+    if (values.length < 2) return {};
+    var hdr = headerMap_(values[0]);
+    // Column name varies across schema generations — check both.
+    var idx = hdr['message_id'];
+    if (idx === undefined) idx = hdr['gmail_message_id'];
+    if (idx === undefined) return {};
+    var out = {};
+    for (var i = 1; i < values.length; i++) {
+      var mid = String(values[i][idx] || '').trim();
+      if (mid) out[mid] = true;
+    }
+    return out;
+  } catch (err) {
+    Logger.log('warmupReadSentMessageIds_ failed: ' + err);
+    return {};
+  }
+}
+
 
 function warmupBuildHitListIndex_(ss) {
   var sh = getSheetSafe_(ss, SHEET_HIT_LIST);


### PR DESCRIPTION
## Summary
Two upgrades to the warmup review queue powering the DApp **Outbound Review** page:

### 1. `?label=` cohort selector
Default \`AI/Warm-up\`; accepts \`AI/Follow-up\`. Replaces the hardcoded label with a sanitized parameter so the same GAS endpoint serves both first-touch warm-ups and manager follow-ups. The DApp page now has a tab toggle for both. Same data shape, same 12 lint rules, same Send action — just a different Gmail label filter on the underlying \`Email Agent Drafts\` pending_review rows.

### 2. Three-source ghost filter
Drafts whose Gmail-side state is gone (operator already sent / deleted) but whose sheet status is still \`pending_review\` get hidden via OR of:

- **\`GmailApp.getDrafts()\`** set membership — most current; runs as the script owner so reflects whatever Gmail account that owner is.
- **Warmup Sends audit tab** — DApp-side sends land here when \`WarmupSendHandler.gs\` ships a draft.
- **Email Agent Follow Up tab** — joins on \`gmail_message_id\`, catches manual Gmail sends after \`sync_email_agent_followup.py\` runs.

Counts surface \`skipped_not_in_gmail\` / \`skipped_sent_via_dapp\` / \`skipped_sent_via_gmail\` for diagnostics.

## Verified live (2026-05-03 @v25)
\`\`\`
$ curl '...exec?action=getWarmupReviewQueue'
{"label": "AI/Warm-up", "counts": {"total": 0, "skipped_not_in_gmail": 77, ...}}

$ curl '...exec?action=getWarmupReviewQueue&label=AI/Follow-up'
{"label": "AI/Follow-up", "counts": {"total": 0, "skipped_not_in_gmail": 19, ...}}
\`\`\`
Both clean — operator sent everything today.

## Companion PR
- \`dapp\` — Outbound Review tab toggle + clickable filter chips + chrome fixes.