### PR TITLE
PR-1f: mint 2 of 3 missing clasp_mirrors (third needs admin@ clasp login)

### DIFF
--- a/clasp_mirrors/1MnAsIQAxcSfZO_hALOtMFJ4y1k4OnqeXKMwYs6xev600rPNUYepqcXsT/.clasp.json
+++ b/clasp_mirrors/1MnAsIQAxcSfZO_hALOtMFJ4y1k4OnqeXKMwYs6xev600rPNUYepqcXsT/.clasp.json
@@ -1,0 +1,16 @@
+{
+  "scriptId": "1MnAsIQAxcSfZO_hALOtMFJ4y1k4OnqeXKMwYs6xev600rPNUYepqcXsT",
+  "rootDir": "",
+  "scriptExtensions": [
+    ".js",
+    ".gs"
+  ],
+  "htmlExtensions": [
+    ".html"
+  ],
+  "jsonExtensions": [
+    ".json"
+  ],
+  "filePushOrder": [],
+  "skipSubdirectories": false
+}

--- a/clasp_mirrors/1gi4YKh2ikLWmp6qEL1A6N3dfF6gQP-jwRPf_hc0N0EvaVU0-1tWu0nxo/.clasp.json
+++ b/clasp_mirrors/1gi4YKh2ikLWmp6qEL1A6N3dfF6gQP-jwRPf_hc0N0EvaVU0-1tWu0nxo/.clasp.json
@@ -1,0 +1,16 @@
+{
+  "scriptId": "1gi4YKh2ikLWmp6qEL1A6N3dfF6gQP-jwRPf_hc0N0EvaVU0-1tWu0nxo",
+  "rootDir": "",
+  "scriptExtensions": [
+    ".js",
+    ".gs"
+  ],
+  "htmlExtensions": [
+    ".html"
+  ],
+  "jsonExtensions": [
+    ".json"
+  ],
+  "filePushOrder": [],
+  "skipSubdirectories": false
+}

