### PR TITLE
PR-1c: cache-refresh hook audit (mirror-grounded, per Gary's correction)

### DIFF
--- a/docs/gas_cache_refresh_hook_audit.md
+++ b/docs/gas_cache_refresh_hook_audit.md
@@ -1,0 +1,80 @@
+# GAS cache-refresh hook audit (mirror-grounded)
+
+_Generated: 2026-05-28 by `scripts/crawl_gas_cache_refresh_hooks.py`._
+
+Closes the cache-refresh-hooks pre-flight item in [`agentic_ai_context/TOKENOMICS_GAS_RESTRUCTURE_PLAN.md` §4](https://github.com/TrueSightDAO/agentic_ai_context/blob/main/TOKENOMICS_GAS_RESTRUCTURE_PLAN.md).
+
+**Grounding shift (Gary, 2026-05-28):** earlier passes used `.gs` header-comment URLs in `google_app_scripts/<theme>/` as the source of which scriptId owns which file. That proxy missed real handlers (many `.gs` files don't carry the convention). This pass operates directly on `clasp_mirrors/<scriptId>/Code.js` — the bundled JS clasp actually pushes — which is authoritative.
+
+Approach is conservative: every match below is a **candidate** hook, not an auto-promoted `post_push_hooks` entry. Operator confirms per project that firing the hook on every `clasp push` is the intended side effect, then moves the entry into `post_push_hooks` with a real URL + method + body shape.
+
+## Candidates per scriptId
+
+### `19Wag9x-sjbLVgIsPh2vj90ZG7Rgq2iGaVOomAeAvtg6CdZKJHLZ9AJrC`
+
+_Source: `clasp_mirrors/19Wag9x-sjbLVgIsPh2vj90ZG7Rgq2iGaVOomAeAvtg6CdZKJHLZ9AJrC/Code.js`._
+
+**Handler functions** (name contains both 'cache' and a refresh-class verb):
+
+- `notifyTreasuryCachePublisher_`
+
+
+### `1duQFfTO0Pj0lC4tPVNmMOhNOS1GvJgzqVxXbsEDu-eqt_64DwxvrOVyl`
+
+_Source: `clasp_mirrors/1duQFfTO0Pj0lC4tPVNmMOhNOS1GvJgzqVxXbsEDu-eqt_64DwxvrOVyl/Code.js`._
+
+**Handler functions** (name contains both 'cache' and a refresh-class verb):
+
+- `notifyTreasuryCachePublisher_`
+
+
+### `1m8IZPs1vFN99cuu-39kbC-OGXggRVtJtXq5rfSB0M1sCQjMdolEUDuGU`
+
+_Source: `clasp_mirrors/1m8IZPs1vFN99cuu-39kbC-OGXggRVtJtXq5rfSB0M1sCQjMdolEUDuGU/Code.js`._
+
+**Action-string literals** (dispatch values that mention both 'refresh' and 'cache'):
+
+- `'refresh_dao_members_cache'`
+
+
+### `1orWgdGckts55owiYOysR_y4sde52T_eUmrtDGAEkb4YV5DlUfJ0JZC5J`
+
+_Source: `clasp_mirrors/1orWgdGckts55owiYOysR_y4sde52T_eUmrtDGAEkb4YV5DlUfJ0JZC5J/Code.js`._
+
+**Handler functions** (name contains both 'cache' and a refresh-class verb):
+
+- `notifyTreasuryCachePublisher_`
+
+
+### `1wONDeDwZ_fXNapDKpstWrBION3aV3r7NXwq7PCdqbW1LvI5ceaykQNbR`
+
+_Source: `clasp_mirrors/1wONDeDwZ_fXNapDKpstWrBION3aV3r7NXwq7PCdqbW1LvI5ceaykQNbR/Code.js`._
+
+**Handler functions** (name contains both 'cache' and a refresh-class verb):
+
+- `notifyTreasuryCachePublisher_`
+
+
+### `1wmgYPwfRDxpiboa8OH-C6Ndovklf8HaJY305n7dhRzs7BmUBQg7fL_sZ`
+
+_Source: `clasp_mirrors/1wmgYPwfRDxpiboa8OH-C6Ndovklf8HaJY305n7dhRzs7BmUBQg7fL_sZ/Code.js`._
+
+**Handler functions** (name contains both 'cache' and a refresh-class verb):
+
+- `notifyTreasuryCachePublisher_`
+
+
+## Consumer callers using a refresh-style action but no resolvable scriptId binding
+
+- `agentic_ai_context/TOKENOMICS_GAS_RESTRUCTURE_PLAN.md` — action `refresh_dao_members_cache`
+- `tokenomics/google_app_scripts/tdg_identity_management/dao_members_cache_publisher.gs` — action `refresh_dao_members_cache`
+- `tokenomics/google_app_scripts/tdg_identity_management/edgar_send_email_verification.gs` — action `refresh_dao_members_cache`
+
+## Summary
+
+- scriptIds with at least one candidate hook: **6**
+- distinct handler functions discovered: **5**
+- distinct refresh+cache action strings: **1**
+- consumer-side action references found: **3**
+
+Operator promotion path: confirm the candidate in the GAS UI, then move it from `candidate_cache_refresh_hooks` into the manifest's `post_push_hooks[]` with the full URL + method + body.

--- a/google_app_scripts/agroverse_notarizations/manifest.json
+++ b/google_app_scripts/agroverse_notarizations/manifest.json
@@ -17,6 +17,7 @@
       },
       "post_push_hooks": [],
       "consumer_callers": [],
+      "candidate_cache_refresh_hooks": [],
       "source_files": [
         "process_notarization_telegram_logs.gs"
       ],

--- a/google_app_scripts/agroverse_qr_codes/manifest.json
+++ b/google_app_scripts/agroverse_qr_codes/manifest.json
@@ -75,6 +75,7 @@
         "dapp/view_inventory_holdings.html",
         "dapp/withdraw_voting_rights.html"
       ],
+      "candidate_cache_refresh_hooks": [],
       "source_files": [
         "process_donation_mint_telegram_logs.gs",
         "qr_code_web_service.gs"
@@ -90,6 +91,7 @@
       },
       "post_push_hooks": [],
       "consumer_callers": [],
+      "candidate_cache_refresh_hooks": [],
       "source_files": [
         "Version.gs",
         "process_qr_code_generation_telegram_logs.gs"
@@ -105,6 +107,7 @@
       },
       "post_push_hooks": [],
       "consumer_callers": [],
+      "candidate_cache_refresh_hooks": [],
       "source_files": [
         "process_qr_code_updates.gs"
       ],
@@ -119,6 +122,7 @@
       },
       "post_push_hooks": [],
       "consumer_callers": [],
