### PR TITLE
doGet: ?type=recalculate_aum operator escape hatch

### DIFF
--- a/google_app_scripts/tdg_asset_management/tdg_wix_dashboard.gs
+++ b/google_app_scripts/tdg_asset_management/tdg_wix_dashboard.gs
@@ -2260,6 +2260,22 @@ function doGet(e) {
         .setMimeType(ContentService.MimeType.JSON);
     }
 
+    if (type === 'recalculate_aum') {
+      // Operator escape hatch: trigger calculateAUM() out-of-band AND
+      // overwrite the Performance Statistics 'AUM' cell (the same thing
+      // the cron does in its main update loop). Useful when a formula
+      // change (e.g. the Equity → Asset section refactor 2026-05-20)
+      // needs to land in the landing-page stat immediately.
+      var newAum = calculateAUM();
+      updatePerformanceStatistic("AUM", newAum, "USD");
+      return ContentService.createTextOutput(JSON.stringify({
+        timestamp: new Date().toISOString(),
+        triggered: 'calculateAUM + updatePerformanceStatistic',
+        aum: newAum,
+        note: 'Performance Statistics AUM cell + aum_breakdown cache both refreshed.'
+      }, null, 2)).setMimeType(ContentService.MimeType.JSON);
+    }
+
     if (type === 'aum_debug') {
       // Diagnostic: dump the first 20 rows of cols A..F of a given AGL's
       // Balance sheet so we can see the actual template layout. Use:


### PR DESCRIPTION
Adds an on-demand trigger for `calculateAUM()` so formula changes land in the landing-page stat immediately without waiting for the next cron run. Mirrors the cron's behavior precisely (calculate + write Performance Statistics cell in one shot).

Used today to align the landing-page `AUM` stat with `/aum`'s headline after the Equity → Asset section refactor (tokenomics#306).

Verified live (deploy @15): both endpoints now return 27,868.36 with the same timestamp.

🤖 Generated with [Claude Code](https://claude.com/claude-code)