### PR TITLE
fix(partner-checkin-scanner): accept check-ins without partner_id (operator partners)

### DIFF
--- a/google_app_scripts/find_nearby_stores/process_partner_check_in_telegram_logs.gs
+++ b/google_app_scripts/find_nearby_stores/process_partner_check_in_telegram_logs.gs
@@ -189,8 +189,13 @@ function processPartnerCheckInsFromTelegramChatLogs() {
       }
 
       var partnerId = String(fields.partner_id || '').trim();
-      if (!partnerId) {
-        Logger.log('Partner check-in ' + updateId + ': missing partner_id; skipping.');
+      var contributorName = String(fields.contributor_name || '').trim();
+      // Accept either a partner_id (venue partner) OR a contributor_name
+      // (operator partner — DAO Partners rows with empty col A by convention,
+      // e.g. Wayne - UX.APP). Reject only if BOTH are missing, since we'd
+      // have nothing to join on downstream.
+      if (!partnerId && !contributorName) {
+        Logger.log('Partner check-in ' + updateId + ': missing both partner_id and contributor_name; skipping.');
         skipped++;
         continue;
       }
@@ -201,7 +206,7 @@ function processPartnerCheckInsFromTelegramChatLogs() {
       try {
         appendPartnerCheckInRow_({
           partner_id: partnerId,
-          contributor_name: String(fields.contributor_name || ''),
+          contributor_name: contributorName,
           check_in_date: String(fields.check_in_date || ''),
           method: String(fields.method || ''),
           stock_status: String(fields.stock_status || ''),


### PR DESCRIPTION
## Summary

Scanner was rejecting any \`[PARTNER CHECK-IN EVENT]\` without a \`partner_id\`, which blocked all operator-partner check-ins — operator rows on **DAO Partners** (renamed today from \`Agroverse Partners\`) have empty col A by convention.

Wayne (UX.APP, registered earlier today) was the first hit: Telegram Chat Logs row 8882 was processed by Edgar (HTTP 200) but skipped here, so the Partner Check-ins row never appeared.

**Fix.** Accept rows that have **either** \`partner_id\` (venue partner) **or** \`contributor_name\` (operator partner). Reject only if both are missing.

## Test plan

- [x] Re-deployed live (\`AKfycbwB...@36\`), manually triggered the scanner.
- [x] Scanner returned \`processed=1, skipped=8, errors=0\` — that 1 is Wayne.
- [x] Verified Wayne now lands at Partner Check-ins R9 with \`Next Check-in Date=2026-05-22\` (Friday).

## Sister context

- Operator role added to \`onboard_partner\`: TrueSightDAO/dao_client#28
- \`check_in_partner\` allows omitting \`--partner-id\`: TrueSightDAO/dao_client#30
- Tab rename + gid migration: TrueSightDAO/tokenomics#300