### PR TITLE
[autopilot] ## Fix: doGet function conflict between practice_event_proce

### DIFF
--- a/google_app_scripts/tdg_credentialing/practice_event_processing.gs
+++ b/google_app_scripts/tdg_credentialing/practice_event_processing.gs
@@ -496,72 +496,15 @@ function listTriggers() {
 }
 
 /**
- * doGet — webhook entry. Triggered by Edgar's trigger_immediate_processing
- * branch for [PRACTICE EVENT] submissions, so processing happens in seconds
- * instead of waiting for the 10-min cron.
+ * doGet is defined in program_admin_endpoint.gs (the combined dispatcher).
+ * See that file for the full action routing table.
  *
- * URL shape:
- *   https://script.google.com/macros/s/<deployment>/exec?action=parseAndProcessCredentialingLogs
- *   https://script.google.com/macros/s/<deployment>/exec?action=installTimeTrigger
- *   https://script.google.com/macros/s/<deployment>/exec?action=reprocessAllRowsWithEmptyPayload
- *   https://script.google.com/macros/s/<deployment>/exec?action=reprocessCredentialingRow&row=5
+ * Actions from this file:
+ *   parseAndProcessCredentialingLogs
+ *   installTimeTrigger
+ *   reprocessAllRowsWithEmptyPayload
+ *   reprocessCredentialingRow&row=N
  */
-function doGet(e) {
-  var action = (e && e.parameter && e.parameter.action) || '';
-  Logger.log('doGet called with action: ' + (action || 'none'));
-
-  if (action === 'parseAndProcessCredentialingLogs') {
-    try {
-      parseAndProcessCredentialingLogs();
-      return ContentService.createTextOutput('✅ Credentialing logs processed.').setMimeType(ContentService.MimeType.TEXT);
-    } catch (err) {
-      Logger.log('❌ ' + err.message);
-      return ContentService.createTextOutput('❌ Error: ' + err.message).setMimeType(ContentService.MimeType.TEXT);
-    }
-  }
-
-  if (action === 'installTimeTrigger') {
-    return ContentService.createTextOutput(JSON.stringify(installTimeTrigger(), null, 2)).setMimeType(ContentService.MimeType.JSON);
-  }
-
-  // Backfill: re-parse + re-commit every PROCESSED row whose col M (Payload
-  // JSON) is empty. Use after pulling the balanced-brace parser fallback
-  // shipped 2026-05-16. Operator can curl the URL directly OR click it from
-  // a browser tab; returns a JSON summary.
-  if (action === 'reprocessAllRowsWithEmptyPayload') {
-    try {
-      var force = String((e && e.parameter && e.parameter.force) || '') === '1';
-      var summary = reprocessAllRowsWithEmptyPayload({ force: force });
-      return ContentService.createTextOutput(JSON.stringify(summary, null, 2)).setMimeType(ContentService.MimeType.JSON);
-    } catch (err) {
-      Logger.log('❌ reprocessAllRowsWithEmptyPayload error: ' + err.message);
-      return ContentService.createTextOutput(JSON.stringify({ ok: false, error: err.message })).setMimeType(ContentService.MimeType.JSON);
-    }
-  }
-
-  // Backfill a single row by number — useful for spot-fixes (e.g. when a
-  // newer parser bug surfaces and the operator wants to retry just one row).
-  if (action === 'reprocessCredentialingRow') {
-    var rowParam = (e && e.parameter && e.parameter.row) || '';
-    var rowNumber = parseInt(rowParam, 10);
-    if (!rowNumber || rowNumber < 2) {
-      return ContentService.createTextOutput(JSON.stringify({ ok: false, error: 'Missing or invalid &row=N (N must be >= 2)' })).setMimeType(ContentService.MimeType.JSON);
-    }
-    try {
-      var result = reprocessCredentialingRow(rowNumber);
-      return ContentService.createTextOutput(JSON.stringify(result, null, 2)).setMimeType(ContentService.MimeType.JSON);
-    } catch (err) {
-      Logger.log('❌ reprocessCredentialingRow(' + rowNumber + ') error: ' + err.message);
-      return ContentService.createTextOutput(JSON.stringify({ ok: false, rowNumber: rowNumber, error: err.message })).setMimeType(ContentService.MimeType.JSON);
-    }
-  }
-
-  return ContentService.createTextOutput(
-    'practice_event_processing.gs — ready. Actions: ' +
-    'parseAndProcessCredentialingLogs, installTimeTrigger, ' +
-    'reprocessAllRowsWithEmptyPayload, reprocessCredentialingRow&row=N'
-  ).setMimeType(ContentService.MimeType.TEXT);
-}
 
 // ============================================================================
 // BACKFILL — re-parse + re-commit existing PROCESSED rows that have empty

--- a/google_app_scripts/tdg_credentialing/program_admin_endpoint.gs
+++ b/google_app_scripts/tdg_credentialing/program_admin_endpoint.gs
@@ -233,12 +233,57 @@ function paListPendingRows(sheetUrl, tabName) {
 }
 
 // ============================================================================
-// HTTP API (admin panels call these)
+// HTTP API — combined dispatcher for ALL actions from both files
 // ============================================================================
 
