### PR TITLE
Partner Check-in backend: scanner + Shipping Planner API + SCHEMA

### DIFF
--- a/SCHEMA.md
+++ b/SCHEMA.md
@@ -1168,6 +1168,37 @@ See [`python_scripts/schema_validation/README.md`](./python_scripts/schema_valid
 
 ---
 
+##### Sheet: `Partner Check-ins`
+**Purpose:** Signed audit trail of periodic check-ins with Agroverse retail partners. Each row is one `[PARTNER CHECK-IN EVENT]` submitted via the DApp (`partner_check_in.html`) or CLI (`dao_client check_in_partner`), verified by Edgar, and appended by the GAS scanner `processPartnerCheckInsFromTelegramChatLogs`.
+
+**Sheet URL:** https://docs.google.com/spreadsheets/d/1GE7PUq-UT6x2rBN-Q2ksogbWpgyuh2SaxJyG_uEK6PU/edit
+
+**Header Row:** 1
+
+| Column | Name | Type | Description |
+|--------|------|------|-------------|
+| A | `Submitted At` | ISO 8601 datetime | When the scanner appended the row. |
+| B | `Partner ID` | String | Slug from `Agroverse Partners`!A. |
+| C | `Contributor Name` | String | From `Contributors contact information`!A. |
+| D | `Check-in Date` | Date (`YYYY-MM-DD`) | When the check-in happened. |
+| E | `Method` | String | Dropdown: `Text`, `Phone`, `In Person`, `Email`, `Other`. |
+| F | `Stock Status` | String | Dropdown: `Low`, `Out`, `OK`, `Unknown`. |
+| G | `Restock Needed` | String | Dropdown: `Yes`, `No`, `Maybe`. |
+| H | `Restock Quantity` | Number | Integer (nullable). Only meaningful when `Restock Needed = Yes`. |
+| I | `Next Check-in Date` | Date (`YYYY-MM-DD`) | Operator's scheduled follow-up (nullable). |
+| J | `Notes` | String | Free-form remark, capped at 2000 chars by scanner. |
+| K | `Update ID` | String | `PCI_…` — dedup key. Unique per event (scanner-enforced). |
+| L | `Digital Signature` | String | Public key (first 64 chars) of the signer. |
+| M | `Submitted By` | String | Resolved contributor name from signature lookup. |
+| N | `Restock SKU` | String | SKU slug the partner asked to restock (e.g. `8-ounce-organic-cacao-nibs`), drawn from `partners-velocity.json` items. `Other` if the partner asked for a SKU they don't currently carry — disambiguate in `Notes`. Only meaningful when `Restock Needed = Yes`. Nullable. |
+
+**Used by:**
+- [`dapp/partner_check_in.html`](https://github.com/TrueSightDAO/dapp/blob/main/partner_check_in.html) — reads history via Shipping Planner `?action=get_partner_check_ins`.
+- [`tokenomics/google_app_scripts/tdg_shipping_planner/shipping_planner_api.gs`](https://github.com/TrueSightDAO/tokenomics/blob/main/google_app_scripts/tdg_shipping_planner/shipping_planner_api.gs) — `getPartnerCheckIns` and `listPartnersNeedingAttention` helpers.
+- [`tokenomics/google_app_scripts/find_nearby_stores/process_partner_check_in_telegram_logs.gs`](https://github.com/TrueSightDAO/tokenomics/blob/main/google_app_scripts/find_nearby_stores/process_partner_check_in_telegram_logs.gs) — scanner that writes rows here.
+
+---
+
 ##### Sheet: `Currencies`
 **Purpose:** Master list of currencies and product metadata
 

--- a/google_app_scripts/find_nearby_stores/process_partner_check_in_telegram_logs.gs
+++ b/google_app_scripts/find_nearby_stores/process_partner_check_in_telegram_logs.gs
@@ -1,0 +1,238 @@
+/**
+ * File: google_app_scripts/find_nearby_stores/process_partner_check_in_telegram_logs.gs
+ * Repository: https://github.com/TrueSightDAO/tokenomics
+ *
+ * Description: Async scanner for `[PARTNER CHECK-IN EVENT]` rows on the canonical
+ *   **Telegram Chat Logs** intake (`1qbZZhf-_7xzmDTriaJVWj6OZshyQsFkdsAV8-pyzASQ`).
+ *
+ *   Edgar writes the signed payload into Telegram Chat Logs col G, then enqueues a
+ *   webhook to this script (`?action=processPartnerCheckInsFromTelegramChatLogs`).
+ *
+ *   For each Telegram log row whose `Update ID` (PCI_…) is not yet present in
+ *   **Partner Check-ins** col K on the Main Ledger, this scanner appends one row A–M.
+ *
+ *   The append also serves as the dedup log for future runs (idempotent).
+ *
+ * Mirror canonicalization status:
+ *   This file is canonical. Copy to the clasp mirror as `.js` before pushing.
+ *   Also add a `?action=processPartnerCheckInsFromTelegramChatLogs` branch to
+ *   the mirror's `doGet` (Code.js).
+ *
+ *   Sync command (run from `tokenomics/`):
+ *     cp google_app_scripts/find_nearby_stores/process_partner_check_in_telegram_logs.gs \
+ *        clasp_mirrors/1NpHrKJW8Q4suu6-f5gXQcbjHqUZtGOG-KcIf81M1GG8lDShm5-fLphD2/process_partner_check_in_telegram_logs.js
+ */
+
+/** Telegram Chat Logs intake spreadsheet (Edgar writes col G of every signed event here). */
+var TELEGRAM_CHAT_LOGS_SPREADSHEET_ID = '1qbZZhf-_7xzmDTriaJVWj6OZshyQsFkdsAV8-pyzASQ';
+var TELEGRAM_CHAT_LOGS_SHEET = 'Telegram Chat Logs';
+/** Telegram Chat Logs col G (zero-based 6) — signed event text Edgar wrote. */
+var TELEGRAM_CHAT_LOGS_MESSAGE_COL = 6;
+/** Per-fire scan window. */
+var PARTNER_CHECK_IN_SCAN_BATCH = 200;
+
+/** Main Ledger spreadsheet where Partner Check-ins tab lives. */
+var MAIN_LEDGER_SPREADSHEET_ID = '1GE7PUq-UT6x2rBN-Q2ksogbWpgyuh2SaxJyG_uEK6PU';
+var PARTNER_CHECK_INS_SHEET = 'Partner Check-ins';
+
+/**
+ * Parse a `[PARTNER CHECK-IN EVENT]` body into a key→value map.
+ * @param {string} text
+ * @return {Object<string,string>}
+ */
+function parsePartnerCheckInText_(text) {
+  var result = {};
+  if (!text) return result;
+  var body = String(text).split('--------', 1)[0] || String(text);
+  var lines = body.split(/\r?\n/);
+  for (var i = 0; i < lines.length; i++) {
+    var line = (lines[i] || '').trim();
+    if (!line) continue;
+    if (line.indexOf('[PARTNER CHECK-IN EVENT]') === 0) continue;
+    if (line.charAt(0) === '-') line = line.substring(1).trim();
+    var m = line.match(/^([A-Za-z][A-Za-z0-9_\s\/\-]*):\s*(.*)$/);
+    if (!m) continue;
+    var key = m[1].trim().toLowerCase().replace(/\s+/g, '_');
+    result[key] = m[2].trim();
+  }
+  return result;
+}
+
+/**
+ * Pull the contributor public key from the signed payload.
+ * @param {string} text
+ * @return {string}
+ */
+function extractMyDigitalSignatureFromText_(text) {
+  if (!text) return '';
+  var m = String(text).match(/My Digital Signature:\s*([^\n\r]+)/);
+  return m ? m[1].trim() : '';
+}
+
+/**
+ * Ensure the Partner Check-ins sheet exists on the Main Ledger.
+ * @param {Spreadsheet} ss
+ * @return {Sheet}
+ */
+function ensurePartnerCheckInsSheet_(ss) {
+  var sheet = ss.getSheetByName(PARTNER_CHECK_INS_SHEET);
+  if (sheet) return sheet;
+  sheet = ss.insertSheet(PARTNER_CHECK_INS_SHEET);
+  var headers = [
+    'Submitted At',
+    'Partner ID',
+    'Contributor Name',
+    'Check-in Date',
+    'Method',
+    'Stock Status',
+    'Restock Needed',
+    'Restock Quantity',
+    'Next Check-in Date',
+    'Notes',
+    'Update ID',
+    'Digital Signature',
+    'Submitted By',
+    'Restock SKU'
+  ];
+  sheet.appendRow(headers);
+  sheet.getRange(1, 1, 1, headers.length).setFontWeight('bold');
+  return sheet;
+}
+
+/**
+ * Append one row to Partner Check-ins.
+ * @param {Object} fields
+ */
+function appendPartnerCheckInRow_(fields) {
+  var ss = SpreadsheetApp.openById(MAIN_LEDGER_SPREADSHEET_ID);
+  var sheet = ensurePartnerCheckInsSheet_(ss);
+  var now = new Date().toISOString();
+  sheet.appendRow([
+    now,
+    fields.partner_id || '',
+    fields.contributor_name || '',
+    fields.check_in_date || '',
+    fields.method || '',
+    fields.stock_status || '',
+    fields.restock_needed || '',
+    fields.restock_quantity || '',
+    fields.next_check_in_date || '',
+    fields.notes || '',
+    fields.update_id || '',
+    fields.digital_signature || '',
+    fields.submitted_by || '',
+    fields.restock_sku || ''
+  ]);
+}
+
+/**
+ * HTTP / time-driven entry point.
+ * Idempotent: dedup is keyed on `Update ID` (col K) of **Partner Check-ins**.
+ * @return {{success:boolean, processed?:number, skipped?:number, errors?:number, error?:string}}
+ */
+function processPartnerCheckInsFromTelegramChatLogs() {
+  var lock = LockService.getScriptLock();
+  if (!lock.tryLock(180000)) {
+    Logger.log('processPartnerCheckInsFromTelegramChatLogs: another run is in progress; skipping.');
+    return { success: false, error: 'busy' };
+  }
+  try {
+    var tcSpreadsheet = SpreadsheetApp.openById(TELEGRAM_CHAT_LOGS_SPREADSHEET_ID);
+    var tcSheet = tcSpreadsheet.getSheetByName(TELEGRAM_CHAT_LOGS_SHEET);
+    if (!tcSheet) {
+      throw new Error('Telegram Chat Logs sheet "' + TELEGRAM_CHAT_LOGS_SHEET + '" not found');
+    }
+
+    var ledgerSpreadsheet = SpreadsheetApp.openById(MAIN_LEDGER_SPREADSHEET_ID);
+    var checkInsSheet = ensurePartnerCheckInsSheet_(ledgerSpreadsheet);
+
+    // Build dedup set from existing Partner Check-ins col K (zero-based 10).
+    var checkInsValues = checkInsSheet.getDataRange().getValues();
+    var seenUpdateIds = {};
+    for (var r = 1; r < checkInsValues.length; r++) {
+      var existingId = String(checkInsValues[r][10] || '').trim();
+      if (existingId) seenUpdateIds[existingId] = true;
+    }
+
+    // Scan Telegram Chat Logs.
+    var lastRow = tcSheet.getLastRow();
+    if (lastRow < 2) {
+      return { success: true, processed: 0, skipped: 0, errors: 0 };
+    }
+    var startRow = Math.max(2, lastRow - PARTNER_CHECK_IN_SCAN_BATCH + 1);
+    var numRows = lastRow - startRow + 1;
+    var lastCol = Math.max(tcSheet.getLastColumn(), TELEGRAM_CHAT_LOGS_MESSAGE_COL + 1);
+    var tcRange = tcSheet.getRange(startRow, 1, numRows, lastCol).getValues();
+
+    var processed = 0;
+    var skipped = 0;
+    var errors = 0;
+
+    for (var i = 0; i < tcRange.length; i++) {
+      var message = String(tcRange[i][TELEGRAM_CHAT_LOGS_MESSAGE_COL] || '');
+      if (message.indexOf('[PARTNER CHECK-IN EVENT]') === -1) continue;
+
+      var fields = parsePartnerCheckInText_(message);
+      var updateId = String(fields.update_id || '').trim();
+      if (!updateId) {
+        Logger.log('Skipping partner check-in at Telegram row ' + (startRow + i) + ': no Update ID.');
+        skipped++;
+        continue;
+      }
+      if (seenUpdateIds[updateId]) {
+        skipped++;
+        continue;
+      }
+
+      var partnerId = String(fields.partner_id || '').trim();
+      if (!partnerId) {
+        Logger.log('Partner check-in ' + updateId + ': missing partner_id; skipping.');
+        skipped++;
+        continue;
+      }
+
+      var digitalSignature = extractMyDigitalSignatureFromText_(message);
+      var submittedBy = digitalSignature || String(fields.my_digital_signature || '').trim();
+
+      try {
+        appendPartnerCheckInRow_({
+          partner_id: partnerId,
+          contributor_name: String(fields.contributor_name || ''),
+          check_in_date: String(fields.check_in_date || ''),
+          method: String(fields.method || ''),
+          stock_status: String(fields.stock_status || ''),
+          restock_needed: String(fields.restock_needed || ''),
+          restock_quantity: String(fields.restock_quantity || ''),
+          next_check_in_date: String(fields.next_check_in_date || ''),
+          notes: String(fields.notes || '').slice(0, 2000),
+          update_id: updateId,
+          digital_signature: submittedBy,
+          submitted_by: submittedBy,
+          restock_sku: String(fields.restock_sku || '')
+        });
+
+        seenUpdateIds[updateId] = true;
+        processed++;
+      } catch (rowErr) {
+        errors++;
+        Logger.log('Partner check-in ' + updateId + ' failed: ' + rowErr);
+      }
+    }
+
+    Logger.log(
+      'processPartnerCheckInsFromTelegramChatLogs: processed=' +
+        processed +
+        ' skipped=' +
+        skipped +
+        ' errors=' +
+        errors +
+        ' window=' +
+        startRow +
+        '-' +
+        lastRow
+    );
+    return { success: true, processed: processed, skipped: skipped, errors: errors };
+  } finally {
+    lock.releaseLock();
+  }
+}

--- a/google_app_scripts/tdg_shipping_planner/shipping_planner_api.gs
+++ b/google_app_scripts/tdg_shipping_planner/shipping_planner_api.gs
@@ -75,6 +75,7 @@ const FREIGHT_WEIGHT_TIERS = [200, 300, 500, 750, 1000];
 // Restock recommender: optional sheets in main spreadsheet
 const PARTNER_ADDRESSES_SHEET_NAME = 'Partner addresses';
 const PARTNER_SALES_SHEET_NAME = 'Partner sales';
+const PARTNER_CHECK_INS_SHEET_NAME = 'Partner Check-ins';
 const RESTOCK_QUANTITIES = [6, 12, 18, 24, 36, 48];
 const DEFAULT_MONTHLY_SALES = 4;
 const TARGET_WEEKS_MIN = 4;
@@ -155,6 +156,137 @@ function createSuccessResponse(data) {
     status: 'success',
     data: data
   });
+}
+
+// ============================================================================
+// PARTNER CHECK-IN FUNCTIONS
+// ============================================================================
+
+/**
+ * Read check-in history for a partner from the Partner Check-ins tab.
+ * @param {string} partnerId
+ * @return {Array<Object>}
+ */
+function getPartnerCheckIns(partnerId) {
+  try {
+    const ss = SpreadsheetApp.openById(MAIN_SPREADSHEET_ID);
+    const sheet = ss.getSheetByName(PARTNER_CHECK_INS_SHEET_NAME);
+    if (!sheet) return [];
+    const values = sheet.getDataRange().getValues();
+    if (values.length < 2) return [];
+    const headers = values[0];
+    var partnerIdIdx = -1;
+    var checkInDateIdx = -1;
+    var methodIdx = -1;
+    var stockStatusIdx = -1;
+    var restockNeededIdx = -1;
+    var restockSkuIdx = -1;
+    var restockQuantityIdx = -1;
+    var nextCheckInIdx = -1;
+    var notesIdx = -1;
+    var submittedAtIdx = -1;
+    for (var i = 0; i < headers.length; i++) {
+      var h = String(headers[i] || '').trim();
+      if (h === 'Partner ID') partnerIdIdx = i;
+      else if (h === 'Check-in Date') checkInDateIdx = i;
+      else if (h === 'Method') methodIdx = i;
+      else if (h === 'Stock Status') stockStatusIdx = i;
+      else if (h === 'Restock Needed') restockNeededIdx = i;
+      else if (h === 'Restock SKU') restockSkuIdx = i;
+      else if (h === 'Restock Quantity') restockQuantityIdx = i;
+      else if (h === 'Next Check-in Date') nextCheckInIdx = i;
+      else if (h === 'Notes') notesIdx = i;
+      else if (h === 'Submitted At') submittedAtIdx = i;
+    }
+    if (partnerIdIdx < 0) return [];
+    var rows = [];
+    for (var r = 1; r < values.length; r++) {
+      var row = values[r];
+      if (String(row[partnerIdIdx] || '').trim() !== partnerId) continue;
+      rows.push({
+        submitted_at: submittedAtIdx >= 0 ? String(row[submittedAtIdx] || '') : '',
+        check_in_date: checkInDateIdx >= 0 ? String(row[checkInDateIdx] || '') : '',
+        method: methodIdx >= 0 ? String(row[methodIdx] || '') : '',
+        stock_status: stockStatusIdx >= 0 ? String(row[stockStatusIdx] || '') : '',
+        restock_needed: restockNeededIdx >= 0 ? String(row[restockNeededIdx] || '') : '',
+        restock_sku: restockSkuIdx >= 0 ? String(row[restockSkuIdx] || '') : '',
+        restock_quantity: restockQuantityIdx >= 0 ? String(row[restockQuantityIdx] || '') : '',
+        next_check_in_date: nextCheckInIdx >= 0 ? String(row[nextCheckInIdx] || '') : '',
+        notes: notesIdx >= 0 ? String(row[notesIdx] || '') : ''
+      });
+    }
+    // Sort by check-in date descending
+    rows.sort(function(a, b) {
+      var da = a.check_in_date ? new Date(a.check_in_date).getTime() : 0;
+      var db = b.check_in_date ? new Date(b.check_in_date).getTime() : 0;
+      return db - da;
+    });
+    return rows.slice(0, 50);
+  } catch (err) {
+    Logger.log('getPartnerCheckIns error: ' + err);
+    return [];
+  }
+}
+
+/**
+ * List partners whose next check-in date is overdue or within 3 days.
+ * @return {Array<Object>}
+ */
+function listPartnersNeedingAttention() {
+  try {
+    const ss = SpreadsheetApp.openById(MAIN_SPREADSHEET_ID);
+    const sheet = ss.getSheetByName(PARTNER_CHECK_INS_SHEET_NAME);
+    if (!sheet) return [];
+    const values = sheet.getDataRange().getValues();
+    if (values.length < 2) return [];
+    const headers = values[0];
+    var partnerIdIdx = -1;
+    var nextCheckInIdx = -1;
+    var checkInDateIdx = -1;
+    for (var i = 0; i < headers.length; i++) {
+      var h = String(headers[i] || '').trim();
+      if (h === 'Partner ID') partnerIdIdx = i;
+      else if (h === 'Next Check-in Date') nextCheckInIdx = i;
+      else if (h === 'Check-in Date') checkInDateIdx = i;
+    }
+    if (partnerIdIdx < 0) return [];
+    var latestByPartner = {};
+    for (var r = 1; r < values.length; r++) {
+      var row = values[r];
+      var pid = String(row[partnerIdIdx] || '').trim();
+      if (!pid) continue;
+      var nextDate = nextCheckInIdx >= 0 ? String(row[nextCheckInIdx] || '').trim() : '';
+      var checkDate = checkInDateIdx >= 0 ? String(row[checkInDateIdx] || '').trim() : '';
+      if (!latestByPartner[pid] || (checkDate && checkDate > latestByPartner[pid].check_in_date)) {
+        latestByPartner[pid] = { partner_id: pid, next_check_in_date: nextDate, check_in_date: checkDate };
+      }
+    }
+    var today = new Date();
+    today.setHours(0, 0, 0, 0);
+    var cutoff = new Date(today);
+    cutoff.setDate(cutoff.getDate() + 3);
+    var result = [];
+    for (var pid in latestByPartner) {
+      if (!Object.prototype.hasOwnProperty.call(latestByPartner, pid)) continue;
+      var entry = latestByPartner[pid];
+      if (!entry.next_check_in_date) continue;
+      var d = new Date(entry.next_check_in_date);
+      if (isNaN(d.getTime())) continue;
+      d.setHours(0, 0, 0, 0);
+      if (d <= cutoff) {
+        result.push({
+          partner_id: pid,
+          next_check_in_date: entry.next_check_in_date,
+          days_overdue: Math.floor((today - d) / 86400000)
+        });
+      }
+    }
+    result.sort(function(a, b) { return a.days_overdue - b.days_overdue; });
+    return result;
+  } catch (err) {
+    Logger.log('listPartnersNeedingAttention error: ' + err);
+    return [];
+  }
 }
 
 // ============================================================================
@@ -1198,8 +1330,24 @@ function doGet(e) {
       });
     }
     
