### PR TITLE
perf(gas): defer warmup full-body Gmail fetch — fix 504 (37s→5s)

### DIFF
--- a/clasp_mirrors/14gKJ0VW49RsSn4S03pgxKXy0sp4Z7Z3Wm1Wj8jQiWW5dj1sFuPnp95sh/store_interaction_history_api.gs
+++ b/clasp_mirrors/14gKJ0VW49RsSn4S03pgxKXy0sp4Z7Z3Wm1Wj8jQiWW5dj1sFuPnp95sh/store_interaction_history_api.gs
@@ -844,7 +844,11 @@ function doGet(e) {
       //   AI/Follow-up (manager follow-ups to replied prospects)
       // Implementation: warmup_review_api.gs (clasp_mirrors/.../WarmupReviewApi.gs).
       var lbl = (e.parameter.label || '').toString();
-      return success_(getWarmupReviewQueue_(lbl));
+      // Full Gmail bodies are an N+1 Gmail-API fetch (~37s) — opt-in only via
+      // ?withBodies=true. Default (page + notification badge) returns fast on the
+      // 500-char body_preview from the sheet; warmup_review.html falls back to it.
+      var withBodies = String(e.parameter.withBodies || '').toLowerCase() === 'true';
+      return success_(getWarmupReviewQueue_(lbl, withBodies));
     }
 
     if (action === 'apply_warmup_send') {

--- a/clasp_mirrors/14gKJ0VW49RsSn4S03pgxKXy0sp4Z7Z3Wm1Wj8jQiWW5dj1sFuPnp95sh/warmup_review_api.gs
+++ b/clasp_mirrors/14gKJ0VW49RsSn4S03pgxKXy0sp4Z7Z3Wm1Wj8jQiWW5dj1sFuPnp95sh/warmup_review_api.gs
@@ -35,7 +35,7 @@ var WARMUP_HOSTS_CIRCLES_HEADER = 'Hosts Circles';
  * Returns drafts grouped by label so the DApp can render tabs without
  * multiple API calls. One bulk read, one GmailApp.getDrafts() call.
  */
-function getWarmupReviewQueue_(optLabel) {
+function getWarmupReviewQueue_(optLabel, optWithBodies) {
   var ss = SpreadsheetApp.openById(HIT_LIST_SPREADSHEET_ID);
   var draftsSh = getSheetSafe_(ss, SHEET_EMAIL_DRAFTS);
   if (!draftsSh) {
@@ -74,7 +74,10 @@ function getWarmupReviewQueue_(optLabel) {
   var hasLiveDrafts = Object.keys(liveDraftIds).length > 0;
 
   // Build full-body lookup from live Gmail drafts (keyed by draft id).
-  var fullBodyByDraftId = hasLiveDrafts ? warmupBuildFullBodyMap_() : {};
+  // This is an N+1 Gmail-API fetch (getPlainBody per draft) — the dominant cost
+  // (~37s). Skip it unless explicitly requested; callers/UI fall back to the
+  // 500-char body_preview already stored in the sheet.
+  var fullBodyByDraftId = (optWithBodies === true && hasLiveDrafts) ? warmupBuildFullBodyMap_() : {};
   // Build prospect reply lookup from DApp Remarks (keyed by shop name lower).
   var prospectReplies = warmupBuildProspectReplyMap_(ss);
 

--- a/google_app_scripts/holistic_hit_list_store_history/store_interaction_history_api.gs
+++ b/google_app_scripts/holistic_hit_list_store_history/store_interaction_history_api.gs
@@ -844,7 +844,11 @@ function doGet(e) {
       //   AI/Follow-up (manager follow-ups to replied prospects)
       // Implementation: warmup_review_api.gs (clasp_mirrors/.../WarmupReviewApi.gs).
       var lbl = (e.parameter.label || '').toString();
-      return success_(getWarmupReviewQueue_(lbl));
+      // Full Gmail bodies are an N+1 Gmail-API fetch (~37s) — opt-in only via
+      // ?withBodies=true. Default (page + notification badge) returns fast on the
+      // 500-char body_preview from the sheet; warmup_review.html falls back to it.
+      var withBodies = String(e.parameter.withBodies || '').toLowerCase() === 'true';
+      return success_(getWarmupReviewQueue_(lbl, withBodies));
     }
 
     if (action === 'apply_warmup_send') {

--- a/google_app_scripts/holistic_hit_list_store_history/warmup_review_api.gs
+++ b/google_app_scripts/holistic_hit_list_store_history/warmup_review_api.gs
@@ -35,7 +35,7 @@ var WARMUP_HOSTS_CIRCLES_HEADER = 'Hosts Circles';
  * Returns drafts grouped by label so the DApp can render tabs without
  * multiple API calls. One bulk read, one GmailApp.getDrafts() call.
  */
-function getWarmupReviewQueue_(optLabel) {
+function getWarmupReviewQueue_(optLabel, optWithBodies) {
   var ss = SpreadsheetApp.openById(HIT_LIST_SPREADSHEET_ID);
   var draftsSh = getSheetSafe_(ss, SHEET_EMAIL_DRAFTS);
   if (!draftsSh) {
@@ -74,7 +74,10 @@ function getWarmupReviewQueue_(optLabel) {
   var hasLiveDrafts = Object.keys(liveDraftIds).length > 0;
 
   // Build full-body lookup from live Gmail drafts (keyed by draft id).
-  var fullBodyByDraftId = hasLiveDrafts ? warmupBuildFullBodyMap_() : {};
+  // This is an N+1 Gmail-API fetch (getPlainBody per draft) — the dominant cost
+  // (~37s). Skip it unless explicitly requested; callers/UI fall back to the
+  // 500-char body_preview already stored in the sheet.
+  var fullBodyByDraftId = (optWithBodies === true && hasLiveDrafts) ? warmupBuildFullBodyMap_() : {};
   // Build prospect reply lookup from DApp Remarks (keyed by shop name lower).
   var prospectReplies = warmupBuildProspectReplyMap_(ss);
 


### PR DESCRIPTION
Follow-up to #312 (re-based clean; supersedes #313 which conflicted with #312's mirror reorg). `getWarmupReviewQueue` was ~37s (N+1 Gmail `getPlainBody` per draft) → Edgar nginx 502/504. Full bodies now opt-in (`?withBodies=true`); default returns fast on the sheet's 500-char `body_preview` (warmup_review.html falls back gracefully). **Verified live: 37s→4.8s direct, 502→200 in 5.4s via proxy. Deployed @49.**