### PR TITLE
PR-1g: deploy_gas_project — identity check (owner_email vs active clasp account)

### DIFF
--- a/docs/gas_deploy_workflow.md
+++ b/docs/gas_deploy_workflow.md
@@ -37,6 +37,63 @@ scripts/deploy_gas_project.py <scriptId> --push --with-hooks
    manifest-declared method + body. `$ENV_VAR` placeholders in body values
    are resolved from the local environment.
 
+## Identity pinning (owner_email vs active clasp account)
+
+Each manifest project block carries an `owner_email` field (PR-1d) that
+specifies *which Google account this scriptId is supposed to deploy as.*
+The deploy script enforces it:
+
+- Before any push, it resolves the **active clasp identity** by
+  exchanging `~/.clasprc.json`'s refresh token for an access token, then
+  calling `oauth2/v3/userinfo`.
+- If the active identity doesn't equal `owner_email`, the script
+  **refuses to push** with a clear "switch accounts" message.
+- Override only when intentional: `--allow-identity-mismatch`.
+
+This is the mistake-proofing for the `1zKgMwd6…` class of constraint:
+the Gmail digital-signature ingestion project must always deploy as
+admin@truesight.me, never as the daily-driver gary@. Even if a tired
+operator runs `deploy_gas_project.py 1zKgMwd6…` from the wrong shell at
+1am, the push won't go through.
+
+### Switching clasp identity (one-time per session)
+
+```bash
+clasp logout
+clasp login   # sign in as the right Google account in the browser flow
+```
+
+### Multiple clasp identities (recommended if you deploy across accounts)
+
+Store one credentials file per account:
+
+```bash
+# As gary@agroverse.shop:
+clasp login
+cp ~/.clasprc.json ~/.clasprc-gary.json
+
+# As admin@truesight.me:
+clasp logout && clasp login   # sign in as admin@
+cp ~/.clasprc.json ~/.clasprc-admin.json
+```
+
+Then point clasp at the right one per deploy:
+
+```bash
+# Deploy a gary@ project:
+CLASPRC_PATH=~/.clasprc-gary.json scripts/deploy_gas_project.py <scriptId> --push
+
+# Deploy an admin@ project:
+CLASPRC_PATH=~/.clasprc-admin.json scripts/deploy_gas_project.py <scriptId> --push
+```
+
+The `CLASPRC_PATH` env var changes which file the deploy script reads
+for identity resolution. **It does not currently change which file
+`clasp` itself reads** — clasp still looks at `~/.clasprc.json`. So
+the per-account-clasprc workflow is: copy the right `~/.clasprc-<account>.json`
+to `~/.clasprc.json` before invoking the deploy script. (A future PR
+could automate the swap; out of scope for this one.)
+
 ## Safety
 
 - **Dry-run by default.** Re-run with `--push` to actually do anything.

--- a/scripts/deploy_gas_project.py
+++ b/scripts/deploy_gas_project.py
@@ -44,6 +44,11 @@ Safety:
 - Refuses to push when there are uncommitted changes to source files for
   this scriptId — push the working tree intentionally, don't accidentally
   ship in-progress edits.
+- **Refuses to push when the active clasp identity doesn't match the
+  project's `owner_email`.** This is the mistake-proofing for the
+  "1zKgMwd6… must always deploy as admin@truesight.me" class of
+  constraint. Override with `--allow-identity-mismatch` only when you
+  intentionally want to push a project under a non-owner account.
 - Reads `manifest.json` only; never edits it. To change which sources
   belong to a project, edit the manifest first.
 
@@ -59,11 +64,74 @@ import os
 import shutil
 import subprocess
 import sys
+import urllib.error
+import urllib.parse
+import urllib.request
 from pathlib import Path
 
 ROOT = Path(__file__).resolve().parent.parent
 SRC = ROOT / "google_app_scripts"
 MIRRORS = ROOT / "clasp_mirrors"
