### PR TITLE
currency_conversion: fix Ledger URL parser + harden offchain write path

### DIFF
--- a/google_app_scripts/tdg_asset_management/currency_conversion_processing.gs
+++ b/google_app_scripts/tdg_asset_management/currency_conversion_processing.gs
@@ -104,7 +104,10 @@ function parseCurrencyConversionMessage(message) {
     const ledgerNameMatch = message.match(/- Ledger:\s*([^\n]+)/i);
     if (ledgerNameMatch) details.ledgerName = ledgerNameMatch[1].trim();
 
-    const ledgerUrlMatch = message.match(/- Ledger URL:\s*([^\n]+)/i);
+    // Ledger URL is intentionally empty for offchain (Main Ledger) submissions.
+    // Use [ \t]* (not \s*) so we don't eat the newline, and * (not +) on the
+    // capture so an empty value matches as '' instead of grabbing the next line.
+    const ledgerUrlMatch = message.match(/- Ledger URL:[ \t]*([^\n]*)/i);
     if (ledgerUrlMatch) details.ledgerUrl = ledgerUrlMatch[1].trim();
 
     const warehouseManagerMatch = message.match(/- Warehouse Manager:\s*([^\n]+)/i);
@@ -339,8 +342,18 @@ function processNewCurrencyConversions() {
         var debitRow = managedLedger
           ? [conversionDate, logMessage, warehouseManager, sourceAmount * -1, sourceCurrency, 'Assets']
           : [conversionDate, logMessage, warehouseManager, sourceAmount * -1, sourceCurrency];
+
+        // Capture lastRow BEFORE appending so we can assert appendRow actually
+        // grew the sheet — otherwise we'd silently mark the intake row as
+        // PROCESSED with garbage line numbers (the 2026-05-11 incident: status
+        // PROCESSED, ledger_lines='3297,3297', target sheet untouched).
+        const beforeAppendLastRow = transactionsSheet.getLastRow();
         transactionsSheet.appendRow(debitRow);
+        SpreadsheetApp.flush();
         const debitRowNumber = transactionsSheet.getLastRow();
+        if (debitRowNumber <= beforeAppendLastRow) {
+          throw new Error(`appendRow did not grow ${targetSheetName} — lastRow stayed at ${beforeAppendLastRow}. Possible silent permission failure on ${targetSpreadsheetUrl}.`);
+        }
         Logger.log(`✅ Inserted ${sourceCurrency} debit (${sourceAmount * -1}) for ${warehouseManager} at ${targetSheetName} row ${debitRowNumber}`);
 
         // Row 2: Target credit (asset increase → positive amount).
@@ -348,12 +361,22 @@ function processNewCurrencyConversions() {
           ? [conversionDate, logMessage, warehouseManager, targetAmount, targetCurrency, 'Assets']
           : [conversionDate, logMessage, warehouseManager, targetAmount, targetCurrency];
         transactionsSheet.appendRow(creditRow);
+        SpreadsheetApp.flush();
         const creditRowNumber = transactionsSheet.getLastRow();
+        if (creditRowNumber <= debitRowNumber) {
+          throw new Error(`appendRow did not grow ${targetSheetName} for credit row — lastRow stayed at ${debitRowNumber}.`);
+        }
         Logger.log(`✅ Inserted ${targetCurrency} credit (+${targetAmount}) for ${warehouseManager} at ${targetSheetName} row ${creditRowNumber}`);
 
         const ledgerLines = `${debitRowNumber},${creditRowNumber}`;
         sheet.getRange(rowNumber, CC_STATUS_COL + 1).setValue('PROCESSED');
-        sheet.getRange(rowNumber, CC_LEDGER_LINES_COL + 1).setValue(ledgerLines);
+        // Force the Ledger Lines cell to text format BEFORE writing — otherwise
+        // a value like '3298,3299' gets parsed by Sheets as the number 32983299
+        // (en-US thousands-separator interpretation) and the audit row stops
+        // pointing at recoverable line numbers.
+        sheet.getRange(rowNumber, CC_LEDGER_LINES_COL + 1)
+          .setNumberFormat('@')
+          .setValue(ledgerLines);
 
         Logger.log(`✅ Successfully processed ${managedLedger ? 'managed' : 'offchain'} currency conversion - ${targetSheetName} lines: ${ledgerLines}`);
         processedCount++;


### PR DESCRIPTION
## Summary
Three connected fixes for the 2026-05-11 audit incident where an offchain currency conversion (Kirsten Ritschel repackaging) landed `Status=PROCESSED` in the Currency Conversion intake sheet but the actual debit+credit rows never appeared in the Main Ledger's `offchain transactions` tab. The audit row's `Ledger URL` column had also been "set" to the next line of the payload.

### 1. Ledger URL regex bug
- Old: `/- Ledger URL:\s*([^\n]+)/i`
- `\s*` matches newlines, so for empty values (`- Ledger URL: \n- Warehouse Manager:...`) it consumed the newline and `[^\n]+` greedily grabbed the next line as the value.
- Fix: `/- Ledger URL:[ \t]*([^\n]*)/i` — match only spaces/tabs (not newlines), allow empty capture.

### 2. Silent appendRow noop → false PROCESSED
- When `appendRow()` silently failed to grow the sheet, `getLastRow()` returned the pre-append row twice, producing `ledger_lines='N,N'` AND a PROCESSED status.
- Fix: capture `beforeAppendLastRow`, `SpreadsheetApp.flush()` after each append, assert `getLastRow()` actually grew, throw on noop so the catch block flips status to FAILED instead.

### 3. Ledger Lines column auto-parsed as number
- Column O inherited `#,##0` number format; `setValue('3298,3299')` got parsed by Sheets en-US as the integer `32983299`, losing the recoverable row-pair.
- Fix: `.setNumberFormat('@').setValue(ledgerLines)` so the cell stays text.

## Already deployed
- `clasp push` to project `1orWgdGckts...UfJ0JZC5J` (live now; deployment ID stable).
- Column O on the Currency Conversion intake sheet set to plain text format via batch update.
- Two existing audit rows had their bad `Ledger URL` value (`"- Warehouse Manager: ..."`) cleared.

## Follow-up not in this PR
- The two intake rows from 2026-05-11 are marked `Status=PROCESSED` but the data never reached the Main Ledger. Resetting them to `NEW` would let the next trigger reprocess (now safely — the new code throws on silent noop instead of marking PROCESSED).

## Test plan
- [ ] Submit a new offchain currency conversion via dapp → confirm audit row's Ledger URL is empty (not the next line)
- [ ] Confirm Status flips to PROCESSED only after debit + credit rows actually land in `offchain transactions`
- [ ] Confirm Ledger Lines Number column displays as `3298,3299` (text) instead of `32,983,299` (number)