### PR TITLE
credentialing GAS: fetch existing blob sha before re-PUT + per-row backfill diagnostics

### DIFF
--- a/google_app_scripts/tdg_credentialing/practice_event_processing.gs
+++ b/google_app_scripts/tdg_credentialing/practice_event_processing.gs
@@ -303,20 +303,37 @@ function buildEventFilename(capturedAt, requestTransactionId) {
 function commitPracticeEvent(program, slug, filename, content) {
   var path = 'programs/' + program + '/' + slug + '/practice/' + filename;
   var url = LC_CONTENTS_API_FMT.replace('{path}', path);
+  var headers = {
+    Authorization: 'Bearer ' + getGithubToken(),
+    Accept: 'application/vnd.github+json',
+    'User-Agent': 'tdg-credentialing-processing/1.0',
+    'X-GitHub-Api-Version': '2022-11-28',
+  };
+
+  // If the file already exists, GitHub requires its blob sha on PUT. Look it
+  // up first so re-commits (e.g. backfill) overwrite cleanly instead of 422-ing.
+  var existingSha = null;
+  var head = UrlFetchApp.fetch(url + '?ref=' + encodeURIComponent(LC_BRANCH), {
+    method: 'get',
+    headers: headers,
+    muteHttpExceptions: true,
+  });
+  var headCode = head.getResponseCode();
+  if (headCode >= 200 && headCode < 300) {
+    try { existingSha = JSON.parse(head.getContentText()).sha || null; } catch (e) { existingSha = null; }
+  }
+
   var body = {
     message: 'practice event: ' + program + ' ' + slug + ' ' + filename,
     branch: LC_BRANCH,
     content: Utilities.base64Encode(content),
   };
+  if (existingSha) body.sha = existingSha;
+
   var resp = UrlFetchApp.fetch(url, {
     method: 'put',
     contentType: 'application/json',
-    headers: {
-      Authorization: 'Bearer ' + getGithubToken(),
-      Accept: 'application/vnd.github+json',
-      'User-Agent': 'tdg-credentialing-processing/1.0',
-      'X-GitHub-Api-Version': '2022-11-28',
-    },
+    headers: headers,
     payload: JSON.stringify(body),
     muteHttpExceptions: true,
   });
@@ -627,6 +644,7 @@ function reprocessAllRowsWithEmptyPayload() {
   var statusColIdx = CRED_INTAKE_HEADERS.indexOf('Status');
 
   var reprocessed = 0, skipped = 0, errors = 0;
+  var reprocessedRows = [], errorDetails = [];
   for (var i = 0; i < values.length; i++) {
     var rowNumber = i + 2;
     var status = String(values[i][statusColIdx] || '');
@@ -634,13 +652,27 @@ function reprocessAllRowsWithEmptyPayload() {
     if (status.indexOf('PROCESSED') !== 0) { skipped++; continue; }
     if (payload) { skipped++; continue; }
     try {
-      reprocessCredentialingRow(rowNumber);
+      var r = reprocessCredentialingRow(rowNumber);
       reprocessed++;
+      reprocessedRows.push({ row: rowNumber, slug: r && r.slug, payload_len: r && r.payload_len });
     } catch (e) {
       Logger.log('Row ' + rowNumber + ' reprocess error: ' + e.message);
       errors++;
+      var rawMsg = String(values[i][2] || '');
+      errorDetails.push({
+        row: rowNumber,
+        error: String(e && e.message || e),
+        raw_message_len: rawMsg.length,
+        raw_message_preview: rawMsg.slice(0, 200),
+      });
     }
   }
   Logger.log('🔁 Backfill done: reprocessed=' + reprocessed + ' skipped=' + skipped + ' errors=' + errors);
-  return { reprocessed: reprocessed, skipped: skipped, errors: errors };
+  return {
+    reprocessed: reprocessed,
+    skipped: skipped,
+    errors: errors,
+    reprocessedRows: reprocessedRows,
+    errorDetails: errorDetails,
+  };
 }

--- a/google_app_scripts/tdg_credentialing/practice_event_processing.gs
+++ b/google_app_scripts/tdg_credentialing/practice_event_processing.gs
@@ -530,7 +530,8 @@ function doGet(e) {
   // a browser tab; returns a JSON summary.
   if (action === 'reprocessAllRowsWithEmptyPayload') {
     try {
-      var summary = reprocessAllRowsWithEmptyPayload();
+      var force = String((e && e.parameter && e.parameter.force) || '') === '1';
+      var summary = reprocessAllRowsWithEmptyPayload({ force: force });
       return ContentService.createTextOutput(JSON.stringify(summary, null, 2)).setMimeType(ContentService.MimeType.JSON);
     } catch (err) {
       Logger.log('❌ reprocessAllRowsWithEmptyPayload error: ' + err.message);
@@ -632,7 +633,9 @@ function reprocessCredentialingRow(rowNumber) {
  * this once after pulling the parser fix to retroactively fill in missed
  * payloads from any pre-fix events.
  */
-function reprocessAllRowsWithEmptyPayload() {
+function reprocessAllRowsWithEmptyPayload(opts) {
+  opts = opts || {};
+  var force = opts.force === true;
   var intake = getIntakeSheet();
   if (!intake) throw new Error('Credentialing Events sheet not found');
   var lastRow = intake.getLastRow();
@@ -650,7 +653,7 @@ function reprocessAllRowsWithEmptyPayload() {
     var status = String(values[i][statusColIdx] || '');
     var payload = String(values[i][payloadColIdx] || '');
     if (status.indexOf('PROCESSED') !== 0) { skipped++; continue; }
-    if (payload) { skipped++; continue; }
+    if (payload && !force) { skipped++; continue; }
     try {
       var r = reprocessCredentialingRow(rowNumber);
       reprocessed++;


### PR DESCRIPTION
## Summary
- `commitPracticeEvent()` now GETs the existing file at the target path before PUT-ing. If the file exists, its blob `sha` is included in the request body — required by the GitHub Contents API for any overwrite (else 422). Fresh writes still work because the GET returns 404, leaving `sha` unset.
- `reprocessAllRowsWithEmptyPayload()` now returns `reprocessedRows` and `errorDetails` arrays alongside the counts, so an operator triggering the backfill via the doGet URL gets per-row diagnostics in the JSON response — no IDE access needed.

## Why
The backfill action from PR #295 returned `errors: 7, reprocessed: 0` on first run. Root cause: every "row with empty payload" was a row that *had already been committed once* with `payload: null`. Re-committing to the same path without supplying the prior blob `sha` is exactly the case GitHub 422s on. The diagnostic upgrade landed alongside so future failures surface in the response.

## Test plan
- [x] Pushed to live @HEAD deployment via `clasp push`
- [ ] Operator re-triggers `?action=reprocessAllRowsWithEmptyPayload` and observes `reprocessed > 0` with the previously-stuck rows now appearing in `reprocessedRows`
- [ ] Verify `truesight.me/credentials/#pk-4LBWHX9DJ_wH` shows 82 minutes (40+42) once the lineage-credentials GitHub Action rebuilds the cache