### PR TITLE
refactor(gas): look up Agroverse Partners by gid first

### DIFF
--- a/google_app_scripts/holistic_hit_list_store_history/partner_poke_drafts.gs
+++ b/google_app_scripts/holistic_hit_list_store_history/partner_poke_drafts.gs
@@ -84,7 +84,11 @@ var VELOCITY_URL  = 'https://raw.githubusercontent.com/TrueSightDAO/agroverse-in
 var INVENTORY_URL = 'https://raw.githubusercontent.com/TrueSightDAO/agroverse-inventory/main/partners-inventory.json';
 
 var PARTNER_CHECK_INS_SHEET   = 'Partner Check-ins';                  // on MAIN_SPREADSHEET_ID
-var AGROVERSE_PARTNERS_SHEET  = 'Agroverse Partners';                  // on MAIN_SPREADSHEET_ID
+var AGROVERSE_PARTNERS_SHEET  = 'Agroverse Partners';                  // on MAIN_SPREADSHEET_ID (display name; gid below is stable)
+// Lookup by gid first so a rename of the tab (queued — see
+// agentic_ai_context/OPEN_FOLLOWUPS.md) doesn't break partner-poke draft
+// generation.
+var AGROVERSE_PARTNERS_SHEET_GID = 1983902109;
 var CONTACT_SHEET             = 'Contributors contact information';   // on MAIN_SPREADSHEET_ID
 var POKE_DRAFT_LOG_DEFAULT    = 'Partner Poke Drafts';                 // on HIT_LIST_SPREADSHEET_ID
 
@@ -394,9 +398,18 @@ function loadAgroversePartners_() {
   var out = {};
   try {
     var ss = SpreadsheetApp.openById(MAIN_SPREADSHEET_ID);
-    var sheet = ss.getSheetByName(AGROVERSE_PARTNERS_SHEET);
+    var sheet = null;
+    var allSheets = ss.getSheets();
+    for (var si = 0; si < allSheets.length; si++) {
+      if (allSheets[si].getSheetId() === AGROVERSE_PARTNERS_SHEET_GID) {
+        sheet = allSheets[si];
+        break;
+      }
+    }
+    if (!sheet) sheet = ss.getSheetByName(AGROVERSE_PARTNERS_SHEET);
     if (!sheet) {
-      Logger.log('[partner-poke] %s sheet not found', AGROVERSE_PARTNERS_SHEET);
+      Logger.log('[partner-poke] partners sheet not found (gid %s name %s)',
+                 AGROVERSE_PARTNERS_SHEET_GID, AGROVERSE_PARTNERS_SHEET);
       return out;
     }
     var lastRow = sheet.getLastRow();

--- a/google_app_scripts/tdg_shipping_planner/shipping_planner_api.gs
+++ b/google_app_scripts/tdg_shipping_planner/shipping_planner_api.gs
@@ -325,7 +325,17 @@ function listPartnersNeedingAttention() {
 function listPartnerContributors() {
   try {
     const ss = SpreadsheetApp.openById(MAIN_SPREADSHEET_ID);
-    const sheet = ss.getSheetByName('Agroverse Partners');
+    // Look up by gid first (stable across rename); fall back to name. The
+    // tab is currently 'Agroverse Partners' but queued for rename to
+    // 'DAO Partners' since its rows now span Operator/Supplier/Freight
+    // Provider beyond just retail. See agentic_ai_context/OPEN_FOLLOWUPS.md.
+    const PARTNERS_GID = 1983902109;
+    const sheets = ss.getSheets();
+    var sheet = null;
+    for (var i = 0; i < sheets.length; i++) {
+      if (sheets[i].getSheetId() === PARTNERS_GID) { sheet = sheets[i]; break; }
+    }
+    if (!sheet) sheet = ss.getSheetByName('Agroverse Partners');
     if (!sheet) return [];
     const values = sheet.getDataRange().getValues();
     if (values.length < 2) return [];


### PR DESCRIPTION
## Summary

Phase 1 of the rename migration logged in [agentic_ai_context OPEN_FOLLOWUPS](https://github.com/TrueSightDAO/agentic_ai_context/blob/main/OPEN_FOLLOWUPS.md). Both Apps Script consumers of the Main Ledger \`Agroverse Partners\` tab now look up by gid (\`1983902109\`) first, falling back to the name. Pattern mirrors \`getSheetByNameOrGid_()\` already present in \`tdg_identity_management/register_member_digital_signatures_telegram.gs\`.

- \`tdg_shipping_planner/shipping_planner_api.gs::listPartnerContributors()\` — serves the dapp/partner_check_in.html Contributor Name dropdown. Most critical to keep working through the rename.
- \`holistic_hit_list_store_history/partner_poke_drafts.gs\` — reads partners for poke-draft generation; \`AGROVERSE_PARTNERS_SHEET_GID\` constant added; lookup wrapped with name fallback.

## Deploy

Apps Script web-app endpoints need a manual re-deploy via clasp / Apps Script UI before the deployed surfaces pick up the change.

## Test plan

- [ ] Re-deploy \`tdg_shipping_planner\` web app, then hit \`listPartnerContributors\` from \`dapp/partner_check_in.html\` and confirm the Contributor Name dropdown still populates.
- [ ] Re-deploy \`partner_poke_drafts\`, manually trigger a poke run, confirm partner rows are read.

Sister PRs (same migration, other repos):
- dao_client: TrueSightDAO/dao_client#29
- market_research: pending