### PR TITLE
PR-final-1: scripts/deploy_gas_project.py — manifest-driven single-project deploy

### DIFF
--- a/docs/gas_deploy_workflow.md
+++ b/docs/gas_deploy_workflow.md
@@ -1,0 +1,105 @@
+# GAS deploy workflow
+
+_Companion to [`scripts/deploy_gas_project.py`](../scripts/deploy_gas_project.py) (PR-final-1)._
+
+The manifest-driven, one-command deploy for a single Google Apps Script project.
+
+## TL;DR
+
+```bash
+# See every known scriptId
+scripts/deploy_gas_project.py --list
+
+# Dry-run (default) — shows what would happen, changes nothing
+scripts/deploy_gas_project.py <scriptId>
+
+# Actually push the source into the GAS project
+scripts/deploy_gas_project.py <scriptId> --push
+
+# Push AND fire every operator-promoted post_push_hooks entry
+scripts/deploy_gas_project.py <scriptId> --push --with-hooks
+```
+
+## What it does, end to end
+
+1. **Pools every source file across every thematic folder that references
+   the scriptId.** Some scriptIds appear in more than one folder (e.g.
+   `19Wag9x…` lives in both `tdg_asset_management/` and `webhooks/`). The
+   deploy unit is the scriptId, not the thematic folder; the script reads
+   each `google_app_scripts/<theme>/manifest.json` and collects every
+   project block whose `scriptId` matches.
+2. **Syncs source `.gs` files into `clasp_mirrors/<scriptId>/`.** Copies
+   only changed files; removes any stale `.gs` in the mirror that no
+   manifest claims. Leaves `Version.gs` / `appsscript.json` /
+   `Credentials.js` / `Code.js` alone.
+3. **`clasp push --force`** from the mirror.
+4. **For each `post_push_hooks[]` entry**, fires the URL with the
+   manifest-declared method + body. `$ENV_VAR` placeholders in body values
+   are resolved from the local environment.
+
+## Safety
+
+- **Dry-run by default.** Re-run with `--push` to actually do anything.
+- **Hooks don't fire unless you pass `--with-hooks`.** First-time deploys
+  for a project should run `--push` alone, confirm the GAS project
+  updated correctly, then re-run `--push --with-hooks` for the cache
+  refresh.
+- **Refuses to push when source files have uncommitted git changes.**
+  Pass `--force-uncommitted` to override (don't).
+- **Skips firing `candidate_cache_refresh_hooks[]`.** Those are operator
+  triage candidates from [PR-1c](gas_cache_refresh_hook_audit.md), not
+  promoted hooks. Promotion is a one-line edit to the manifest (move the
+  entry from `candidate_cache_refresh_hooks` to `post_push_hooks` and
+  add the real URL/method/body).
+- **Refuses to push when the mirror is missing.** Mint via
+  `mkdir -p clasp_mirrors/<scriptId> && cd $_ && clasp clone <scriptId> --rootDir .`
+  first.
+
+## Operator promotion path for cache-refresh hooks
+
+Today, every `candidate_cache_refresh_hooks` entry in every manifest is a
+discovery from [`scripts/crawl_gas_cache_refresh_hooks.py`](../scripts/crawl_gas_cache_refresh_hooks.py)
+(PR-1c). They are NOT auto-fired on push.
+
+When you want to promote one to a real hook:
+
+1. Open `google_app_scripts/<theme>/manifest.json`.
+2. Find the project block for the scriptId.
+3. Copy the entry from `candidate_cache_refresh_hooks` and add a new
+   block under `post_push_hooks[]` with full `url`, `method`, `body`,
+   and a human-readable `label`:
+   ```json
+   {
+     "label": "refresh dao_members cache",
+     "url": "https://script.google.com/macros/s/AKfyc.../exec",
+     "method": "POST",
+     "body": {
+       "action": "refresh_dao_members_cache",
+       "secret": "$DAO_MEMBERS_CACHE_SECRET",
+       "force": true
+     }
+   }
+   ```
+4. Optionally leave the `candidate_cache_refresh_hooks` entry in place as
+   a discovery breadcrumb — the deploy script doesn't fire candidates so
+   it's harmless.
+5. Run `scripts/deploy_gas_project.py <scriptId> --push --with-hooks` for
+   the first real-world test.
+
+## When you'd use this vs `clasp_mirrors/.../clasp push` directly
+
+Direct `cd clasp_mirrors/<scriptId> && clasp push` works fine if you've
+already manually synced source files. But you have to remember which
+`.gs` files belong in this mirror (the manifest tells you — but only if
+you read it) and you have to remember every cache to refresh
+afterwards. The deploy script does both for you.
+
+## Future
+
+- **PR-2…PR-N** restructures each multi-scriptId thematic folder into
+  one folder per scriptId. After that lands, the deploy script could
+  accept a folder path instead of a scriptId — but the underlying logic
+  doesn't change.
+- **PR-final-2** wraps this script as a `gas_deploy_project` tool in
+  the `truesight_autopilot` capability manifest, so Telegram
+  message → GAS deploy + cache refresh end-to-end.

--- a/scripts/deploy_gas_project.py
+++ b/scripts/deploy_gas_project.py
@@ -1,0 +1,400 @@
+#!/usr/bin/env python3
+"""Deploy a single GAS project end-to-end: source-sync → clasp push → post-push hooks.
+
+Manifest-driven. The single source of truth for what to deploy and what to fire
+afterwards is each `google_app_scripts/<theme>/manifest.json`.
+
+Usage:
+    # Dry-run (default) — print everything that would happen, change nothing
+    scripts/deploy_gas_project.py <scriptId>
+
+    # Actually push
+    scripts/deploy_gas_project.py <scriptId> --push
+
+    # Also fire every entry in `post_push_hooks[]` for this scriptId
+    scripts/deploy_gas_project.py <scriptId> --push --with-hooks
+
+    # Push without firing hooks (the safe first-time default)
+    scripts/deploy_gas_project.py <scriptId> --push --no-hooks
+
+    # List every scriptId that has a manifest entry
+    scripts/deploy_gas_project.py --list
+
+How it works:
+
+1. Walk every `google_app_scripts/<theme>/manifest.json`. Collect every
+   project block whose `scriptId` matches the argument. (Some scriptIds
+   appear in source files spread across more than one thematic folder —
+   the deploy unit is the **scriptId**, not the thematic folder, so we
+   pool source_files across every matching manifest.)
+2. Resolve every `source_files[]` relative path to its `.gs` source under
+   `google_app_scripts/<theme>/<file>`.
+3. Sync those source files into `clasp_mirrors/<scriptId>/` so the mirror
+   matches what should be deployed. Strip any stale `.gs` from the mirror
+   that no manifest claims, to keep the deploy unit honest.
+4. `clasp push --force` from the mirror (when `--push`).
+5. For each entry in the project's `post_push_hooks[]` (when `--with-hooks`),
+   fire the URL+method+body. Skip `candidate_cache_refresh_hooks` — those
+   are operator-triage candidates, not promoted hooks.
+
+Safety:
+
+- Dry-run by default. Nothing changes on disk or in GAS unless you pass
+  `--push`. Hooks don't fire unless you also pass `--with-hooks`.
+- Refuses to push when there are uncommitted changes to source files for
+  this scriptId — push the working tree intentionally, don't accidentally
+  ship in-progress edits.
+- Reads `manifest.json` only; never edits it. To change which sources
+  belong to a project, edit the manifest first.
+
+Idempotent: re-running with the same args is a no-op when the mirror is
+already in sync with source.
+"""
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+SRC = ROOT / "google_app_scripts"
+MIRRORS = ROOT / "clasp_mirrors"
+
+
+# ── manifest discovery ────────────────────────────────────────────────────
+
+
+def discover_projects_for_scriptid(target_sid: str) -> list[dict]:
+    """Return [{thematic_folder, source_files: [Path], project: dict}] for
+    every project block whose scriptId matches `target_sid`."""
+    out: list[dict] = []
+    for manifest_path in sorted(SRC.glob("*/manifest.json")):
+        try:
+            data = json.loads(manifest_path.read_text(encoding="utf-8"))
+        except Exception as e:
+            print(f"  ! skipping unreadable manifest {manifest_path}: {e}", file=sys.stderr)
+            continue
+        thematic = manifest_path.parent
+        for project in data.get("projects", []):
+            if project.get("scriptId") != target_sid:
+                continue
+            source_paths = [thematic / f for f in project.get("source_files", [])]
+            out.append({
+                "thematic_folder": thematic,
+                "source_files": source_paths,
+                "project": project,
+            })
+    return out
+
+
+def list_all_scriptids() -> list[tuple[str, str]]:
+    """Returns [(scriptId, thematic_folder_name), ...] across all manifests."""
+    out: list[tuple[str, str]] = []
+    for manifest_path in sorted(SRC.glob("*/manifest.json")):
+        try:
+            data = json.loads(manifest_path.read_text(encoding="utf-8"))
+        except Exception:
+            continue
+        for project in data.get("projects", []):
+            sid = project.get("scriptId")
+            if sid:
+                out.append((sid, manifest_path.parent.name))
+    return out
+
+
+# ── sync logic ─────────────────────────────────────────────────────────────
+
+
+def _file_hash(path: Path) -> str:
+    h = hashlib.sha256()
+    with path.open("rb") as f:
+        for chunk in iter(lambda: f.read(64 * 1024), b""):
+            h.update(chunk)
+    return h.hexdigest()
+
+
+def plan_mirror_sync(scriptId: str, source_files: list[Path]) -> dict:
+    """Return a dict describing what the sync would do. Does not touch disk."""
+    mirror = MIRRORS / scriptId
+    plan = {
+        "mirror_dir": mirror,
+        "mirror_exists": mirror.is_dir(),
+        "to_copy": [],     # [(source, mirror_target)]
+        "to_skip_identical": [],
+        "to_remove_stale": [],  # mirror .gs files not in manifest
+        "missing_source": [],
+    }
+    if not mirror.is_dir():
+        return plan
+
+    # Map manifest source basenames → expected mirror filenames.
+    expected_basenames: set[str] = set()
+    for src in source_files:
+        if not src.is_file():
+            plan["missing_source"].append(src)
+            continue
+        basename = src.name  # keep the same .gs filename in the mirror
+        expected_basenames.add(basename)
+        mirror_target = mirror / basename
+        if mirror_target.is_file() and _file_hash(src) == _file_hash(mirror_target):
+            plan["to_skip_identical"].append((src, mirror_target))
+        else:
+            plan["to_copy"].append((src, mirror_target))
+
+    # Stale: any .gs in the mirror NOT in the expected basenames.
+    # Leave Version.gs / appsscript.json / Credentials.js / Code.js intact — those
+    # are clasp-managed bundles or clasp config. Only prune additional .gs files
+    # that the manifest no longer claims.
+    PRESERVE = {"Version.gs", "appsscript.json", "Credentials.js", "Code.js"}
+    for existing in sorted(mirror.glob("*.gs")):
+        if existing.name in PRESERVE:
+            continue
+        if existing.name not in expected_basenames:
+            plan["to_remove_stale"].append(existing)
+
+    return plan
+
+
+def apply_mirror_sync(plan: dict, dry_run: bool) -> bool:
+    """Apply the sync plan; return True on success."""
+    if plan["missing_source"]:
+        print("  ✗ missing source files (cannot deploy):")
+        for p in plan["missing_source"]:
+            print(f"      {p}")
+        return False
+    if not plan["mirror_exists"]:
+        print(f"  ✗ mirror directory missing: {plan['mirror_dir']}")
+        print(f"      mint it first via:")
+        print(f"      mkdir -p {plan['mirror_dir']} && cd {plan['mirror_dir']} && clasp clone <scriptId> --rootDir .")
+        return False
+
+    for src, target in plan["to_copy"]:
+        rel_src = src.relative_to(ROOT)
+        rel_target = target.relative_to(ROOT)
+        if dry_run:
+            print(f"  [DRY-RUN]  copy  {rel_src}  →  {rel_target}")
+        else:
+            shutil.copy2(src, target)
+            print(f"             copy  {rel_src}  →  {rel_target}")
+    for src, target in plan["to_skip_identical"]:
+        print(f"  ⏭  unchanged   {src.relative_to(ROOT)}")
+    for stale in plan["to_remove_stale"]:
+        rel = stale.relative_to(ROOT)
+        if dry_run:
+            print(f"  [DRY-RUN]  remove stale  {rel}")
+        else:
+            stale.unlink()
+            print(f"             remove stale  {rel}")
+    return True
+
+
+# ── clasp push ─────────────────────────────────────────────────────────────
+
+
+def run_clasp_push(mirror_dir: Path, dry_run: bool) -> bool:
+    if dry_run:
+        print(f"  [DRY-RUN]  cd {mirror_dir.relative_to(ROOT)} && clasp push --force")
+        return True
+    print(f"             cd {mirror_dir.relative_to(ROOT)} && clasp push --force")
+    try:
+        r = subprocess.run(
+            ["clasp", "push", "--force"],
+            cwd=mirror_dir,
+            capture_output=True, text=True, check=False,
+        )
+        # clasp 3 prints to stdout; surface both
+        if r.stdout:
+            for line in r.stdout.splitlines():
+                print(f"             | {line}")
+        if r.returncode != 0:
+            print(f"  ✗ clasp push exited {r.returncode}")
+            if r.stderr:
+                for line in r.stderr.splitlines():
+                    print(f"             ! {line}")
+            return False
+        return True
+    except FileNotFoundError:
+        print("  ✗ clasp not installed (or not on PATH)")
+        return False
+
+
+# ── post-push hooks ────────────────────────────────────────────────────────
+
+
+def run_post_push_hooks(project: dict, dry_run: bool) -> bool:
+    hooks = project.get("post_push_hooks") or []
+    candidates = project.get("candidate_cache_refresh_hooks") or []
+    if candidates and not hooks:
+        print(f"  ⚠  {len(candidates)} candidate cache-refresh hook(s) NOT fired — promote them to "
+              f"post_push_hooks in manifest.json after operator review (see docs/gas_cache_refresh_hook_audit.md).")
+    if not hooks:
+        print("  (no post_push_hooks configured for this scriptId)")
+        return True
+
+    import urllib.request
+    import urllib.error
+    ok = True
+    for i, hook in enumerate(hooks, 1):
+        url = hook.get("url", "")
+        method = (hook.get("method") or "GET").upper()
+        body = hook.get("body")
+        label = hook.get("label") or f"hook #{i}"
+        if not url:
+            print(f"  ✗ hook '{label}' missing url; skipping")
+            ok = False
+            continue
+        # Resolve $ENV_VAR placeholders inside body values (per the manifest
+        # schema doc in TOKENOMICS_GAS_RESTRUCTURE_PLAN.md §3).
+        if isinstance(body, dict):
+            body = {k: (os.environ.get(v[1:], "") if isinstance(v, str) and v.startswith("$") else v)
+                    for k, v in body.items()}
+        body_bytes = None
+        headers = {"User-Agent": "tokenomics-deploy-gas-project/0.1"}
+        if body is not None:
+            body_bytes = json.dumps(body).encode("utf-8")
+            headers["Content-Type"] = "application/json"
+        if dry_run:
+            preview = f"{method} {url}"
+            if body is not None:
+                preview += f" body={json.dumps(body)[:120]}"
+            print(f"  [DRY-RUN]  hook '{label}': {preview}")
+            continue
+        print(f"             hook '{label}': {method} {url}")
+        try:
+            req = urllib.request.Request(url, data=body_bytes, method=method, headers=headers)
+            with urllib.request.urlopen(req, timeout=30) as resp:
+                print(f"             → HTTP {resp.status}")
+        except urllib.error.HTTPError as e:
+            print(f"             → HTTP {e.code} {e.reason}")
+            ok = False
+        except Exception as e:
+            print(f"             → error: {e}")
+            ok = False
+    return ok
+
+
+# ── working-tree safety ────────────────────────────────────────────────────
+
+
+def uncommitted_in_paths(paths: list[Path]) -> list[Path]:
+    """Return any of `paths` that have uncommitted changes vs HEAD."""
+    if not paths:
+        return []
+    try:
+        r = subprocess.run(
+            ["git", "-C", str(ROOT), "diff", "--name-only", "HEAD", "--"]
+            + [str(p.relative_to(ROOT)) for p in paths],
+            capture_output=True, text=True, check=False,
+        )
+        return [ROOT / line for line in r.stdout.splitlines() if line]
+    except FileNotFoundError:
+        return []
+
+
+# ── main ────────────────────────────────────────────────────────────────────
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    ap.add_argument("scriptId", nargs="?", help="GAS scriptId to deploy")
+    ap.add_argument("--push", action="store_true", help="actually clasp push (default: dry-run)")
+    ap.add_argument("--with-hooks", action="store_true",
+                    help="also fire post_push_hooks[] (only with --push; default: skipped)")
+    ap.add_argument("--no-hooks", action="store_true",
+                    help="explicit: skip hooks even if --with-hooks shows up")
+    ap.add_argument("--list", action="store_true", help="list every known scriptId and exit")
+    ap.add_argument("--force-uncommitted", action="store_true",
+                    help="push even when source has uncommitted git changes (default: refuse)")
+    args = ap.parse_args()
+
+    if args.list:
+        rows = list_all_scriptids()
+        if not rows:
+            print("No projects discovered in manifests under google_app_scripts/.")
+            return 0
+        width = max(len(sid) for sid, _ in rows)
+        for sid, theme in rows:
+            print(f"  {sid:<{width}}   {theme}")
+        return 0
+
+    if not args.scriptId:
+        ap.print_help()
+        return 2
+
+    target = args.scriptId
+    dry_run = not args.push
+    fire_hooks = args.push and args.with_hooks and not args.no_hooks
+
+    print(f"=== deploy_gas_project  scriptId={target}  dry_run={dry_run}  fire_hooks={fire_hooks} ===\n")
+
+    projects = discover_projects_for_scriptid(target)
+    if not projects:
+        print(f"✗ no manifest entry references scriptId {target}")
+        print(f"  (run `scripts/deploy_gas_project.py --list` to see known scriptIds)")
+        return 1
+
+    # Pool source_files across every thematic folder that references this
+    # scriptId. The deploy unit is the scriptId; thematic folder is only a
+    # readability convention.
+    all_sources: list[Path] = []
+    seen_basenames: set[str] = set()
+    for entry in projects:
+        for src in entry["source_files"]:
+            if src.name in seen_basenames:
+                continue
+            seen_basenames.add(src.name)
+            all_sources.append(src)
+        print(f"  manifest: {entry['thematic_folder'].relative_to(ROOT)}/manifest.json"
+              f"  files: {[s.name for s in entry['source_files']]}")
+    if not all_sources:
+        print(f"\n✗ scriptId {target} has zero source_files across all manifests — nothing to deploy")
+        return 1
+
+    project_block = projects[0]["project"]
+    print(f"\n  owner_email:     {project_block.get('owner_email', '?')}")
+    print(f"  source_files:    {[s.name for s in all_sources]}")
+
+    # Safety: refuse to push when source has uncommitted changes.
+    if args.push and not args.force_uncommitted:
+        dirty = uncommitted_in_paths(all_sources)
+        if dirty:
+            print("\n✗ refusing to push — these source files have uncommitted changes vs HEAD:")
+            for p in dirty:
+                print(f"    {p.relative_to(ROOT)}")
+            print("  commit or stash first, or pass --force-uncommitted to override.")
+            return 1
+
+    # Sync
+    print("\n--- sync source → mirror ---")
+    plan = plan_mirror_sync(target, all_sources)
+    if not apply_mirror_sync(plan, dry_run=dry_run):
+        return 1
+
+    # Push
+    print("\n--- clasp push ---")
+    if not run_clasp_push(plan["mirror_dir"], dry_run=dry_run):
+        return 1
+
+    # Hooks
+    print("\n--- post-push hooks ---")
+    if fire_hooks:
+        if not run_post_push_hooks(project_block, dry_run=False):
+            return 1
+    else:
+        run_post_push_hooks(project_block, dry_run=True)
+        if not args.push:
+            print("  (dry-run mode — re-run with --push to actually push, and --with-hooks to fire hooks)")
+        elif not args.with_hooks:
+            print("  (--with-hooks not passed — skipped firing; safe first-time default)")
+
+    print("\n=== done ===")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Goal

Close PR-final-1 from `TOKENOMICS_GAS_RESTRUCTURE_PLAN.md` §5: a single command per GAS project that wraps `clasp push` + every `post_push_hooks[].url` in one operation, driven by each project's `manifest.json`. Replaces today's *'deploy and remember to also curl the refresh URL'* pattern.

## What's in the box

`scripts/deploy_gas_project.py` (and `docs/gas_deploy_workflow.md`).

```bash
# Known scriptIds
scripts/deploy_gas_project.py --list

# Dry-run (default — change nothing)
scripts/deploy_gas_project.py <scriptId>

# Actually push (hooks still skipped)
scripts/deploy_gas_project.py <scriptId> --push

# Push + fire post_push_hooks[]
scripts/deploy_gas_project.py <scriptId> --push --with-hooks
```

## How it works

1. **Pools source files across every thematic folder that references the scriptId.** Some scriptIds appear in more than one folder (e.g. `19Wag9x…` in both `tdg_asset_management/` and `webhooks/`); the deploy unit is the scriptId, so we read every `google_app_scripts/<theme>/manifest.json` and collect every matching project block.
2. **Syncs source `.gs` files into `clasp_mirrors/<scriptId>/`.** Copies only changed files; removes stale `.gs` in the mirror that no manifest claims. Leaves `Version.gs` / `appsscript.json` / `Credentials.js` / `Code.js` alone.
3. **`clasp push --force`** from the mirror.
4. **For each `post_push_hooks[]` entry**, fires the URL with the manifest-declared method + body. `$ENV_VAR` placeholders in body values resolve from the local environment.

## Safety

- **Dry-run by default.** `--push` for real action.
- **`--with-hooks` is opt-in even with `--push`.** First-time deploys: push alone, confirm the GAS project updated correctly, then re-run with `--with-hooks` for the cache refresh.
- **Skips firing `candidate_cache_refresh_hooks[]`.** Those are PR-1c operator-triage candidates, not promoted hooks. Promotion is a one-line manifest edit (see workflow doc).
- **Refuses to push when source has uncommitted git changes.** `--force-uncommitted` to override.
- **Refuses to push when the mirror is missing** — prints the mint incantation.

## Smoke-tested

Three representative scriptIds, dry-run only — no actual `clasp push`, no GAS project touched:

| scriptId | Folder(s) | Result |
|---|---|---|
| `1Dj3-m_ejxYJ` (tdg_credentialing) | single | clean single-file plan |
| `1m8IZPs1` (Edgar email verification) | single | shows admin@ owner + warns about 1 candidate cache-refresh hook NOT fired |
| `19Wag9x` (multi-folder) | `tdg_asset_management/` AND `webhooks/` | pools 2 sources from 2 different folders into 1 deploy plan |

## What it unblocks

PR-final-2 (autopilot `gas_deploy_project` tool) is now a thin wrapper around this script — one entry in autopilot's capability manifest and you get Telegram-driven "deploy `tdg_credentialing` to GAS" with one message.

## Rollout

No operational change on merge. Operator runs `--push` at their leisure on whichever projects they want to redeploy. The first `--push --with-hooks` per project is the real-world test that the manifest data we built in PR-1 → PR-1f is accurate.