+      "candidate_cache_refresh_hooks": [],
       "source_files": [
         "web_app.gs"
       ],

--- a/google_app_scripts/agroverse_site_statistics/manifest.json
+++ b/google_app_scripts/agroverse_site_statistics/manifest.json
@@ -27,6 +27,7 @@
       "consumer_callers": [
         "agroverse_shop/index.html"
       ],
+      "candidate_cache_refresh_hooks": [],
       "source_files": [
         "agroverse_wix_site_updates.gs"
       ],

--- a/google_app_scripts/find_nearby_stores/manifest.json
+++ b/google_app_scripts/find_nearby_stores/manifest.json
@@ -17,6 +17,7 @@
       },
       "post_push_hooks": [],
       "consumer_callers": [],
+      "candidate_cache_refresh_hooks": [],
       "source_files": [
         "process_retail_field_reports_telegram_logs.gs",
         "process_store_adds_telegram_logs.gs"

--- a/google_app_scripts/holistic_hit_list_store_history/manifest.json
+++ b/google_app_scripts/holistic_hit_list_store_history/manifest.json
@@ -30,6 +30,7 @@
         "dapp/stores_by_status.html",
         "dapp/warmup_review.html"
       ],
+      "candidate_cache_refresh_hooks": [],
       "source_files": [
         "email_agent_drafts.gs",
         "partner_poke_drafts.gs",

--- a/google_app_scripts/newsletter_subscriber_sync/manifest.json
+++ b/google_app_scripts/newsletter_subscriber_sync/manifest.json
@@ -17,6 +17,7 @@
       },
       "post_push_hooks": [],
       "consumer_callers": [],
+      "candidate_cache_refresh_hooks": [],
       "source_files": [
         "newsletter_subscriber_sync.gs"
       ],

--- a/google_app_scripts/pipeline_metrics_snapshot/manifest.json
+++ b/google_app_scripts/pipeline_metrics_snapshot/manifest.json
@@ -17,6 +17,7 @@
       },
       "post_push_hooks": [],
       "consumer_callers": [],
+      "candidate_cache_refresh_hooks": [],
       "source_files": [
         "sync_pipeline_metrics.gs"
       ],

--- a/google_app_scripts/seacoast_freight_quotation_ingest/manifest.json
+++ b/google_app_scripts/seacoast_freight_quotation_ingest/manifest.json
@@ -17,6 +17,7 @@
       },
       "post_push_hooks": [],
       "consumer_callers": [],
+      "candidate_cache_refresh_hooks": [],
       "source_files": [
         "Code.gs"
       ],

--- a/google_app_scripts/sunmint_tree_planting/manifest.json
+++ b/google_app_scripts/sunmint_tree_planting/manifest.json
@@ -17,6 +17,7 @@
       },
       "post_push_hooks": [],
       "consumer_callers": [],
+      "candidate_cache_refresh_hooks": [],
       "source_files": [
         "process_tree_planting_telegram_logs.gs"
       ],

--- a/google_app_scripts/tdg_asset_management/manifest.json
+++ b/google_app_scripts/tdg_asset_management/manifest.json
@@ -27,6 +27,7 @@
       "consumer_callers": [
         "agentic_ai_context/STRIPE_LEDGER_ROUTING.md"
       ],