+CLASPRC = Path(os.environ.get("CLASPRC_PATH") or os.path.expanduser("~/.clasprc.json"))
+
+
+# ── clasp identity resolution ──────────────────────────────────────────────
+
+
+def resolve_clasp_identity() -> tuple[str | None, str | None]:
+    """Return (email, error) of the active clasp account.
+
+    Reads `~/.clasprc.json`, exchanges its refresh_token for a fresh access
+    token, calls Google's `oauth2/v3/userinfo`. Returns `(email, None)` on
+    success; `(None, reason)` if any step fails — caller decides whether
+    to treat that as fatal or just a warning.
+    """
+    if not CLASPRC.is_file():
+        return None, f"no clasprc at {CLASPRC} (clasp not logged in?)"
+    try:
+        rc = json.loads(CLASPRC.read_text(encoding="utf-8"))
+    except Exception as e:
+        return None, f"failed to parse {CLASPRC}: {e}"
+    tok = (rc.get("tokens") or {}).get("default") or {}
+    client_id = tok.get("client_id") or ""
+    client_secret = tok.get("client_secret") or ""
+    refresh_token = tok.get("refresh_token") or ""
+    if not (client_id and client_secret and refresh_token):
+        return None, f"clasprc at {CLASPRC} is missing client_id/secret/refresh_token"
+
+    try:
+        data = urllib.parse.urlencode({
+            "client_id": client_id,
+            "client_secret": client_secret,
+            "refresh_token": refresh_token,
+            "grant_type": "refresh_token",
+        }).encode("utf-8")
+        req = urllib.request.Request(
+            "https://oauth2.googleapis.com/token",
+            data=data,
+            headers={"Content-Type": "application/x-www-form-urlencoded"},
+        )
+        resp = json.loads(urllib.request.urlopen(req, timeout=10).read())
+        access = resp.get("access_token")
+        if not access:
+            return None, f"oauth refresh returned no access_token: {resp}"
+        info = json.loads(urllib.request.urlopen(
+            urllib.request.Request(
+                "https://www.googleapis.com/oauth2/v3/userinfo",
+                headers={"Authorization": f"Bearer {access}"},
+            ),
+            timeout=10,
+        ).read())
+        email = info.get("email")
+        if not email:
+            return None, f"userinfo returned no email: {info}"
+        return email, None
+    except urllib.error.HTTPError as e:
+        return None, f"HTTP {e.code} resolving clasp identity: {e.reason}"
+    except urllib.error.URLError as e:
+        return None, f"network error resolving clasp identity: {e}"
+    except Exception as e:
+        return None, f"unexpected error resolving clasp identity: {e}"
 
 
 # ── manifest discovery ────────────────────────────────────────────────────
@@ -310,6 +378,8 @@ def main() -> int:
     ap.add_argument("--list", action="store_true", help="list every known scriptId and exit")
     ap.add_argument("--force-uncommitted", action="store_true",
                     help="push even when source has uncommitted git changes (default: refuse)")
+    ap.add_argument("--allow-identity-mismatch", action="store_true",
+                    help="push even when active clasp identity != project owner_email (default: refuse)")
     args = ap.parse_args()
 
     if args.list:
@@ -356,8 +426,38 @@ def main() -> int:
         return 1
 
     project_block = projects[0]["project"]
-    print(f"\n  owner_email:     {project_block.get('owner_email', '?')}")
+    owner_email = (project_block.get("owner_email") or "").strip().lower()
+    print(f"\n  owner_email:     {owner_email or '?'}")
     print(f"  source_files:    {[s.name for s in all_sources]}")
