### PR TITLE
Add sendOnboardingInvitation handler to 1m8IZPs1 (Seth-voice copy)

### DIFF
--- a/google_app_scripts/tdg_identity_management/edgar_send_email_verification.gs
+++ b/google_app_scripts/tdg_identity_management/edgar_send_email_verification.gs
@@ -97,10 +97,34 @@ function doGet(e) {
     });
   }
 
+  if (action === 'sendOnboardingInvitation') {
+    // Edgar → GET ?action=sendOnboardingInvitation&secret=...&email=...
+    //   &contributor_name=...&inviter_name=...&inviter_email=...&return_url=...
+    // Implementation lives in edgar_send_onboarding_invitation.gs. Sends a
+    // Seth-Godin-voiced welcome to a contributor a governor just added via
+    // dapp/governor_contributor_admin.html. Distinct from the verification
+    // flow above; both run as admin@truesight.me from the same project.
+    logEmailVerification_('doGet', {
+      transport: 'GET',
+      action: 'sendOnboardingInvitation',
+      secret_present: Boolean(e.parameter && e.parameter.secret),
+      email_present: Boolean(e.parameter && e.parameter.email),
+      inviter_name_present: Boolean(e.parameter && e.parameter.inviter_name),
+    });
+    return handleOnboardingInvitationRequest_({
+      secret: e.parameter.secret,
+      email: e.parameter.email,
+      contributor_name: e.parameter.contributor_name || '',
+      inviter_name: e.parameter.inviter_name || '',
+      inviter_email: e.parameter.inviter_email || '',
+      return_url: e.parameter.return_url || '',
+    });
+  }
+
   return ContentService.createTextOutput(
     JSON.stringify({
       ok: false,
-      error: 'No valid action (use action=sendEmailVerification, action=refresh_dao_members_cache, or action=apply_permission_change on GET, or POST JSON for email verification).',
+      error: 'No valid action (use action=sendEmailVerification, action=sendOnboardingInvitation, action=refresh_dao_members_cache, or action=apply_permission_change on GET, or POST JSON).',
     })
   ).setMimeType(ContentService.MimeType.JSON);
 }