+      "candidate_cache_refresh_hooks": [],
       "source_files": [
         "stripe_sales_sync.gs"
       ],
@@ -41,6 +42,7 @@
       },
       "post_push_hooks": [],
       "consumer_callers": [],
+      "candidate_cache_refresh_hooks": [],
       "source_files": [
         "tdg_airdrop_refresher.gs"
       ],
@@ -63,6 +65,16 @@
       },
       "post_push_hooks": [],
       "consumer_callers": [],
+      "candidate_cache_refresh_hooks": [
+        {
+          "handler_functions": [
+            "notifyTreasuryCachePublisher_"
+          ],
+          "action_strings": [],
+          "mirror_code_path": "clasp_mirrors/19Wag9x-sjbLVgIsPh2vj90ZG7Rgq2iGaVOomAeAvtg6CdZKJHLZ9AJrC/Code.js",
+          "consumer_callers_with_known_url": []
+        }
+      ],
       "source_files": [
         "tdg_expenses_processing.gs"
       ],
@@ -77,6 +89,7 @@
       },
       "post_push_hooks": [],
       "consumer_callers": [],
+      "candidate_cache_refresh_hooks": [],
       "source_files": [
         "tdg_recurring_tokenization_monthly.gs"
       ],
@@ -91,6 +104,7 @@
       },
       "post_push_hooks": [],
       "consumer_callers": [],
+      "candidate_cache_refresh_hooks": [],
       "source_files": [
         "tdg_wallet_balance_check.gs"
       ],
@@ -105,6 +119,7 @@
       },
       "post_push_hooks": [],
       "consumer_callers": [],
+      "candidate_cache_refresh_hooks": [],
       "source_files": [
         "tdg_wix_dashboard.gs"
       ],
@@ -119,6 +134,16 @@
       },
       "post_push_hooks": [],
       "consumer_callers": [],
+      "candidate_cache_refresh_hooks": [
+        {
+          "handler_functions": [
+            "notifyTreasuryCachePublisher_"
+          ],
+          "action_strings": [],
+          "mirror_code_path": "clasp_mirrors/1orWgdGckts55owiYOysR_y4sde52T_eUmrtDGAEkb4YV5DlUfJ0JZC5J/Code.js",
+          "consumer_callers_with_known_url": []
+        }
+      ],
       "source_files": [
         "capital_injection_processing.gs"
       ],
@@ -133,6 +158,7 @@
       },
       "post_push_hooks": [],
       "consumer_callers": [],
+      "candidate_cache_refresh_hooks": [],
       "source_files": [
         "tdg_wix_dashboard.gs",
         "web_app.gs"

--- a/google_app_scripts/tdg_credentialing/manifest.json
+++ b/google_app_scripts/tdg_credentialing/manifest.json
@@ -17,6 +17,7 @@
       },
       "post_push_hooks": [],
       "consumer_callers": [],
+      "candidate_cache_refresh_hooks": [],
       "source_files": [
         "practice_event_processing.gs"
       ],

--- a/google_app_scripts/tdg_identity_management/manifest.json
+++ b/google_app_scripts/tdg_identity_management/manifest.json
@@ -25,6 +25,7 @@
       },
       "post_push_hooks": [],
       "consumer_callers": [],
+      "candidate_cache_refresh_hooks": [],
       "source_files": [
         "register_member_digital_signatures_telegram.gs"
       ],
@@ -39,6 +40,16 @@
       },
       "post_push_hooks": [],
       "consumer_callers": [],
+      "candidate_cache_refresh_hooks": [
+        {
+          "handler_functions": [],
+          "action_strings": [
+            "refresh_dao_members_cache"
+          ],
+          "mirror_code_path": "clasp_mirrors/1m8IZPs1vFN99cuu-39kbC-OGXggRVtJtXq5rfSB0M1sCQjMdolEUDuGU/Code.js",
+          "consumer_callers_with_known_url": []
+        }
+      ],
       "source_files": [
         "email_verification_from_edgar.gs"
       ],
@@ -61,6 +72,7 @@
       },
       "post_push_hooks": [],
       "consumer_callers": [],
+      "candidate_cache_refresh_hooks": [],
       "source_files": [
         "register_member_digital_signatures_email.gs"
       ],

--- a/google_app_scripts/tdg_inventory_management/manifest.json
+++ b/google_app_scripts/tdg_inventory_management/manifest.json
@@ -34,6 +34,7 @@
         "dapp/routes.js",
         "dapp/view_inventory_holdings.html"
       ],
+      "candidate_cache_refresh_hooks": [],
       "source_files": [
         "Version.gs",
         "web_app.gs"
@@ -57,6 +58,7 @@
       },
       "post_push_hooks": [],
       "consumer_callers": [],
+      "candidate_cache_refresh_hooks": [],
       "source_files": [
         "process_sales_telegram_logs.gs"
       ],