--- a/docs/gas_orphan_mirror_audit.md
+++ b/docs/gas_orphan_mirror_audit.md
@@ -7,10 +7,10 @@ Resolves the 51-vs-36 delta noted in [`agentic_ai_context/TOKENOMICS_GAS_RESTRUC
 ## Summary
 
 - **37** distinct scriptIds referenced in `google_app_scripts/**/*.gs` source-comment URLs.
-- **47** clasp_mirror folders.
-- **34** healthy (in both).
+- **49** clasp_mirror folders.
+- **36** healthy (in both).
 - **13** orphan mirrors (mirror exists; no source references it).
-- **3** unmirrored sources (source references; no mirror folder — `clasp push` would fail without one).
+- **1** unmirrored sources (source references; no mirror folder — `clasp push` would fail without one).
 
 ## Orphan mirrors (no source file references this scriptId)
 
@@ -34,17 +34,12 @@ These mirrors have no `.gs` source under `google_app_scripts/` carrying the stan
 
 These would fail at `clasp push` time because there is no local clasp project to push to. Mint the mirror via `scripts/clone_clasp_mirrors.mjs` (or whatever the workspace convention is) **before** the restructure PR for that scriptId lands.
 
-- `1MnAsIQAxcSfZO_hALOtMFJ4y1k4OnqeXKMwYs6xev600rPNUYepqcXsT` — referenced by:
-    - `google_app_scripts/agroverse_qr_codes/process_donation_mint_telegram_logs.gs`
-    - `google_app_scripts/agroverse_qr_codes/qr_code_web_service.gs`
-- `1gi4YKh2ikLWmp6qEL1A6N3dfF6gQP-jwRPf_hc0N0EvaVU0-1tWu0nxo` — referenced by:
-    - `google_app_scripts/seacoast_freight_quotation_ingest/Code.gs`
 - `1zKgMwd6KJFjoWkRH6OobgFvtVzrXVuEKfxVbgixgnfcp4TZTjrsfNKq0` — referenced by:
     - `google_app_scripts/tdg_identity_management/register_member_digital_signatures_email.gs`
 
 ## Healthy
 
-_34 scriptIds appear in both `google_app_scripts/` and `clasp_mirrors/`._
+_36 scriptIds appear in both `google_app_scripts/` and `clasp_mirrors/`._
 
 <details><summary>Show full list</summary>
 
@@ -61,6 +56,7 @@ _34 scriptIds appear in both `google_app_scripts/` and `clasp_mirrors/`._
 - `1IBrXqW_uTsFkbKU-fiOTrkfBlxLnX8KHsKSw2qqF3NoOa36wU0OKEVGH`
 - `1Jp8qNIBCZaRTlmOmbJoJmYnSFyXtQkUHP2Qv5uqKZpt0Ugo-e25nhASF`
 - `1LxWu9hOs56JZ6Mbxra3eDv74xjpjgkJQW40xjpQBIHObsqiv1D5jr5fK`
+- `1MnAsIQAxcSfZO_hALOtMFJ4y1k4OnqeXKMwYs6xev600rPNUYepqcXsT`
 - `1N6o00N9VtRK_L3e0NQXEsmC6QME1KObZdmdbJgo0Tbgj_7P-ElNL5THn`
 - `1NpHrKJW8Q4suu6-f5gXQcbjHqUZtGOG-KcIf81M1GG8lDShm5-fLphD2`
 - `1Og2g8Q0_SdM9A5mJNO-tq_9r8XMQ00ybBmss4L3tItBAJ01-KdM-w40c`
@@ -74,6 +70,7 @@ _34 scriptIds appear in both `google_app_scripts/` and `clasp_mirrors/`._
 - `1_3D4o2RdHdPuu5EHCUwkMQe8sFJBqXWqCiE-wpwME2Gdr6_oTt3VBAVC`
 - `1dsWecVwbN0dOvilIz9r8DNt7LD3Ay13V8G9qliow4tZtF5LHsvQOFpF7`
 - `1duQFfTO0Pj0lC4tPVNmMOhNOS1GvJgzqVxXbsEDu-eqt_64DwxvrOVyl`
+- `1gi4YKh2ikLWmp6qEL1A6N3dfF6gQP-jwRPf_hc0N0EvaVU0-1tWu0nxo`
 - `1m2sQONdMGw6HbxIVP0H0JJJ1aYrYLSRRlHb2MIplrDDsKhm8-IwKBntk`
 - `1m8IZPs1vFN99cuu-39kbC-OGXggRVtJtXq5rfSB0M1sCQjMdolEUDuGU`
 - `1orWgdGckts55owiYOysR_y4sde52T_eUmrtDGAEkb4YV5DlUfJ0JZC5J`

--- a/docs/gas_orphan_mirror_dispositions.md
+++ b/docs/gas_orphan_mirror_dispositions.md
@@ -4,6 +4,18 @@ _Triage-and-act companion to [`docs/gas_orphan_mirror_audit.md`](gas_orphan_mirr
 
 Each row in the original orphan-mirror audit needs an operator-confirmed disposition. This doc tracks the decision per orphan and the action taken (or recommended) — so the restructure roadmap (`TOKENOMICS_GAS_RESTRUCTURE_PLAN.md` §4) can close out the "orphan-mirror disposition" pre-flight item one row at a time.
 
+## Actions taken in PR-1f (2026-05-29) — mint the missing mirrors
+
+| scriptId | Owner | Action |
+|---|---|---|
+| `1MnAsIQAxcSfZO_hAL…` | **admin@truesight.me** (QR + tree-pledge notification) | ✅ Minted via `clasp clone` — 5 files (`appsscript.json`, `Credentials.js`, `process_donation_mint_telegram_logs.js`, `qr_code_web_service.js`, `Version.js`). |
+| `1gi4YKh2ikLWmp6qEL…` | garyjob@agroverse.shop | ✅ Minted via `clasp clone` — 2 files (`Code.js`, `appsscript.json`). The redundant `google_app_scripts/seacoast_freight_quotation_ingest/.clasp.json` was `git rm`'d (the convention is one clasp project per mirror folder, not per thematic source folder). |
+| `1zKgMwd6KJFjoWkRH6…` | **admin@truesight.me** (Gmail-based digital-signature ingestion) | ⛔ **Failed — `The caller does not have permission`.** The current `clasp` identity on Gary's machine doesn't have access. **Operator action:** either (a) `clasp login` as the admin@truesight.me account that owns this project, then re-run the mint step; or (b) share the GAS project with the current clasp account from `script.google.com`. After that, re-run: `mkdir -p clasp_mirrors/1zKgMwd6KJFjoWkRH6OobgFvtVzrXVuEKfxVbgixgnfcp4TZTjrsfNKq0 && cd $_ && clasp clone 1zKgMwd6KJFjoWkRH6OobgFvtVzrXVuEKfxVbgixgnfcp4TZTjrsfNKq0 --rootDir . && cd ../.. && node scripts/ensure_clasp_version_gs.mjs && python3 scripts/audit_orphan_clasp_mirrors.py`. |
+
+After this PR: audit moves from 34 healthy / 13 orphans / 3 unmirrored → **36 healthy / 13 orphans / 1 unmirrored**.
+
+---
+
 ## Actions taken in PR-1e (2026-05-29)
 
 | # | scriptId | Disposition | Action |

--- a/google_app_scripts/seacoast_freight_quotation_ingest/.clasp.json
+++ b/google_app_scripts/seacoast_freight_quotation_ingest/.clasp.json
@@ -1,4 +1,0 @@
-{
-  "scriptId": "1gi4YKh2ikLWmp6qEL1A6N3dfF6gQP-jwRPf_hc0N0EvaVU0-1tWu0nxo",
-  "rootDir": ""
-}


### PR DESCRIPTION
## Goal

Close 2 of 3 "unmirrored sources" from PR-1b — the scriptIds whose sources reference a `/exec` URL but had no `clasp_mirrors/<scriptId>/` folder, so `clasp push` would fail. After this PR, audit moves from **34 healthy / 13 orphans / 3 unmirrored → 36 healthy / 13 orphans / 1 unmirrored**.

## Actions

### Minted (clasp clone, current clasp identity)

| scriptId | Owner | Files pulled |
|---|---|---|
| `1MnAsIQAxcSfZO_hAL…` (Agroverse QR web service + tree-pledge notification) | admin@truesight.me | `appsscript.json`, `Credentials.js`, `Version.js`, `process_donation_mint_telegram_logs.js`, `qr_code_web_service.js` |
| `1gi4YKh2ikLWmp6qEL…` (Agroverse freight quotation ingest) | garyjob@agroverse.shop | `Code.js`, `appsscript.json` |

`ensure_clasp_version_gs.mjs` ran after the clone so each new mirror also has `Version.gs`. Per the repo convention only `.clasp.json` ends up tracked (everything else is gitignored under `clasp_mirrors/**`).

### Convention cleanup for seacoast

The existing `google_app_scripts/seacoast_freight_quotation_ingest/.clasp.json` (with `rootDir: ""` — non-standard) is `git rm`'d. The minted `clasp_mirrors/1gi4YKh2…/.clasp.json` is the canonical clasp project root going forward, consistent with the rest of the codebase.

### Failed mint — operator action required

| scriptId | Owner | Result |
|---|---|---|
| `1zKgMwd6KJFjoWkRH6…` (Gmail-based digital-signature ingestion) | admin@truesight.me | ⛔ `The caller does not have permission` |

The current clasp identity on Gary's machine doesn't have access to this GAS project. **Operator action:** either (a) `clasp login` as the admin@truesight.me account that owns this project, or (b) share the GAS project with the current clasp account from `script.google.com`. Then run:

```bash
mkdir -p clasp_mirrors/1zKgMwd6KJFjoWkRH6OobgFvtVzrXVuEKfxVbgixgnfcp4TZTjrsfNKq0
cd clasp_mirrors/1zKgMwd6KJFjoWkRH6OobgFvtVzrXVuEKfxVbgixgnfcp4TZTjrsfNKq0
clasp clone 1zKgMwd6KJFjoWkRH6OobgFvtVzrXVuEKfxVbgixgnfcp4TZTjrsfNKq0 --rootDir .
cd ../..
node scripts/ensure_clasp_version_gs.mjs
python3 scripts/audit_orphan_clasp_mirrors.py
```

## Testing

- `audit_orphan_clasp_mirrors.py` after the mints: **36 healthy / 13 orphans / 1 unmirrored** (was 34/13/3).
- `gen_gas_manifests.py` + `assign_gas_owner_emails.py` re-run: idempotent (the scriptIds were already represented in their thematic-folder manifests; only the mirror state changed).
- No clasp push performed; the GAS projects themselves are untouched.

## Rollout

No operational change. The minted mirrors enable future `clasp push` from those folders but don't push anything.