+    // Get partner check-in history
+    if (action === 'get_partner_check_ins') {
+      const partnerId = (e.parameter.partner_id || '').toString().trim();
+      if (!partnerId) {
+        return createErrorResponse('Missing partner_id parameter');
+      }
+      const rows = getPartnerCheckIns(partnerId);
+      return createSuccessResponse({ partner_id: partnerId, check_ins: rows });
+    }
+    
+    // List partners needing attention (overdue next check-in)
+    if (action === 'list_partners_needing_attention') {
+      const rows = listPartnersNeedingAttention();
+      return createSuccessResponse({ partners: rows });
+    }
+    
     // Default: return available actions
-    return createErrorResponse('Invalid or missing action parameter. Available actions: list_managers, get_inventory, calculate_shipping');
+    return createErrorResponse('Invalid or missing action parameter. Available actions: list_managers, get_inventory, get_partner_check_ins, list_partners_needing_attention, calculate_shipping');
     
   } catch (error) {
     Logger.log('Error in doGet: ' + error.message);


### PR DESCRIPTION
## Summary
- `google_app_scripts/find_nearby_stores/process_partner_check_in_telegram_logs.gs` (new) — async scanner that reads `[PARTNER CHECK-IN EVENT]` rows from the canonical Telegram Chat Logs intake, dedups on `Update ID` (col K), and appends to Main Ledger > `Partner Check-ins`. Idempotent, `LockService`-guarded (180s), 200-row scan window. Auto-creates the destination tab via `ensurePartnerCheckInsSheet_`.
- `google_app_scripts/tdg_shipping_planner/shipping_planner_api.gs`: new actions
  - `?action=get_partner_check_ins&partner_id=<slug>` — last 50 check-ins for that partner.
  - `?action=list_partners_needing_attention` — partners overdue or within 3 days of next check-in.
- `SCHEMA.md`: documents `Partner Check-ins` tab columns A–N.

## v0.2 review-pass
- Scanner `appendRow` and `ensurePartnerCheckInsSheet_` headers append `Restock SKU` as col N (not insert at H), so the hardcoded col-K Update-ID dedup index stays correct.
- API `getPartnerCheckIns` includes `restock_sku` in the lookup map by header name (dynamic — no fixed offset).

## Plan + review notes
agentic_ai_context/PARTNER_CHECK_IN_IMPLEMENTATION.md

## Manual deploy steps (after merge)
1. Create `Partner Check-ins` tab on Main Ledger with headers A–N (the scanner will also auto-create on first run, but pre-creating lets the operator add dropdown validations + col widths upfront).
2. `cp google_app_scripts/find_nearby_stores/process_partner_check_in_telegram_logs.gs clasp_mirrors/1NpHrKJW.../process_partner_check_in_telegram_logs.js` then `clasp push` in that mirror.
3. Same for `tdg_shipping_planner` mirror → re-deploy web app.
4. Time-driven trigger every 30 min on `processPartnerCheckInsFromTelegramChatLogs`.

## Test plan
- [ ] Run `processPartnerCheckInsFromTelegramChatLogs()` manually → returns `{success: true, processed: 0}` on empty.
- [ ] Submit a real check-in via `dao_client check_in_partner --dry-run`; copy text into Telegram Chat Logs; re-run scanner; verify one row in `Partner Check-ins` with `Restock SKU` populated.
- [ ] Re-run scanner; same event skipped (dedup on Update ID).
- [ ] `?action=get_partner_check_ins&partner_id=the-way-home-shop` returns the appended row.
- [ ] `?action=list_partners_needing_attention` works (may return empty until rows accumulate).

🤖 Generated with [Claude Code](https://claude.com/claude-code)