@@ -71,6 +73,16 @@
       },
       "post_push_hooks": [],
       "consumer_callers": [],
+      "candidate_cache_refresh_hooks": [
+        {
+          "handler_functions": [
+            "notifyTreasuryCachePublisher_"
+          ],
+          "action_strings": [],
+          "mirror_code_path": "clasp_mirrors/1duQFfTO0Pj0lC4tPVNmMOhNOS1GvJgzqVxXbsEDu-eqt_64DwxvrOVyl/Code.js",
+          "consumer_callers_with_known_url": []
+        }
+      ],
       "source_files": [
         "sales_update_managed_agl_ledgers.gs"
       ],
@@ -93,6 +105,16 @@
       },
       "post_push_hooks": [],
       "consumer_callers": [],
+      "candidate_cache_refresh_hooks": [
+        {
+          "handler_functions": [
+            "notifyTreasuryCachePublisher_"
+          ],
+          "action_strings": [],
+          "mirror_code_path": "clasp_mirrors/1wONDeDwZ_fXNapDKpstWrBION3aV3r7NXwq7PCdqbW1LvI5ceaykQNbR/Code.js",
+          "consumer_callers_with_known_url": []
+        }
+      ],
       "source_files": [
         "process_movement_telegram_logs.gs"
       ],
@@ -123,6 +145,16 @@
       },
       "post_push_hooks": [],
       "consumer_callers": [],
+      "candidate_cache_refresh_hooks": [
+        {
+          "handler_functions": [
+            "notifyTreasuryCachePublisher_"
+          ],
+          "action_strings": [],
+          "mirror_code_path": "clasp_mirrors/1wmgYPwfRDxpiboa8OH-C6Ndovklf8HaJY305n7dhRzs7BmUBQg7fL_sZ/Code.js",
+          "consumer_callers_with_known_url": []
+        }
+      ],
       "source_files": [
         "sales_update_main_dao_offchain_ledger.gs"
       ],

--- a/google_app_scripts/tdg_proposal/manifest.json
+++ b/google_app_scripts/tdg_proposal/manifest.json
@@ -25,6 +25,7 @@
       },
       "post_push_hooks": [],
       "consumer_callers": [],
+      "candidate_cache_refresh_hooks": [],
       "source_files": [
         "proposal_manager.gs"
       ],

--- a/google_app_scripts/tdg_scoring/manifest.json
+++ b/google_app_scripts/tdg_scoring/manifest.json
@@ -17,6 +17,7 @@
       },
       "post_push_hooks": [],
       "consumer_callers": [],
+      "candidate_cache_refresh_hooks": [],
       "source_files": [
         "transfer_scored_contributions_to_main_ledger.gs"
       ],
@@ -39,6 +40,7 @@
       },
       "post_push_hooks": [],
       "consumer_callers": [],
+      "candidate_cache_refresh_hooks": [],
       "source_files": [
         "grok_scoring_for_telegram_and_whatsapp_logs.gs"
       ],
@@ -61,6 +63,7 @@
       },
       "post_push_hooks": [],
       "consumer_callers": [],
+      "candidate_cache_refresh_hooks": [],
       "source_files": [
         "importer_telegram_chatlogs_to_google_sheet.gs"
       ],

--- a/google_app_scripts/tdg_shipping_planner/manifest.json
+++ b/google_app_scripts/tdg_shipping_planner/manifest.json
@@ -31,6 +31,7 @@
         "dapp/routes.js",
         "dapp/shipping_planner.html"
       ],
+      "candidate_cache_refresh_hooks": [],
       "source_files": [
         "shipping_planner_api.gs"
       ],

--- a/google_app_scripts/webhooks/manifest.json
+++ b/google_app_scripts/webhooks/manifest.json
@@ -25,6 +25,7 @@
       },
       "post_push_hooks": [],
       "consumer_callers": [],
+      "candidate_cache_refresh_hooks": [],
       "source_files": [
         "telegram_webhook_listener.gs"
       ],
@@ -47,6 +48,16 @@
       },
       "post_push_hooks": [],
       "consumer_callers": [],
+      "candidate_cache_refresh_hooks": [
+        {
+          "handler_functions": [
+            "notifyTreasuryCachePublisher_"
+          ],
+          "action_strings": [],
+          "mirror_code_path": "clasp_mirrors/19Wag9x-sjbLVgIsPh2vj90ZG7Rgq2iGaVOomAeAvtg6CdZKJHLZ9AJrC/Code.js",
+          "consumer_callers_with_known_url": []
+        }
+      ],
       "source_files": [
         "telegram_webhook_listener.gs"
       ],
@@ -69,6 +80,7 @@
       },
       "post_push_hooks": [],
       "consumer_callers": [],
+      "candidate_cache_refresh_hooks": [],
       "source_files": [
         "telegram_webhook_listener.gs"
       ],
@@ -91,6 +103,7 @@
       },
       "post_push_hooks": [],
       "consumer_callers": [],
