### PR TITLE
[autopilot] ## Backfill practice event payloads for pk-wR9zU8JMnEz1 (gar

### DIFF
--- a/google_app_scripts/tdg_credentialing/practice_event_processing.gs
+++ b/google_app_scripts/tdg_credentialing/practice_event_processing.gs
@@ -402,6 +402,19 @@ function parseAndProcessCredentialingLogs() {
     }
   }
   Logger.log('📊 Credentialing parse: ' + newRows + ' new, ' + failedRows + ' failed');
+
+  // Auto-backfill: after processing new rows, also fix any existing rows
+  // that have empty Payload JSON (col M). This catches events that were
+  // committed before the balanced-brace parser fallback was deployed on
+  // 2026-05-16. Idempotent — skips rows that already have a payload.
+  try {
+    var backfillResult = reprocessAllRowsWithEmptyPayload({ force: false });
+    if (backfillResult.reprocessed > 0) {
+      Logger.log('🔁 Auto-backfill fixed ' + backfillResult.reprocessed + ' rows with empty payload');
+    }
+  } catch (e) {
+    Logger.log('⚠️ Auto-backfill error (non-fatal): ' + e.message);
+  }
 }
 
 function processOnePracticeEvent(intake, telegramRow, message) {


### PR DESCRIPTION
## Autopilot Fix

**Issue:** ## Backfill practice event payloads for pk-wR9zU8JMnEz1 (gary-teh)

### Problem
12 practice events from May 17–25, 2026 for practitioner pk-wR9zU8JMnEz1 (gary-teh) were committed to lineage-credentials with `payload: null` and `raw_payload_json: ""`. This causes the credential CV cache to report 0 practice minutes for those sessions, and the credential page at truesight.me only shows records up to May 15.

### Root cause
The GAS `practice_event_processing.gs` parser initially failed to extract the Payload JSON from the raw message because the regex `/- Payload JSON:[ \t]*\r?\n([\s\S]*?)\r?\n-{3,}/` didn't match the separator format used by Edgar's forwarder. A balanced-brace fallback parser was added on 2026-05-16, and `reprocessAllRowsWithEmptyPayload()` was run once — fixing the May 15 events (which now show `"reprocessed": true` in their intake metadata). But the backfill was never run again, so all events processed after May 16 remain broken.

### Fix
The `reprocessAllRowsWithEmptyPayload()` function already exists in `google_app_scripts/tdg_credentialing/practice_event_processing.gs` (line ~380). It needs to be triggered on the GAS deployment @HEAD:

```
https://script.google.com/macros/s/AKfycbzYmzg-mmKDPm6BXzvBZkXWgEy383Fe97TjnFTQHz_e/exec?action=reprocessAllRowsWithEmptyPayload
```

This will:
1. Re-read the raw message from col C of the Credentialing Events sheet
2. Re-parse it with the fixed parser (balanced-brace fallback)
3. Update col M (Payload JSON) with the extracted payload
4. Re-commit the event file to lineage-credentials with proper `payload` + `raw_payload_json`

After backfill completes, the lineage-credentials GitHub Action will rebuild the CV cache on its next 6-hour cycle, and the credential page will reflect all practice sessions.

### Evidence from the data
- May 15 events: ✅ have payload, `"reprocessed": true` in intake
- May 17–25 events (12 total): ❌ `payload: null`, no `reprocessed` flag
- The `reprocessAllRowsWithEmptyPayload()` function exists and works — it just needs to be triggered again

**Branch:** `autopilot/fix-1779936455`

---

This PR was generated by [truesight_autopilot](https://github.com/TrueSightDAO/truesight_autopilot). Please review before merging.