### PR TITLE
Bind edgar_send_email_verification.gs to scriptId 1m8IZPs1 (admin@)

### DIFF
--- a/google_app_scripts/tdg_identity_management/edgar_send_email_verification.gs
+++ b/google_app_scripts/tdg_identity_management/edgar_send_email_verification.gs
@@ -2,6 +2,13 @@
  * File: google_app_scripts/tdg_identity_management/edgar_send_email_verification.gs
  * Repository: https://github.com/TrueSightDAO/tokenomics
  *
+ * Apps Script project:
+ *   https://script.google.com/home/projects/1m8IZPs1vFN99cuu-39kbC-OGXggRVtJtXq5rfSB0M1sCQjMdolEUDuGU/edit
+ *
+ * Routing verified 2026-05-29 by matching the `handleEmailVerificationRequest_`
+ * function fingerprint against `clasp_mirrors/1m8IZPs1.../Code.js`. owner_email
+ * is admin@truesight.me per the manifest (PR-1d).
+ *
  * Summary:
  * - Standalone web app invoked by Edgar (`sentiment_importer`) after a verified
  *   `[EMAIL REGISTERED EVENT]`. Sends the contributor a DApp link with `em` + `vk`.

--- a/google_app_scripts/tdg_identity_management/manifest.json
+++ b/google_app_scripts/tdg_identity_management/manifest.json
@@ -51,6 +51,7 @@
         }
       ],
       "source_files": [
+        "edgar_send_email_verification.gs",
         "email_verification_from_edgar.gs"
       ],
       "notes": "Audit-derived from in-source header-comment scriptIds on 2026-05-28. Pre-flight checklist (TOKENOMICS_GAS_RESTRUCTURE_PLAN.md §4) must resolve: full deployments list, post-push cache-refresh hooks, confirmed owner_email, consumer callers."
@@ -82,7 +83,6 @@
   "files_without_scriptid": [
     "dao_members_cache_publisher.gs",
     "dapp_permission_change_handler.gs",
-    "edgar_send_email_verification.gs",
     "process_contributor_add_telegram_logs.gs"
   ],
   "exec_urls_seen_in_folder_sources": [


### PR DESCRIPTION
## Goal

Close one autopilot-blocking source-file → scriptId binding gap surfaced 2026-05-29: autopilot trying to find which mirror owns `edgar_send_email_verification.gs` couldn't resolve from the manifest because the file lacked the standard `script.google.com/home/projects/<scriptId>/edit` header URL.

## Verification

The file's distinctive function `handleEmailVerificationRequest_` is present in `clasp_mirrors/1m8IZPs1.../Code.js` and NOT in any other mirror. Conclusive evidence that 1m8IZPs1 is the deployed GAS project for this source.

## Files

- `edgar_send_email_verification.gs` — header gains the scriptId URL + a one-line 'routing verified by fingerprint match' note.
- `tdg_identity_management/manifest.json` — gen_gas_manifests.py auto-regenerated; `1m8IZPs1`'s `source_files` now includes the file.

## Three more like this still unbound

Same folder still has 3 `files_without_scriptid` after this PR:

- `dao_members_cache_publisher.gs` (contains `handleDaoMembersCacheRefreshRequest_`)
- `dapp_permission_change_handler.gs` (contains `applyDapPermissionChangeNow`)
- `process_contributor_add_telegram_logs.gs` (contains `processContributorAddNow`)

**None of their function fingerprints appear in any clasp_mirrors/ Code.js** — meaning these source files exist locally but have never been `clasp push`'d to a GAS project. The destination scriptId for each is operator-confirmation territory (most likely 1m8IZPs1 since they live in the same thematic folder, but the audit can't auto-verify it from existing mirror state). Operator can either add the header URL manually when ready to push, or leave them unbound until that decision is made.