+      "candidate_cache_refresh_hooks": [],
       "source_files": [
         "telegram_webhook_listener.gs"
       ],
@@ -113,6 +126,7 @@
       },
       "post_push_hooks": [],
       "consumer_callers": [],
+      "candidate_cache_refresh_hooks": [],
       "source_files": [
         "telegram_webhook_listener.gs"
       ],
@@ -127,6 +141,16 @@
       },
       "post_push_hooks": [],
       "consumer_callers": [],
+      "candidate_cache_refresh_hooks": [
+        {
+          "handler_functions": [
+            "notifyTreasuryCachePublisher_"
+          ],
+          "action_strings": [],
+          "mirror_code_path": "clasp_mirrors/1duQFfTO0Pj0lC4tPVNmMOhNOS1GvJgzqVxXbsEDu-eqt_64DwxvrOVyl/Code.js",
+          "consumer_callers_with_known_url": []
+        }
+      ],
       "source_files": [
         "telegram_webhook_listener.gs"
       ],
@@ -141,6 +165,7 @@
       },
       "post_push_hooks": [],
       "consumer_callers": [],
+      "candidate_cache_refresh_hooks": [],
       "source_files": [
         "telegram_webhook_listener.gs"
       ],
@@ -171,6 +196,16 @@
       },
       "post_push_hooks": [],
       "consumer_callers": [],
+      "candidate_cache_refresh_hooks": [
+        {
+          "handler_functions": [
+            "notifyTreasuryCachePublisher_"
+          ],
+          "action_strings": [],
+          "mirror_code_path": "clasp_mirrors/1wmgYPwfRDxpiboa8OH-C6Ndovklf8HaJY305n7dhRzs7BmUBQg7fL_sZ/Code.js",
+          "consumer_callers_with_known_url": []
+        }
+      ],
       "source_files": [
         "telegram_webhook_listener.gs"
       ],

--- a/google_app_scripts/wix_workflows/manifest.json
+++ b/google_app_scripts/wix_workflows/manifest.json
@@ -17,6 +17,7 @@
       },
       "post_push_hooks": [],
       "consumer_callers": [],
+      "candidate_cache_refresh_hooks": [],
       "source_files": [
         "populate_wix_event.gs"
       ],

