### PR TITLE
Rename GAS property: GITHUB_TOKEN -> TRUESIGHT_CREDENTIALING_PAT

### DIFF
--- a/google_app_scripts/tdg_credentialing/README.md
+++ b/google_app_scripts/tdg_credentialing/README.md
@@ -10,7 +10,7 @@ This script needs a **GitHub Personal Access Token** with `contents:write` scope
 
 1. Push this folder to its Apps Script project (clasp).
 2. In the Apps Script editor: **Project Settings → Script Properties → Add property**:
-   - Name: `GITHUB_TOKEN`
+   - Name: `TRUESIGHT_CREDENTIALING_PAT`
    - Value: `ghp_…` (a fine-grained PAT with `Contents: read & write` on `TrueSightDAO/lineage-credentials`)
 3. Deploy the script as a Web App (executes as: USER_DEPLOYING, who has access: Anyone).
 4. From the live deployment URL run `?action=installTimeTrigger` once to install the 10-min cron fallback.

--- a/google_app_scripts/tdg_credentialing/practice_event_processing.gs
+++ b/google_app_scripts/tdg_credentialing/practice_event_processing.gs
@@ -27,7 +27,7 @@
  *      is only ever set to PROCESSED after the commit succeeds.
  *
  * Required Script Property:
- *   GITHUB_TOKEN — a PAT with 'contents:write' on TrueSightDAO/lineage-credentials.
+ *   TRUESIGHT_CREDENTIALING_PAT — a PAT with 'contents:write' on TrueSightDAO/lineage-credentials.
  *                  Set via Apps Script project → Project Settings → Script Properties.
  *
  * Edgar config (sentiment_importer/config/application.rb):
@@ -210,9 +210,9 @@ function setIntakeRowStatus(sheet, rowNumber, status, commitSha, commitUrl) {
 // ============================================================================
 
 function getGithubToken() {
-  var token = PropertiesService.getScriptProperties().getProperty('GITHUB_TOKEN');
+  var token = PropertiesService.getScriptProperties().getProperty('TRUESIGHT_CREDENTIALING_PAT');
   if (!token) {
-    throw new Error('GITHUB_TOKEN script property is not set. Add a PAT with contents:write on TrueSightDAO/lineage-credentials.');
+    throw new Error('TRUESIGHT_CREDENTIALING_PAT script property is not set. Add a PAT with contents:write on TrueSightDAO/lineage-credentials.');
   }
   return token;
 }


### PR DESCRIPTION
## Summary
- Renames the Script Property in `tdg_credentialing/practice_event_processing.gs` from `GITHUB_TOKEN` to `TRUESIGHT_CREDENTIALING_PAT` so it is unambiguously the credentialing PAT.
- Updates the setup instructions in `tdg_credentialing/README.md` to match.

The live GAS deployment has already been clasp-pushed; Gary has set the new property name in Script Properties.

## Test plan
- [x] `replace_all` across the two files; no stale `GITHUB_TOKEN` references remain in `tdg_credentialing/`
- [x] clasp pushed to live Apps Script project
- [ ] Next `[PRACTICE EVENT]` payload commits to lineage-credentials without auth error