### PR TITLE
Credentialing GAS: reprocess must never downgrade enriched event files

### DIFF
--- a/google_app_scripts/tdg_credentialing/practice_event_processing.gs
+++ b/google_app_scripts/tdg_credentialing/practice_event_processing.gs
@@ -349,6 +349,38 @@ function commitPracticeEvent(program, slug, filename, content) {
   };
 }
 
+/**
+ * Fetch + decode an existing committed practice-event file, or null.
+ * Used by reprocessing so re-commits never DOWNGRADE fields enriched
+ * out-of-band — e.g. the 2026-06-05 oracle source_url permalink backfill
+ * (?reading=<sums>&cast=<ts> deep links reconstructed from the original
+ * Telegram texts). A re-parse of the original message only knows the bare
+ * page URL and must not clobber the richer one.
+ */
+function fetchExistingPracticeEvent(program, slug, filename) {
+  var path = 'programs/' + program + '/' + slug + '/practice/' + filename;
+  var url = LC_CONTENTS_API_FMT.replace('{path}', path);
+  try {
+    var resp = UrlFetchApp.fetch(url + '?ref=' + encodeURIComponent(LC_BRANCH), {
+      method: 'get',
+      headers: {
+        Authorization: 'Bearer ' + getGithubToken(),
+        Accept: 'application/vnd.github+json',
+        'User-Agent': 'tdg-credentialing-processing/1.0',
+        'X-GitHub-Api-Version': '2022-11-28',
+      },
+      muteHttpExceptions: true,
+    });
+    var code = resp.getResponseCode();
+    if (code < 200 || code >= 300) return null;
+    var meta = JSON.parse(resp.getContentText());
+    var raw = Utilities.newBlob(Utilities.base64Decode((meta.content || '').replace(/\n/g, ''))).getDataAsString();
+    return JSON.parse(raw);
+  } catch (e) {
+    return null;
+  }
+}
+
 // ============================================================================
 // MAIN PIPELINE
 // ============================================================================
@@ -577,6 +609,24 @@ function reprocessCredentialingRow(rowNumber) {
     },
   };
   var filename = buildEventFilename(parsed.capturedAt, parsed.requestTransactionId);
+
+  // Never-downgrade guard: a reprocess rebuilds the file from the ORIGINAL
+  // message, but the committed file may carry fields enriched after the
+  // fact (oracle source_url permalinks; payloads backfilled out-of-band).
+  // Keep any existing value that is strictly richer than the re-parse.
+  var existing = fetchExistingPracticeEvent(parsed.program, slug, filename);
+  if (existing) {
+    if (existing.source_url && parsed.sourceUrl &&
+        existing.source_url.indexOf(parsed.sourceUrl) === 0 &&
+        existing.source_url.length > parsed.sourceUrl.length) {
+      eventFile.source_url = existing.source_url;
+    }
+    if (!eventFile.payload && existing.payload) {
+      eventFile.payload = existing.payload;
+      eventFile.raw_payload_json = existing.raw_payload_json || '';
+    }
+  }
+
   var commit = commitPracticeEvent(parsed.program, slug, filename, JSON.stringify(eventFile, null, 2));
 
   setIntakeRowStatus(intake, rowNumber, 'PROCESSED', commit.sha || '', commit.html_url || '');


### PR DESCRIPTION
## Goal
`reprocessCredentialingRow` rebuilds the lineage-credentials event file from the ORIGINAL Telegram message and recommits — which would clobber fields enriched after the fact. Concretely: the 2026-06-05 oracle source_url permalink backfill (`?reading=<sums>&cast=<ts>` deep links) would be reverted to bare `oracle.truesight.me/` by any reprocess run (the 10-min auto-backfill or the anonymous `reprocessAllRowsWithEmptyPayload` endpoint).

## Changes
- New `fetchExistingPracticeEvent()` — GETs + decodes the committed file via the Contents API (same headers/branch as `commitPracticeEvent`), null on absence/error.
- `reprocessCredentialingRow`: before recommitting, keep the existing `source_url` when it extends the re-parsed one (prefix match + strictly longer), and keep existing `payload`/`raw_payload_json` when the re-parse yields none.

## Immediate mitigation already applied (out-of-band)
Intake-sheet col M (Payload JSON) filled for the 9 oracle rows from the original texts, so the `force:false` auto-backfill now skips them regardless of deploy timing.

## Rollout
Reference file only (this PR). Deploy: sync into `clasp_mirrors/1Dj3-m_ejxYJ4UQK2zNadnqNHJIvPQfj-VYvH9_Gnap6MYRmOJhK3B0VR/`, bump Version.gs, `clasp push`, then `clasp deploy -i AKfycbwYx6B2…` to refresh the anonymous deployment in place — blocked on operator `clasp login` (local + box `.clasprc.json` tokens are empty).