### PR TITLE
[autopilot] ## Problem

`dao_members.json` (published to `treasury-cache

### DIFF
--- a/google_app_scripts/tdg_identity_management/dao_members_cache_publisher.gs
+++ b/google_app_scripts/tdg_identity_management/dao_members_cache_publisher.gs
@@ -164,7 +164,8 @@ function publishDaoMembersCacheToGithub_(opts) {
       const name = String(row[0] || '').trim();
       if (!name) return;
       votingByName[name.toLowerCase()] = {
-        voting_rights: toNumberOrNull_(row[6]),          // I = Total TDG controlled
+        name: name,                                        // preserve original casing
+        voting_rights: toNumberOrNull_(row[6]),            // I = Total TDG controlled
         total_voting_power_pct: String(row[8] || ''),     // K = Total Voting Power
       };
     });

--- a/google_app_scripts/tdg_identity_management/dao_members_cache_publisher.gs
+++ b/google_app_scripts/tdg_identity_management/dao_members_cache_publisher.gs
@@ -218,6 +218,16 @@ function publishDaoMembersCacheToGithub_(opts) {
     });
   });
 
+  // ----- Ensure every contributor from voting weight sheet is present --------
+  // Contributors who haven't registered any ACTIVE public key are missing from
+  // byName. Add them with an empty public_keys array so dao_members.json is the
+  // superset of all DAO contributors (matching the members.html page).
+  Object.keys(votingByName).forEach(function (k) {
+    if (!byName[k]) {
+      byName[k] = { name: votingByName[k].name || k, email: null, public_keys: [] };
+    }
+  });
+
   // ----- Merge voting weight + governor flag + emit sorted contributors ----
   const contributors = Object.keys(byName).sort().map(function (k) {
     const entry = byName[k];


### PR DESCRIPTION
## Autopilot Fix

**Issue:** ## Problem

`dao_members.json` (published to `treasury-cache`) currently only includes contributors who have registered at least one ACTIVE RSA public key in the `Contributors Digital Signatures` sheet. This means ~375 DAO contributors who appear on the `members.html` page (powered by `lineage-credentials/_cache/index.json`) are missing from `dao_members.json`.

The `members.html` page reads from `lineage-credentials/_cache/index.json` which includes **all** 387 contributors regardless of key registration status. The `dao_members.json` should be the superset — it should include every contributor from the `Contributors voting weight` sheet, with `public_keys: []` for those who haven't registered keys yet.

## Root Cause

In `dao_members_cache_publisher.gs`, the `publishDaoMembersCacheToGithub_()` function builds the contributor list by iterating `sigsRows` (rows from `Contributors Digital Signatures` sheet) and filtering to only ACTIVE public keys:

```javascript
sigsRows.forEach(function (row) {
    const name = String(row[0] || '').trim();
    const status = String(row[3] || '').trim().toUpperCase();
    const publicKey = String(row[4] || '').trim();
    if (!name || !publicKey || status !== 'ACTIVE') return;
    // ...
    byName[key] = { name: name, email: null, public_keys: [] };
});
```

This means anyone without an ACTIVE public key is skipped entirely.

## Fix

After building `byName` from the signatures sheet, also iterate the `Contributors voting weight` sheet (which has ALL contributors) and add any missing names with empty `public_keys` arrays. The voting weight sheet is already read into `votingByName` — we just need to ensure every name in `votingByName` also appears in `byName` if not already present.

The change is in the section after `byName` is built from sigsRows — add a loop that iterates `votingByName` and inserts any missing names with `public_keys: []`.

**Branch:** `autopilot/fix-1780085669`

---

This PR was generated by [truesight_autopilot](https://github.com/TrueSightDAO/truesight_autopilot). Please review before merging.