### PR TITLE
Fix Telegram Chat Logs column mapping in credentialing GAS

### DIFF
--- a/google_app_scripts/tdg_credentialing/practice_event_processing.gs
+++ b/google_app_scripts/tdg_credentialing/practice_event_processing.gs
@@ -67,12 +67,21 @@ const CRED_INTAKE_HEADERS = [
   'Processed At',                // Q
 ];
 
-// Telegram Chat Logs columns we read (matches the layout the other processors use).
-// Column indices are 0-based — getValues() rows are 0-indexed arrays.
+// Telegram Chat Logs columns we read. Layout matches the canonical
+// constants used in tdg_asset_management/capital_injection_processing.gs:
+//   col 0  Update ID
+//   col 1  Chatroom ID
+//   col 2  Chatroom Name
+//   col 3  Message ID
+//   col 4  Reporter / Contributor Name
+//   col 5  (reserved)
+//   col 6  Message body  ← we were reading col 2 here, which is the chatroom
+//                          name ("Edgar Direct"), so [PRACTICE EVENT] never
+//                          matched and processing silently no-op'd.
 const TCL_UPDATE_ID_COL  = 0;
-const TCL_MESSAGE_ID_COL = 1;
-const TCL_MESSAGE_COL    = 2;
-const TCL_REPORTER_COL   = 3;
+const TCL_MESSAGE_ID_COL = 3;
+const TCL_MESSAGE_COL    = 6;
+const TCL_REPORTER_COL   = 4;
 
 // Lineage-credentials repo coordinates.
 const LC_OWNER = 'TrueSightDAO';


### PR DESCRIPTION
## Root cause
The four TCL_* column constants in `practice_event_processing.gs` did not match the canonical Telegram Chat Logs layout (col 0 = Update ID, col 3 = Message ID, col 4 = Reporter, col 6 = Message body — per `capital_injection_processing.gs`).

`message.indexOf('[PRACTICE EVENT]')` was being run against "Edgar Direct" (the chatroom name in col 2), so practice events sat unprocessed.

## Fix
Update the four constants. clasp pushed; deployment AKfycbys7... was rebumped from v2 → v3 to publish the change.

## Live verification
Gary's three submitted capoeira sessions landed on the Credentialing Events tab as PROCESSED and committed to `lineage-credentials/programs/capoeira-tribo-mirim/pk-wR9zU8JMnEz1/practice/`.

## Deployment-management note for future sessions
The webhook URL (`AKfycbys7...`) is pinned to an explicit version, not @HEAD. After every `clasp push`, run `clasp deploy --deploymentId <id>` to refresh the URL to HEAD. Bare `clasp push` updates HEAD but does NOT reach the deployed webhook.

## Test plan
- [x] manual trigger via `?action=parseAndProcessCredentialingLogs` returns "✅ processed"
- [x] new rows in Credentialing Events tab with Status=PROCESSED
- [x] event JSON files in lineage-credentials repo