### PR TITLE
QR generator: forward instead of dead-ending (stop the stumble)

### DIFF
--- a/python_scripts/agroverse_qr_code_generator/batch_compiler.py
+++ b/python_scripts/agroverse_qr_code_generator/batch_compiler.py
@@ -1,47 +1,77 @@
 #!/usr/bin/env python3
-"""DEPRECATED — moved to TrueSightDAO/lineage-assets.
+"""Compatibility forwarder — the QR generator MOVED to TrueSightDAO/lineage-assets.
 
-Running this file aborts with a redirect message. The old code is
-preserved in git history (last working version was at
-tokenomics@<sha-before-deprecation>) but invoking it from this path
-will silently produce output in the wrong location — the previously-
-generated compiled images land in this directory's package_qr_codes/
-scratch dir instead of lineage-assets/pngs/, the JSON manifest never
-gets written, and truesight.me/qr/?id=<id> can't resolve the QR image.
+This used to be the generator. It now **transparently forwards** to:
 
-To regenerate a QR (cacao bag / tree / drum / membership / etc.):
+    ~/Applications/lineage-assets/scripts/qr_generator/batch_compiler.py
 
-    cd ~/Applications/lineage-assets/scripts/qr_generator
-    python3 batch_compiler.py [--limit N]
+so the historical command (and muscle memory) still works when run from this
+directory, instead of hard-aborting. Relative path args (--credentials,
+--output-dir, --pngs-dir, --qrs-dir, --template, logos) are resolved against
+your current working directory before forwarding, so e.g.
+`--credentials gdrive_key.json` keeps pointing at the file next to where you
+invoked this.
 
-That version writes three artifacts per mint in one run:
-  - operator-local compiled label image (package_qr_codes/)
-  - raw QR PNG into lineage-assets/pngs/<qr_id>.png
-  - per-QR JSON manifest into lineage-assets/qrs/<qr_id>.json
+PREFERRED entry point (params already locked — box-size 12, logo-ratio 0.25,
+Helvetica):
 
-See agentic_ai_context/LINEAGE_ASSETS.md §"Generator" for the full doc,
-or DEPRECATED.md in this directory for the migration breadcrumb.
+    cd ~/Applications/lineage-assets/scripts/qr_generator && ./generate_qr_batch.sh
+
+Docs: agentic_ai_context/LINEAGE_ASSETS.md  ·  DEPRECATED.md (this dir)
 """
+import os
+import subprocess
 import sys
 
-MESSAGE = (
-    "\n"
-    "  ╭───────────────────────────────────────────────────────────────╮\n"
-    "  │  This generator has moved.                                    │\n"
-    "  │                                                               │\n"
-    "  │  Old path (this file):                                        │\n"
-    "  │    tokenomics/python_scripts/agroverse_qr_code_generator/     │\n"
-    "  │                                                               │\n"
-    "  │  New path:                                                    │\n"
-    "  │    ~/Applications/lineage-assets/scripts/qr_generator/        │\n"
-    "  │                                                               │\n"
-    "  │  Run from the new path so output lands in lineage-assets      │\n"
-    "  │  (PNG + JSON manifest) and truesight.me/qr/?id=<id> resolves. │\n"
-    "  │                                                               │\n"
-    "  │  Migration doc: agentic_ai_context/LINEAGE_ASSETS.md          │\n"
-    "  ╰───────────────────────────────────────────────────────────────╯\n"
-)
+TARGET_DIR = os.path.expanduser("~/Applications/lineage-assets/scripts/qr_generator")
+TARGET = os.path.join(TARGET_DIR, "batch_compiler.py")
+
+# Flags whose values are filesystem paths — resolve to absolute before we cd.
+PATH_FLAGS = {
+    "--credentials", "--template", "--output-dir",
+    "--pngs-dir", "--qrs-dir", "--cacao-logo", "--non-cacao-logo",
+}
+
+
+def _resolve_paths(argv):
+    out, i = [], 0
+    while i < len(argv):
+        a = argv[i]
+        if a in PATH_FLAGS and i + 1 < len(argv):
+            v = argv[i + 1]
+            if v and not os.path.isabs(v):
+                v = os.path.abspath(v)
+            out += [a, v]
+            i += 2
+            continue
+        if "=" in a and a.split("=", 1)[0] in PATH_FLAGS:
+            flag, val = a.split("=", 1)
+            if val and not os.path.isabs(val):
+                val = os.path.abspath(val)
+            out.append(f"{flag}={val}")
+            i += 1
+            continue
+        out.append(a)
+        i += 1
+    return out
+
+
+def main():
+    if not os.path.exists(TARGET):
+        sys.stderr.write(
+            f"[error] QR generator not found at {TARGET}\n"
+            f"        Clone it:  git clone https://github.com/TrueSightDAO/lineage-assets.git "
+            f"~/Applications/lineage-assets\n"
+        )
+        return 2
+    sys.stderr.write(
+        "[note] batch_compiler moved to lineage-assets — forwarding there "
+        "(relative paths resolved).\n"
+        "       Canonical wrapper: lineage-assets/scripts/qr_generator/generate_qr_batch.sh\n"
+    )
+    args = _resolve_paths(sys.argv[1:])
+    return subprocess.call([sys.executable, "batch_compiler.py"] + args, cwd=TARGET_DIR)
+
 
 if __name__ == "__main__":
-    sys.stderr.write(MESSAGE)
-    sys.exit(2)
+    sys.exit(main())


### PR DESCRIPTION
The deprecated `tokenomics/python_scripts/agroverse_qr_code_generator/batch_compiler.py` hard-aborted with the 'moved to lineage-assets' message — breaking the historical command every time. It now **transparently forwards** to the lineage-assets generator, resolving relative `--credentials`/`--output-dir`/etc. against the caller's cwd, so the muscle-memory command just works. Canonical entry remains `lineage-assets/.../generate_qr_batch.sh`. 🤖 Generated with [Claude Code](https://claude.com/claude-code)