+/**
+ * Combined doGet — routes actions from both practice_event_processing.gs and
+ * program_admin_endpoint.gs. This is the single entry point for the web app.
+ *
+ * Actions from practice_event_processing.gs:
+ *   ?action=parseAndProcessCredentialingLogs
+ *   ?action=installTimeTrigger
+ *   ?action=reprocessAllRowsWithEmptyPayload[&force=1]
+ *   ?action=reprocessCredentialingRow&row=N
+ *
+ * Actions from program_admin_endpoint.gs:
+ *   ?action=list_sheet_editors&sheet_url=<URL>
+ *   ?action=list_pending_rows&sheet_url=<URL>&tab=<tab>
+ *   ?action=resolve_admin&sheet_url=<URL>&email=<email>
+ *   ?action=process_attestation_events
+ */
 function doGet(e) {
   const action = (e && e.parameter && e.parameter.action) || '';
+  Logger.log('doGet called with action: ' + (action || 'none'));
+
   try {
+    // --- practice_event_processing.gs actions ---
+    if (action === 'parseAndProcessCredentialingLogs') {
+      parseAndProcessCredentialingLogs();
+      return ContentService.createTextOutput('✅ Credentialing logs processed.').setMimeType(ContentService.MimeType.TEXT);
+    }
+
+    if (action === 'installTimeTrigger') {
+      return ContentService.createTextOutput(JSON.stringify(installTimeTrigger(), null, 2)).setMimeType(ContentService.MimeType.JSON);
+    }
+
+    if (action === 'reprocessAllRowsWithEmptyPayload') {
+      const force = String((e && e.parameter && e.parameter.force) || '') === '1';
+      const summary = reprocessAllRowsWithEmptyPayload({ force: force });
+      return ContentService.createTextOutput(JSON.stringify(summary, null, 2)).setMimeType(ContentService.MimeType.JSON);
+    }
+
+    if (action === 'reprocessCredentialingRow') {
+      const rowParam = (e && e.parameter && e.parameter.row) || '';
+      const rowNumber = parseInt(rowParam, 10);
+      if (!rowNumber || rowNumber < 2) {
+        return ContentService.createTextOutput(JSON.stringify({ ok: false, error: 'Missing or invalid &row=N (N must be >= 2)' })).setMimeType(ContentService.MimeType.JSON);
+      }
+      const result = reprocessCredentialingRow(rowNumber);
+      return ContentService.createTextOutput(JSON.stringify(result, null, 2)).setMimeType(ContentService.MimeType.JSON);
+    }
+
+    // --- program_admin_endpoint.gs actions ---
     if (action === 'list_sheet_editors') {
       const sheetUrl = e.parameter.sheet_url;
       const editors = paListSheetEditors(sheetUrl);
@@ -260,6 +305,7 @@ function doGet(e) {
       const summary = paProcessAttestationEvents();
       return paJson({ status: 'ok', summary: summary });
     }
+
     return paJson({ status: 'error', message: 'Unknown action: ' + action }, 400);
   } catch (err) {
     return paJson({ status: 'error', message: String(err && err.message ? err.message : err) }, 500);


### PR DESCRIPTION
## Autopilot Fix

**Issue:** ## Fix: doGet function conflict between practice_event_processing.gs and program_admin_endpoint.gs

### Root cause of the null payload issue
Both `practice_event_processing.gs` and `program_admin_endpoint.gs` define a `doGet(e)` function. In Google Apps Script, when two files define the same function, the **last one loaded wins**. Since `program_admin_endpoint.gs` loads after `practice_event_processing.gs`, its `doGet` overrides the one from `practice_event_processing.gs`.

This means:
1. The `reprocessAllRowsWithEmptyPayload` action (defined in `practice_event_processing.gs`'s `doGet`) is **never reachable** via the web app URL
2. The `parseAndProcessCredentialingLogs` action is also unreachable via webhook
3. Only the actions defined in `program_admin_endpoint.gs`'s `doGet` work (`list_sheet_editors`, `list_pending_rows`, `resolve_admin`, `process_attestation_events`)

This is why calling `?action=reprocessAllRowsWithEmptyPayload` returns `{"status":"error","message":"Unknown action: reprocessAllRowsWithEmptyPayload"}`

### Impact
- 12 practice events for pk-wR9zU8JMnEz1 (gary-teh) from May 17–25 have `payload: null` because the backfill function can't be triggered
- The 10-minute cron trigger (`parseAndProcessCredentialingLogs`) still works because it's called directly by the trigger, not through `doGet`
- But the webhook (`trigger_immediate_processing`) can't call `parseAndProcessCredentialingLogs` via the deployment URL because `doGet` is shadowed

### Fix
Merge the two `doGet` functions into a single dispatcher that handles actions from both files. The combined `doGet` should be placed in a shared file (or one of the existing files) and should route:

From `practice_event_processing.gs`:
- `parseAndProcessCredentialingLogs`
- `installTimeTrigger`
- `reprocessAllRowsWithEmptyPayload`
- `reprocessCredentialingRow`

From `program_admin_endpoint.gs`:
- `list_sheet_editors`
- `list_pending_rows`
- `resolve_admin`
- `process_attestation_events`

### Steps to deploy
1. Merge the `doGet` functions into one
2. `clasp push` to update the project code
3. The @HEAD deployment will immediately reflect the change
4. Visit `?action=reprocessAllRowsWithEmptyPayload` to backfill the 12 broken events
5. After backfill, the lineage-credentials CV cache will rebuild on its next 6-hour cycle

**Branch:** `autopilot/fix-1779937444`

---

This PR was generated by [truesight_autopilot](https://github.com/TrueSightDAO/truesight_autopilot). Please review before merging.