--- a/scripts/crawl_gas_cache_refresh_hooks.py
+++ b/scripts/crawl_gas_cache_refresh_hooks.py
@@ -1,0 +1,316 @@
+#!/usr/bin/env python3
+"""Crawl cache-refresh hooks — mirror-grounded.
+
+Operates on `clasp_mirrors/<scriptId>/Code.js` (the locally-clasp-pulled,
+gitignored, concatenated source of every .gs file in that GAS project)
+rather than scanning google_app_scripts/<theme>/*.gs for header-comment
+URLs. The mirror IS the authoritative deployment unit — that's the lesson
+of the orphan-mirror audit (some .gs sources don't carry the header
+convention; some files outside thematic folders DO belong to a scriptId).
+
+For each mirror's Code.js:
+1. Find function definitions whose name contains both a "cache" stem AND
+   a refresh-class verb (refresh / publish / update / invalidate / rebuild
+   / sync / reset). Cache-write internals like `cacheAumBreakdown` are
+   filtered out because they lack a refresh-class verb in the name.
+2. Find string literals that contain both "refresh" and "cache" (the
+   action-enum values a doPost / doGet handler dispatches on).
+
+Also scans consumer repos for any reference to action=refresh_* with a
+known /exec URL in the same line, binding the caller back to its scriptId
+via the URL→scriptId map.
+
+Output:
+- Per-manifest field `candidate_cache_refresh_hooks` carries the discovered
+  handler names, action strings, mirror Code.js paths, and consumer
+  callers per scriptId.
+- docs/gas_cache_refresh_hook_audit.md is the operator-triage table.
+
+Conservative by design: candidates are NOT auto-promoted to post_push_hooks.
+Operator confirms per project that firing the hook on every clasp push is
+the intended side effect, then moves the entry into post_push_hooks with
+a real URL+method+body.
+"""
+from __future__ import annotations
+
+import json
+import re
+import subprocess
+from datetime import date
+from pathlib import Path
+
+TOKENOMICS = Path(__file__).resolve().parent.parent
+SRC = TOKENOMICS / "google_app_scripts"
+MIRRORS = TOKENOMICS / "clasp_mirrors"
+WORKSPACE = TOKENOMICS.parent
+CONSUMER_REPOS = [
+    "dapp",
+    "truesight_autopilot",
+    "agentic_ai_context",
+    "agroverse_shop",
+    "truesight_me",
+    "agentic_ai_api_credentials",
+    "ecosystem_change_logs",
+    "market_research",
+    "tokenomics",
+]
+
+REFRESH_VERBS = {"refresh", "publish", "update", "invalidate", "rebuild", "sync", "reset"}
+
+FUNC_DEF_RE = re.compile(r"function\s+([A-Za-z_][A-Za-z0-9_]*)\s*\(")
+STRING_LITERAL_RE = re.compile(r"['\"]([A-Za-z_][A-Za-z0-9_]{4,})['\"]")
+EXEC_URL_RE = re.compile(r"https://script\.google\.com/macros/s/[A-Za-z0-9_-]+/exec")
+SCRIPT_ID_RE = re.compile(r"script\.google\.com/home/projects/([A-Za-z0-9_-]+)")
+CONSUMER_ACTION_RE = re.compile(
+    r"(?:action=|[\"']action[\"']\s*[:=]\s*[\"'])"
+    r"([A-Za-z_][A-Za-z0-9_]*)"
+)
+
+
+def is_hook_func(name: str) -> bool:
+    n = name.lower()
+    return "cache" in n and any(v in n for v in REFRESH_VERBS)
+
+
+def is_hook_action(literal: str) -> bool:
+    n = literal.lower()
+    return "refresh" in n and "cache" in n
+
+
+def scan_mirror(code_js: Path) -> tuple[set[str], set[str]]:
+    try:
+        text = code_js.read_text(encoding="utf-8", errors="replace")
+    except OSError:
+        return set(), set()
+    funcs = {m for m in FUNC_DEF_RE.findall(text) if is_hook_func(m)}
+    actions = {m for m in STRING_LITERAL_RE.findall(text) if is_hook_action(m)}
+    return funcs, actions
+
+
+def build_url_to_scriptid_map() -> dict[str, str]:
+    """Mirror-grounded: read each mirror's Code.js for /exec URLs (most
+    accurate source — the script knows its own deployment URL)."""
+    out: dict[str, str] = {}
+    if not MIRRORS.is_dir():
+        return out
+    for mdir in sorted(MIRRORS.iterdir()):
+        if not mdir.is_dir():
+            continue
+        sid = mdir.name
+        code = mdir / "Code.js"
+        if not code.is_file():
+            continue
+        try:
+            text = code.read_text(encoding="utf-8", errors="replace")
+        except OSError:
+            continue
+        for url in EXEC_URL_RE.findall(text):
+            out[url] = sid
+
+    # Augment with whatever the .gs source comments reveal (some .gs files
+    # carry the URL in a doc comment that the bundled Code.js may not).
+    for gs in SRC.rglob("*.gs"):
+        try:
+            text = gs.read_text(encoding="utf-8", errors="replace")
+        except OSError:
+            continue
+        sids = set(SCRIPT_ID_RE.findall(text))
+        if len(sids) != 1:
+            continue
+        sid = next(iter(sids))
+        for url in EXEC_URL_RE.findall(text):
+            out.setdefault(url, sid)
+    return out
+
+
+def consumer_grep_actions() -> list[tuple[str, str, str]]:
+    """Return [(repo/path, action, line)] for any line referencing
+    action=<something> in a consumer repo."""
+    hits: list[tuple[str, str, str]] = []
+    for repo in CONSUMER_REPOS:
+        root = WORKSPACE / repo
+        if not root.is_dir():
+            continue
+        try:
+            r = subprocess.run(
+                ["git", "-C", str(root), "grep", "-n", "-E",
+                 r"(action=[A-Za-z_][A-Za-z0-9_]*|[\"']action[\"'][^,}]{0,40}[\"'][A-Za-z_][A-Za-z0-9_]*[\"'])"],
+                capture_output=True, text=True, check=False,
+            )
+            for line in r.stdout.splitlines():
+                parts = line.split(":", 2)
+                if len(parts) != 3:
+                    continue
+                path, _ln, content = parts
+                m = CONSUMER_ACTION_RE.search(content)
+                if not m:
+                    continue
+                action = m.group(1)
+                if not is_hook_action(action) and "refresh" not in action.lower():
+                    continue
+                hits.append((f"{repo}/{path}", action, content.strip()[:240]))
+        except FileNotFoundError:
+            continue
+    return hits
+
+
+def main() -> None:
+    # Pass A — mirror-grounded discovery.
+    per_sid: dict[str, dict] = {}
+    if not MIRRORS.is_dir():
+        print("  no clasp_mirrors/ directory — aborting")
+        return
+    for mdir in sorted(MIRRORS.iterdir()):
+        if not mdir.is_dir() or mdir.name.startswith("."):
+            continue
+        sid = mdir.name
+        code = mdir / "Code.js"
+        if not code.is_file():
+            continue
+        funcs, actions = scan_mirror(code)
+        if not funcs and not actions:
+            continue
+        per_sid[sid] = {
+            "handler_functions": sorted(funcs),
+            "action_strings": sorted(actions),
+            "mirror_code_path": str(code.relative_to(TOKENOMICS)),
+        }
+
+    # Pass B — consumer-side bindings.
+    url_to_sid = build_url_to_scriptid_map()
+    consumer_hits = consumer_grep_actions()
+    callers_by_sid: dict[str, list[dict]] = {}
+    for path, action, line in consumer_hits:
+        bound_sid = None
+        for url, sid in url_to_sid.items():
+            if url in line or url.split("/exec")[0] in line:
+                bound_sid = sid
+                break
+        callers_by_sid.setdefault(bound_sid or "UNBOUND", []).append({
+            "path": path, "action": action, "line": line,
+        })
+
+    # Build per-project candidate block.
+    sid_to_block: dict[str, dict] = {}
+    for sid, e in per_sid.items():
+        callers = sorted({c["path"] for c in callers_by_sid.get(sid, [])})
+        sid_to_block[sid] = {
+            "handler_functions": e["handler_functions"],
+            "action_strings": e["action_strings"],
+            "mirror_code_path": e["mirror_code_path"],
+            "consumer_callers_with_known_url": callers,
+        }
+
+    # Write into manifests.
+    updated = 0
+    for manifest_path in sorted(SRC.glob("*/manifest.json")):
+        manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+        changed = False
+        for project in manifest.get("projects", []):
+            sid = project.get("scriptId")
+            block = sid_to_block.get(sid)
+            if block is not None:
+                new_list = [block]
+            else:
+                new_list = []
+            if project.get("candidate_cache_refresh_hooks") != new_list:
+                project["candidate_cache_refresh_hooks"] = new_list
+                changed = True
+        if changed:
+            manifest_path.write_text(
+                json.dumps(manifest, indent=2, ensure_ascii=False) + "\n",
+                encoding="utf-8",
+            )
+            updated += 1
+            print(f"  updated {manifest_path.relative_to(TOKENOMICS)}")
+
+    # Write audit doc.
+    md = [
+        "# GAS cache-refresh hook audit (mirror-grounded)",
+        "",
+        f"_Generated: {date.today().isoformat()} by `scripts/crawl_gas_cache_refresh_hooks.py`._",
+        "",
+        "Closes the cache-refresh-hooks pre-flight item in "
+        "[`agentic_ai_context/TOKENOMICS_GAS_RESTRUCTURE_PLAN.md` §4]"
+        "(https://github.com/TrueSightDAO/agentic_ai_context/blob/main/TOKENOMICS_GAS_RESTRUCTURE_PLAN.md).",
+        "",
+        "**Grounding shift (Gary, 2026-05-28):** earlier passes used `.gs` "
+        "header-comment URLs in `google_app_scripts/<theme>/` as the source "
+        "of which scriptId owns which file. That proxy missed real handlers "
+        "(many `.gs` files don't carry the convention). This pass operates "
+        "directly on `clasp_mirrors/<scriptId>/Code.js` — the bundled JS "
+        "clasp actually pushes — which is authoritative.",
+        "",
+        "Approach is conservative: every match below is a **candidate** "
+        "hook, not an auto-promoted `post_push_hooks` entry. Operator "
+        "confirms per project that firing the hook on every `clasp push` "
+        "is the intended side effect, then moves the entry into "
+        "`post_push_hooks` with a real URL + method + body shape.",
+        "",
+        "## Candidates per scriptId",
+        "",
+    ]
+    if not per_sid:
+        md.append("_No cache-refresh handler patterns found in any mirror's `Code.js`._")
+        md.append("")
+    for sid in sorted(per_sid.keys()):
+        e = per_sid[sid]
+        md.append(f"### `{sid}`")
+        md.append("")
+        md.append(f"_Source: `{e['mirror_code_path']}`._")
+        md.append("")
+        if e["handler_functions"]:
+            md.append("**Handler functions** (name contains both 'cache' and a refresh-class verb):")
+            md.append("")
+            for fn in e["handler_functions"]:
+                md.append(f"- `{fn}`")
+            md.append("")
+        if e["action_strings"]:
+            md.append("**Action-string literals** (dispatch values that mention both 'refresh' and 'cache'):")
+            md.append("")
+            for s in e["action_strings"]:
+                md.append(f"- `'{s}'`")
+            md.append("")
+        callers = callers_by_sid.get(sid, [])
+        if callers:
+            md.append("**Consumer callers (URL-bound):**")
+            md.append("")
+            for c in callers:
+                md.append(f"- `{c['path']}` — action `{c['action']}`")
+            md.append("")
+        md.append("")
+
+    unbound = callers_by_sid.get("UNBOUND", [])
+    if unbound:
+        md.append("## Consumer callers using a refresh-style action but no resolvable scriptId binding")
+        md.append("")
+        for c in unbound:
+            md.append(f"- `{c['path']}` — action `{c['action']}`")
+        md.append("")
+
+    md.append("## Summary")
+    md.append("")
+    total_handlers = sum(len(e["handler_functions"]) for e in per_sid.values())
+    total_actions = sum(len(e["action_strings"]) for e in per_sid.values())
+    consumer_total = sum(len(v) for v in callers_by_sid.values())
+    md.append(f"- scriptIds with at least one candidate hook: **{len(per_sid)}**")
+    md.append(f"- distinct handler functions discovered: **{total_handlers}**")
+    md.append(f"- distinct refresh+cache action strings: **{total_actions}**")
+    md.append(f"- consumer-side action references found: **{consumer_total}**")
+    md.append("")
+    md.append("Operator promotion path: confirm the candidate in the GAS UI, "
+              "then move it from `candidate_cache_refresh_hooks` into the "
+              "manifest's `post_push_hooks[]` with the full URL + method + body.")
+    md.append("")
+
+    out_path = TOKENOMICS / "docs" / "gas_cache_refresh_hook_audit.md"
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    out_path.write_text("\n".join(md), encoding="utf-8")
+    print(f"wrote {out_path.relative_to(TOKENOMICS)}: "
+          f"{len(per_sid)} scriptIds, {total_handlers} handlers, "
+          f"{total_actions} action strings.")
+    print(f"Manifests updated: {updated}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/gen_gas_manifests.py
+++ b/scripts/gen_gas_manifests.py
@@ -85,6 +85,7 @@ def emit_manifest(folder: Path) -> dict | None:
             },
             "post_push_hooks": prior.get("post_push_hooks") or [],
             "consumer_callers": prior.get("consumer_callers") or [],