@@ -169,13 +193,30 @@ function handleEmailVerificationRequest_(body) {
 }
 
 /**
- * Edgar → POST JSON { secret, email, verification_key, return_url }
+ * Edgar → POST JSON. Dispatches on `action` field:
+ *   - "sendEmailVerification" (default for backward compat) → email verification
+ *   - "sendOnboardingInvitation"                            → onboarding invitation
+ * Other action values fall through to verification for backward compat.
  */
 function doPost(e) {
   try {
     const body = e.postData && e.postData.contents ? JSON.parse(e.postData.contents) : {};
+    const action = body && body.action ? String(body.action) : 'sendEmailVerification';
+
+    if (action === 'sendOnboardingInvitation') {
+      logEmailVerification_('doPost', {
+        transport: 'POST_JSON',
+        action: action,
+        secret_present: Boolean(body && body.secret),
+        email_present: Boolean(body && body.email),
+        inviter_name_present: Boolean(body && body.inviter_name),
+      });
+      return handleOnboardingInvitationRequest_(body);
+    }
+
     logEmailVerification_('doPost', {
       transport: 'POST_JSON',
+      action: action,
       secret_present: Boolean(body && body.secret),
       email_present: Boolean(body && body.email),
       vk_len: body && body.verification_key ? String(body.verification_key).length : 0,

--- a/google_app_scripts/tdg_identity_management/edgar_send_onboarding_invitation.gs
+++ b/google_app_scripts/tdg_identity_management/edgar_send_onboarding_invitation.gs
@@ -1,0 +1,313 @@
+/**
+ * File: google_app_scripts/tdg_identity_management/edgar_send_onboarding_invitation.gs
+ * Repository: https://github.com/TrueSightDAO/tokenomics
+ *
+ * Apps Script project:
+ *   https://script.google.com/home/projects/1m8IZPs1vFN99cuu-39kbC-OGXggRVtJtXq5rfSB0M1sCQjMdolEUDuGU/edit
+ *
+ * owner_email: admin@truesight.me (same Apps Script project + same script
+ * properties as edgar_send_email_verification.gs; deploy as Execute as User
+ * = admin@truesight.me so GmailApp.sendEmail sends from that account).
+ *
+ * ---------------------------------------------------------------------------
+ * Summary
+ * ---------------------------------------------------------------------------
+ * Edgar (`sentiment_importer`) calls this handler after a governor uses
+ * `dapp/governor_contributor_admin.html` to add a new contributor on someone
+ * else's behalf. The handler emails the new contributor a Seth-Godin-voiced
+ * invitation that:
+ *   - tells them who invited them (the governor's display name),
+ *   - gives them ONE primary action — generate their signing key at
+ *     create_signature.html (with the email pre-filled),
+ *   - links a secondary high-level intro (truesight.me/edgar.html) without
+ *     stealing focus from the primary action.
+ *
+ * This is distinct from the existing email-verification handler:
+ *   - VERIFICATION = contributor self-registered, prove email ownership.
+ *   - INVITATION   = governor onboarded someone; nudge them to start.
+ * Both live in the same Apps Script project (1m8IZPs1) because both run as
+ * admin@truesight.me at the From line.
+ *
+ * ---------------------------------------------------------------------------
+ * Transport (Edgar → GAS)
+ * ---------------------------------------------------------------------------
+ * GET:
+ *   /exec?action=sendOnboardingInvitation
+ *        &secret=...
+ *        &email=<new-contributor@example.com>
+ *        &contributor_name=<First Last>     // optional but recommended
+ *        &inviter_name=<Governor Display>   // required — Seth-voice copy names them
+ *        &inviter_email=<governor@...>      // optional — Reply-To if present
+ *        &return_url=<base for create_signature.html>   // optional; GitHub Pages default
+ *
+ * POST JSON: same fields.
+ *
+ * Dispatcher: edgar_send_email_verification.gs's doGet/doPost route on
+ * action === 'sendOnboardingInvitation'.
+ *
+ * ---------------------------------------------------------------------------
+ * Script property
+ * ---------------------------------------------------------------------------
+ * - `EMAIL_VERIFICATION_SECRET` — shared with the verification flow; one
+ *   secret per project. Edgar passes it as `secret=`.
+ *
+ * ---------------------------------------------------------------------------
+ * Operator / debug (Apps Script editor, not the web URL):
+ * ---------------------------------------------------------------------------
+ * - `TEST_sendOnboardingInvitation()` — edit the TEST_ constants at top of
+ *   that function, then Run. Sends real Gmail (uses script secret).
+ * - `editorDryRunOnboardingInvitation()` — prompts for fields, logs the
+ *   composed email body, no send.
+ */
+
+
+/**
+ * Edgar → GET ?action=sendOnboardingInvitation&secret=...&email=...&contributor_name=...&inviter_name=...&inviter_email=...&return_url=...
+ *
+ * Or shared with handleEmailVerificationRequest_, called via dispatcher.
+ */
+function handleOnboardingInvitationRequest_(body) {
+  try {
+    logOnboardingInvitation_('handler_enter', {
+      email: String((body && body.email) || '').trim().toLowerCase(),
+      contributor_name_present: Boolean(body && body.contributor_name),
+      inviter_name_present: Boolean(body && body.inviter_name),
+      inviter_email_present: Boolean(body && body.inviter_email),
+      return_url_len: String((body && body.return_url) || '').length,
+      secret_present: Boolean(body && body.secret),
+    });
+
+    const expected = PropertiesService.getScriptProperties().getProperty('EMAIL_VERIFICATION_SECRET');
+    if (!expected || String(body.secret || '') !== String(expected)) {
+      logOnboardingInvitation_('handler_unauthorized', {
+        script_secret_configured: Boolean(expected),
+        submitted_secret_len: body && body.secret ? String(body.secret).length : 0,
+      });
+      return jsonOnboardingInvitationResponse_({ ok: false, error: 'Unauthorized' });
+    }
+
+    const email = String(body.email || '').trim().toLowerCase();
+    if (!email || !email.includes('@')) {
+      logOnboardingInvitation_('handler_missing_email', { email_present: Boolean(email) });
+      return jsonOnboardingInvitationResponse_({ ok: false, error: 'Missing or malformed email' });
+    }
+
+    const contributorName = String(body.contributor_name || '').trim();
+    const inviterName = String(body.inviter_name || '').trim();
+    const inviterEmail = String(body.inviter_email || '').trim().toLowerCase();
+    if (!inviterName) {
+      logOnboardingInvitation_('handler_missing_inviter', { email: email });
+      return jsonOnboardingInvitationResponse_({
+        ok: false,
+        error: 'Missing inviter_name — invitation must name who extended it.',
+      });
+    }
+
+    const returnUrl = String(body.return_url || 'https://dapp.truesight.me/create_signature.html').trim();
+    const signatureUrl = buildOnboardingSignatureUrl_(email, returnUrl);
+
+    const subject = composeOnboardingSubject_({ inviterName: inviterName });
+    const plainBody = composeOnboardingBody_({
+      contributorName: contributorName,
+      inviterName: inviterName,
+      signatureUrl: signatureUrl,
+    });
+
+    logOnboardingInvitation_('handler_sending_gmail', {
+      email: email,
+      signature_url_preview: signatureUrl.substring(0, 200) + (signatureUrl.length > 200 ? '…' : ''),
+      subject: subject,
+      inviter_name: inviterName,
+    });
+
+    const mailOpts = { name: 'TrueSight DAO' };
+    if (inviterEmail && inviterEmail.includes('@')) {
+      mailOpts.replyTo = inviterEmail;
+    }
+    GmailApp.sendEmail(email, subject, plainBody, mailOpts);
+
+    logOnboardingInvitation_('handler_sent_ok', { email: email, inviter_name: inviterName });
+    return jsonOnboardingInvitationResponse_({ ok: true });
+  } catch (err) {
+    Logger.log('[onboardingInvitation] handler_exception ' + String(err && err.message ? err.message : err));
+    if (err && err.stack) Logger.log(err.stack);
+    return jsonOnboardingInvitationResponse_({
+      ok: false,
+      error: String(err && err.message ? err.message : err),
+    });
+  }
+}
+
+
+/**
+ * Compose the Subject line. Short, names the inviter, sets expectation.
+ *
+ * Seth-Godin lens: the recipient is busy and skeptical; one specific human
+ * inviting them is more relevant than a generic "Welcome" subject.
+ */
+function composeOnboardingSubject_(opts) {
+  return opts.inviterName + ' added you to TrueSight DAO';
+}
+
+
+/**
+ * Compose the plain-text body.
+ *
+ * Seth-Godin lens (per agentic_ai_context/CMO_SETH_GODIN.md):
+ *   - Smallest viable audience: grassroots contributors who've been burned
+ *     by crypto-bro maximalism and want something that respects their time.
+ *   - Permission marketing: this email is anticipated (a governor just
+ *     onboarded them) — earn the next click by being short.
+ *   - Story, not bullet points: open with what just happened, name the
+ *     human who did it, then offer the single next step.
+ *   - One ask: generate the signing key. The intro link is optional context,
+ *     deliberately deprioritised below the primary action.
+ *   - Tribe signal: "Not a wallet. Not gas." names the difference from the
+ *     crypto status quo most readers expect.
+ */
+function composeOnboardingBody_(opts) {
+  const contributorName = opts.contributorName || 'there';
+  const inviterName = opts.inviterName;
+  const signatureUrl = opts.signatureUrl;
+
+  return (
+    'Hi ' + contributorName + ',\n\n' +
+    inviterName + ' added you to TrueSight DAO today.\n\n' +
+    'The first thing to know: every action you take in this DAO is signed by a key only you control. Not a wallet. Not gas. Not crypto in the way you have been told it has to be.\n\n' +
+    'Generate your signing key (takes 30 seconds, lives in your browser):\n' +
+    signatureUrl + '\n\n' +
+    'Once that is done, you can submit contributions, propose work, and have your time recorded on the ledger like every other contributor.\n\n' +
+    'If you want some context on what you are part of:\n' +
+    'https://truesight.me/edgar.html\n' +
+    'https://truesight.me/whitepaper\n\n' +
+    'Welcome.\n\n' +
+    '— TrueSight DAO'
+  );
+}
+
+
+/**
+ * Build the create_signature.html URL with the contributor's email pre-filled.
+ * Mirrors buildSignatureVerificationUrl_ but for the invitation flow (no
+ * verification key is involved here — the contributor will generate one
+ * client-side and submit via the DApp).
+ */
+function buildOnboardingSignatureUrl_(email, returnUrl) {
+  const base = String(returnUrl || '').split('#')[0];
+  const join = base.indexOf('?') >= 0 ? '&' : '?';
+  return base + join + 'em=' + encodeURIComponent(email);
+}
+
+
+function jsonOnboardingInvitationResponse_(obj) {
+  const text = JSON.stringify(obj);
+  Logger.log('[onboardingInvitation] response_json=' + text);
+  return ContentService.createTextOutput(text).setMimeType(ContentService.MimeType.JSON);
+}
+
+
+function logOnboardingInvitation_(stage, fields) {
+  let extra = '';
+  try {
+    extra = JSON.stringify(fields || {});
+  } catch (e) {
+    extra = String(fields);
+  }
+  Logger.log('[onboardingInvitation] stage=' + stage + ' ' + extra);
+}
+
+
+// ---------------------------------------------------------------------------
+// Editor-only test / dry-run helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Edit these, then Run → TEST_sendOnboardingInvitation in the Apps Script
+ * editor. Sends a real invitation email using EMAIL_VERIFICATION_SECRET from
+ * Script properties. NOTE: the editor runs as Session.getActiveUser(), not
+ * the deployed "Execute as" owner; the From line for editor-runs is the
+ * editor account, not necessarily admin@truesight.me. To test production
+ * sending behaviour, call the deployed /exec URL.
+ */
+function TEST_sendOnboardingInvitation() {
+  const TEST_EMAIL = 'you@example.com';
+  const TEST_CONTRIBUTOR_NAME = 'Alex';
+  const TEST_INVITER_NAME = 'Gary Teh';
+  const TEST_INVITER_EMAIL = 'garyjob@agroverse.shop';
+  const TEST_RETURN_URL = 'https://dapp.truesight.me/create_signature.html';
+
+  const secret = PropertiesService.getScriptProperties().getProperty('EMAIL_VERIFICATION_SECRET');
+  if (!secret) throw new Error('Script property EMAIL_VERIFICATION_SECRET is not set');
+
+  Logger.log(
+    '[onboardingInvitation] NOTE: editor Run uses Session.getActiveUser().getEmail()=' +
+      Session.getActiveUser().getEmail() +
+      ' — GmailApp.sendEmail sends as this user, not necessarily the web app "Execute as" owner.'
+  );
+
+  const out = handleOnboardingInvitationRequest_({
+    secret: secret,
+    email: TEST_EMAIL,
+    contributor_name: TEST_CONTRIBUTOR_NAME,
+    inviter_name: TEST_INVITER_NAME,
+    inviter_email: TEST_INVITER_EMAIL,
+    return_url: TEST_RETURN_URL,
+  });
+  Logger.log('[onboardingInvitation] TEST_sendOnboardingInvitation raw response: ' + out.getContent());
+}
+
+
+/**
+ * Run from editor: prompts for fields; logs what would be sent. No mail.
+ */
+function editorDryRunOnboardingInvitation() {
+  const emailRaw = Browser.inputBox(
+    'Dry run — onboarding invitation',
+    'New contributor email:',
+    Browser.Buttons.OK_CANCEL
+  );
+  if (emailRaw === 'cancel' || !emailRaw) return;
+
+  const contribName = Browser.inputBox(
+    'Dry run — onboarding invitation',
+    'Contributor name (optional, blank ok):',
+    Browser.Buttons.OK_CANCEL
+  );
+  if (contribName === 'cancel') return;
+
+  const inviterName = Browser.inputBox(
+    'Dry run — onboarding invitation',
+    'Inviter name (the governor who onboarded them):',
+    Browser.Buttons.OK_CANCEL
+  );
+  if (inviterName === 'cancel' || !inviterName) return;
+
+  const inviterEmail = Browser.inputBox(
+    'Dry run — onboarding invitation',
+    'Inviter email (optional Reply-To, blank ok):',
+    Browser.Buttons.OK_CANCEL
+  );
+  if (inviterEmail === 'cancel') return;
+
+  const retRaw = Browser.inputBox(
+    'Dry run — onboarding invitation',
+    'Return URL (blank = DApp default):',
+    Browser.Buttons.OK_CANCEL
+  );
+  if (retRaw === 'cancel') return;
+
+  const email = String(emailRaw).trim().toLowerCase();
+  const returnUrl = String(retRaw || '').trim() || 'https://dapp.truesight.me/create_signature.html';
+  const signatureUrl = buildOnboardingSignatureUrl_(email, returnUrl);
+
+  const subject = composeOnboardingSubject_({ inviterName: String(inviterName).trim() });
+  const body = composeOnboardingBody_({
+    contributorName: String(contribName || '').trim(),
+    inviterName: String(inviterName).trim(),
+    signatureUrl: signatureUrl,
+  });
+
+  Logger.log('[onboardingInvitation] DRY RUN email=' + email);
+  Logger.log('[onboardingInvitation] DRY RUN subject=' + subject);
+  Logger.log('[onboardingInvitation] DRY RUN body=\n' + body);
+}

--- a/google_app_scripts/tdg_identity_management/manifest.json
+++ b/google_app_scripts/tdg_identity_management/manifest.json
@@ -52,6 +52,7 @@
       ],
       "source_files": [
         "edgar_send_email_verification.gs",
+        "edgar_send_onboarding_invitation.gs",
         "email_verification_from_edgar.gs"
       ],
       "notes": "Audit-derived from in-source header-comment scriptIds on 2026-05-28. Pre-flight checklist (TOKENOMICS_GAS_RESTRUCTURE_PLAN.md §4) must resolve: full deployments list, post-push cache-refresh hooks, confirmed owner_email, consumer callers."


### PR DESCRIPTION
## Goal

Gary 2026-05-29: when a governor uses `dapp/governor_contributor_admin.html` to add a new contributor on their behalf, send the new contributor an invitation email from admin@truesight.me with the next step (create_signature.html) and a short intro context link.

Two specific operator asks baked in:
- **Seth Godin voice** (per `agentic_ai_context/CMO_SETH_GODIN.md`).
- **Name the inviter** — *'indicate who sent extended the invitation'*.

## Where the code lives

| | |
|---|---|
| Apps Script project | `1m8IZPs1vFN99cuu-39kbC-OGXggRVtJtXq5rfSB0M1sCQjMdolEUDuGU` (owner_email admin@truesight.me — same project as the existing email-verification webhook so the From line is consistent) |
| New source file | `google_app_scripts/tdg_identity_management/edgar_send_onboarding_invitation.gs` |
| Dispatcher edit | `edgar_send_email_verification.gs` — `doGet` + `doPost` route `action=sendOnboardingInvitation` to the new handler |
| Manifest | `tdg_identity_management/manifest.json` — `source_files` for `1m8IZPs1` now includes the new file (auto-regenerated by `gen_gas_manifests.py`) |

## Email shape

**Subject:** `<Inviter Name> added you to TrueSight DAO`

**Body** (rendered preview from the local handler):

> Hi Alex,
>
> Gary Teh added you to TrueSight DAO today.
>
> The first thing to know: every action you take in this DAO is signed by a key only you control. Not a wallet. Not gas. Not crypto in the way you have been told it has to be.
>
> Generate your signing key (takes 30 seconds, lives in your browser):
> https://dapp.truesight.me/create_signature.html?em=alex%40example.com
>
> Once that is done, you can submit contributions, propose work, and have your time recorded on the ledger like every other contributor.
>
> If you want some context on what you are part of:
> https://truesight.me/edgar.html
> https://truesight.me/whitepaper
>
> Welcome.
>
> — TrueSight DAO

Per Seth-lens: smallest viable audience (grassroots contributors burned by crypto-bro maximalism), single ask (the signature link with email pre-filled), one tribe-signaling line ("Not a wallet. Not gas."), context links deliberately *below* the primary action so they don't compete for the first click.

## Edgar API

```
GET /exec?action=sendOnboardingInvitation
       &secret=<EMAIL_VERIFICATION_SECRET>
       &email=<new-contributor@example.com>
       &contributor_name=<First Last>     # optional but recommended
       &inviter_name=<Governor Display>   # REQUIRED — Seth-voice copy names them
       &inviter_email=<governor@…>        # optional — becomes Reply-To
       &return_url=<base for create_signature.html>  # optional; DApp default
```

POST JSON same fields plus `action: "sendOnboardingInvitation"`. `doPost` defaults to the verification flow for backward compat.

## Operator helpers (editor-only)

- `TEST_sendOnboardingInvitation()` — edit constants, Run, sends real Gmail using the script's secret. Same caveat as the verification flow: editor-runs send from `Session.getActiveUser()`, not the deployed 'Execute as' owner, so use the deployed `/exec` to test the production From line.
- `editorDryRunOnboardingInvitation()` — prompts for fields, logs subject + body, no send.

## Rollout

**No `clasp push` in this PR.** Per Gary's standing constraint that `1zKgMwd6…` and other admin@-pinned scriptIds must always deploy as admin@, the push is operator-driven from his laptop:

```bash
cp ~/.clasprc-admin.json ~/.clasprc.json
cd ~/Applications/tokenomics
python3 scripts/deploy_gas_project.py 1m8IZPs1vFN99cuu-39kbC-OGXggRVtJtXq5rfSB0M1sCQjMdolEUDuGU --push
cp ~/.clasprc-gary.json ~/.clasprc.json
```

PR-1g identity check enforces `owner_email == admin@truesight.me`, so the push only succeeds with the admin clasprc loaded.

## Edgar-side follow-up (not in this PR)

`sentiment_importer` (the Rails Edgar app) needs a tiny addition: after the governor's `[CONTRIBUTOR ADD EVENT]` (or whatever the existing event name is) lands successfully, POST to this new `/exec` URL with the contributor's email + the governor's display name. That's a separate `sentiment_importer` PR. Until then, the handler exists + is callable but won't fire automatically.