### PR TITLE
fix(pipeline-metrics): coerce TIME-cast Date cells back to integer counts

### DIFF
--- a/google_app_scripts/pipeline_metrics_snapshot/sync_pipeline_metrics.gs
+++ b/google_app_scripts/pipeline_metrics_snapshot/sync_pipeline_metrics.gs
@@ -287,6 +287,21 @@ function _headerMapPipeline_(headerRow) {
 
 function _touchCountPipeline_(v) {
   if (v === '' || v === null || v === undefined) return 0;
+  // Hit List columns AU/AV are integer COUNTIFS results, but a stale TIME
+  // number-format leaked from neighbouring weekday-hours columns can survive
+  // on rows appended before that bug was fixed. SpreadsheetApp.getValues()
+  // surfaces TIME-formatted cells as JS Date objects, so parseFloat(String(v))
+  // would silently yield NaN and the count would collapse to 0 — which is how
+  // 32 stores were previously miscounted as "never warmed-up" in
+  // ADVISORY_SNAPSHOT.md. Detect Dates here and recover the underlying serial.
+  if (v instanceof Date) {
+    var ms = v.getTime();
+    if (!isFinite(ms)) return 0;
+    var sheetEpoch = Date.UTC(1899, 11, 30); // Sheets day 0
+    var n = Math.round((ms - sheetEpoch) / 86400000);
+    if (!isFinite(n) || n < 0) return 0;
+    return Math.floor(n);
+  }
   var n = parseFloat(String(v).trim().replace(/,/g, ''));
   if (isNaN(n) || n < 0) return 0;
   return Math.floor(n);


### PR DESCRIPTION
## Summary

- Defense-in-depth patch for the GAS that powers \`metrics/weekly.md\` (read by \`generate_advisory_snapshot.py\` and embedded in \`ADVISORY_SNAPSHOT.md\`).
- \`_touchCountPipeline_\` now recognizes JS \`Date\` instances returned by \`getValues()\` for TIME-formatted cells and recovers the underlying integer serial.

## Why

Hit List columns AU (Warm-up email sent) and AV (Follow-up emails sent) hold \`COUNTIFS\` results — integers. A stale \`{type: TIME, pattern: 'h:mm'}\` number-format leaked from the neighbouring weekday-hours columns onto rows appended before the format audit. \`SpreadsheetApp.getValues()\` surfaces TIME-formatted cells as JS \`Date\` objects, and \`parseFloat(String(date))\` returns \`NaN\` → the GAS counted those cells as 0.

Result: 32 Hit List rows in \`AI: Warm up prospect\` with a real AU value of \`2\` were aggregated as \"never warmed-up\" — bubbling up through \`metrics/weekly.md\` into \`ADVISORY_SNAPSHOT.md\` as the fictional \"50 of 79 stores have zero logged warm-up sends\" claim that the oracle flagged on 2026-05-09.

## What's already fixed (live)

The Hit List cell formats themselves were reset to \`{type: NUMBER, pattern: '0'}\` via a one-shot \`batchUpdate\` (covering AU2:AV669, all 668 data rows). Live data is correct on the next snapshot run today.

This PR hardens the GAS for **defense in depth**: if any future format leak re-surfaces TIME-cast cells (e.g. row inserts that copy formatting from above), the snapshot stays numerically correct.

## Implementation

\`\`\`js
if (v instanceof Date) {
  var ms = v.getTime();
  if (!isFinite(ms)) return 0;
  var sheetEpoch = Date.UTC(1899, 11, 30); // Sheets day 0
  var n = Math.round((ms - sheetEpoch) / 86400000);
  if (!isFinite(n) || n < 0) return 0;
  return Math.floor(n);
}
\`\`\`

## Deploy

- \`clasp push\` on script id \`11fA8NXSOwKyddXDZmmx3BRCDU1Y38GVidENCj0mujH0pT-AqIoOyaetj\` from the local clasp_mirror.
- Daily 06:00 trigger picks up the new code on its next run.

## Test plan

- [x] No syntax errors in the GAS file.
- [x] Existing \`parseFloat\` path unchanged for non-Date values.
- [ ] After clasp push: run \`syncPipelineMetrics()\` once from the editor; confirm \`metrics/weekly.json\` outreach_visibility cohorts match the live UNFORMATTED values (\`AU=0: 5\`, \`AU=1: 5\`, \`AU=2: 65\`, \`AU=3: 4\` for warm-up bucket).
- [ ] After next 06:00 trigger: \`ecosystem_change_logs/metrics/weekly.md\` shows the corrected depth distribution.

## Related

- Companion PR in \`go_to_market\` blocks the upstream cause: rows landing in warm-up with \`filler@godaddy.com\` placeholders → see \`fix/promote-skip-filler-email\`.
- Audit body for the full investigation chain: 2026-05-09 \`[CONTRIBUTION EVENT]\` "Hit List warm-up audit — TIME-format bug masking 32 phantom AU=0".