+            "candidate_cache_refresh_hooks": prior.get("candidate_cache_refresh_hooks") or [],
             "source_files": owned,  # always re-derived
             "notes": prior.get("notes") or (
                 "Audit-derived from in-source header-comment scriptIds on 2026-05-28. "


### PR DESCRIPTION
## Goal

Close the last automatable pre-flight item from `TOKENOMICS_GAS_RESTRUCTURE_PLAN.md` §4: enumerate every cache-refresh hook per scriptId so PR-final-1 can wire them into `deploy.sh`.

## The grounding shift (Gary's correction, 2026-05-28)

Earlier passes (PR-1, PR-1b) used `.gs` **header-comment URLs** in `google_app_scripts/<theme>/` as the source-of-truth for which scriptId owns which file. That proxy missed real handlers — `dao_members_cache_publisher.gs` and `edgar_send_email_verification.gs` both define the cache-refresh dispatch but neither carries a `script.google.com/home/projects/…` header comment.

This PR moves the grounding to `clasp_mirrors/<scriptId>/Code.js` — the bundled JS that clasp actually pushes. Each mirror **is** one GAS project; its `Code.js` carries every function and string the project deploys. That's authoritative.

## Findings

`docs/gas_cache_refresh_hook_audit.md` + per-manifest `candidate_cache_refresh_hooks` blocks:

- **6 scriptIds** carry candidate cache-refresh patterns.
- **5 of them define `notifyTreasuryCachePublisher_`** — the GAS-side trigger that fires the cache-publisher webhook when a transaction lands. The architectural pattern Gary mentioned in the morning autopilot transcript.
- **1 dispatches on `'refresh_dao_members_cache'`** — that's the `dao_members_cache_publisher` project, the receiver of every refresh request.
- 3 consumer references found, **all in tokenomics itself**. The cache-refresh action is **GAS-to-GAS**, not from the workspace's HTTP consumers. Useful architectural finding for PR-final-1: `deploy.sh` doesn't need to make the cache-refresh call itself; the dispatching GAS project does.

## Files

- New: `scripts/crawl_gas_cache_refresh_hooks.py` — mirror-grounded sweep + consumer-binding pass + audit-doc writer. Idempotent.
- New: `docs/gas_cache_refresh_hook_audit.md` — operator-triage table.
- Updated: every `google_app_scripts/<theme>/manifest.json` with a `candidate_cache_refresh_hooks` field per project.
- Updated: `scripts/gen_gas_manifests.py` — `candidate_cache_refresh_hooks` added to the merge-preserve allowlist so re-runs don't blow it away.

## Conservative by design

Candidates are NOT auto-promoted to `post_push_hooks`. Firing a side-effecting endpoint on every `clasp push` is an operator decision per project; the audit doc and per-manifest blocks support triage without committing the workspace to behavior.

## Pre-flight §4 status after this PR

- ✅ `/exec` deployments — 18 URLs probed live (PR-1b).
- ✅ The 51 → 36 clasp_mirrors delta — orphan + unmirrored audit (PR-1b).
- ✅ `consumer_callers` — 6 scriptIds populated (PR-1b).
- ✅ **Cache-refresh hooks discovery** — 6 scriptIds populated (this PR).
- ☐ `owner_email` confirmation per scriptId.
- ☐ Mint the 3 missing clasp_mirrors.
- ☐ Disposition for the 18 orphan mirrors.
- ☐ Shared `_shared/` helpers canonicalisation.

## Testing

- Scripts run clean from a fresh checkout, idempotent across re-runs.
- Re-running `gen_gas_manifests.py` after this script preserves `candidate_cache_refresh_hooks` (verified in commit).
- No `.gs` file moved, no clasp_mirrors touched, no `.clasp.json` touched. Zero deploy disruption.

## Rollout

No operational change. Documentation + data only.