+
+    # Safety: refuse to push when active clasp identity doesn't match
+    # the project's owner_email. This is the mistake-proofing for the
+    # "1zKgMwd6… must always deploy as admin@truesight.me" class of
+    # constraint — Gary's 2026-05-29 ask.
+    active_email, identity_err = resolve_clasp_identity()
+    if active_email:
+        print(f"  clasp identity:  {active_email}")
+    elif identity_err:
+        print(f"  clasp identity:  (unresolved — {identity_err})")
+
+    if owner_email and active_email and active_email.lower() != owner_email:
+        msg = (
+            f"\n✗ identity mismatch — refusing to push.\n"
+            f"    project owner_email:  {owner_email}\n"
+            f"    active clasp:         {active_email}\n"
+            f"  Switch clasp accounts before pushing:\n"
+            f"    clasp logout && clasp login   # then sign in as {owner_email}\n"
+            f"  Or set CLASPRC_PATH=~/.clasprc-<account>.json to point at a per-account credentials file.\n"
+            f"  Override only when intentional: --allow-identity-mismatch."
+        )
+        if args.push and not args.allow_identity_mismatch:
+            print(msg)
+            return 1
+        elif args.push:
+            print("\n⚠  --allow-identity-mismatch is set; pushing anyway:" + msg)
+        else:
+            # Dry-run still tells the user about the mismatch loudly.
+            print("\n⚠  identity mismatch — push would be refused without --allow-identity-mismatch." + msg)
 
     # Safety: refuse to push when source has uncommitted changes.
     if args.push and not args.force_uncommitted:


### PR DESCRIPTION
## Goal

Close the *'ensure `1zKgMwd6…` always deploys as admin@truesight.me'* constraint (Gary 2026-05-29). Generalised: every project's `owner_email` from PR-1d now becomes a per-project identity constraint that the deploy script enforces.

## How it works

Before any `clasp push`, the script resolves the **active clasp identity** by exchanging `~/.clasprc.json`'s refresh token for an access token, then calling Google's `oauth2/v3/userinfo`. The resulting email is compared (case-insensitive) against the project block's `owner_email`.

| Scenario | Behavior |
|---|---|
| Match | Proceed normally. |
| Mismatch + `--push` | **Refuse**, exit 1, print clear *switch accounts* message. |
| Mismatch + dry-run | Warn loudly so the operator sees the issue before hitting `--push`. |
| Identity unresolved (no clasprc / network down) | Log the reason but don't block dry-run; only blocks `--push` when an explicit mismatch is detected. |

New CLI flag: `--allow-identity-mismatch` for the rare intentional cross-account push.

New env var: `CLASPRC_PATH` lets operators point identity resolution at a per-account credentials file (e.g. `~/.clasprc-admin.json`). Note: clasp itself still reads `~/.clasprc.json` — the per-account-clasprc workflow is *copy the right file to `~/.clasprc.json` before invoking the deploy script.* Auto-swap is out of scope for this PR.

## Example: `1zKgMwd6…` constraint enforced

`1zKgMwd6KJFjoWkRH6OobgFvtVzrXVuEKfxVbgixgnfcp4TZTjrsfNKq0` carries `owner_email: admin@truesight.me` from PR-1d. Even if a tired operator runs `deploy_gas_project.py 1zKgMwd6… --push` from the wrong shell at 1am, the script refuses unless they:

1. `clasp logout && clasp login` as admin@truesight.me, OR
2. Set up multi-account clasprc files and copy the admin one into place, OR
3. Pass `--allow-identity-mismatch` (explicit override).

## Smoke-tested

| scriptId | owner_email | active clasp | Result |
|---|---|---|---|
| `1Dj3-m` (credentialing) | gary@agroverse.shop | gary@agroverse.shop | ✅ clean dry-run, both match |
| `1MnAsIQA` (QR web service) | admin@truesight.me | gary@agroverse.shop | ⚠ dry-run warns 'push would be refused' |
| `1MnAsIQA` with `--push` | admin@truesight.me | gary@agroverse.shop | ✗ refused, exit 1, clear switch-accounts message |

## Files

- `scripts/deploy_gas_project.py` — `resolve_clasp_identity()` helper (OAuth refresh + userinfo), identity-check block before push, `--allow-identity-mismatch` flag, `CLASPRC_PATH` env support. Module-level urllib imports.
- `docs/gas_deploy_workflow.md` — new 'Identity pinning' section: the constraint, one-time switch flow (`clasp logout && clasp login`), and the multi-account workflow (per-account clasprc files).

## Rollout

No operational change on merge. The first `--push` for any project where active clasp identity differs from `owner_email` will fail loudly — that's the point. Operator either switches accounts or passes the explicit override.