### PR TITLE
feat(identity): add sentinel role to dao_members.json cache

### DIFF
--- a/google_app_scripts/tdg_identity_management/dao_members_cache_publisher.gs
+++ b/google_app_scripts/tdg_identity_management/dao_members_cache_publisher.gs
@@ -48,6 +48,8 @@ const DAO_MEMBERS_CACHE_SPREADSHEET_ID =
 const DAO_MEMBERS_CACHE_SIGS_SHEET = 'Contributors Digital Signatures';
 const DAO_MEMBERS_CACHE_VOTING_SHEET = 'Contributors voting weight';
 const DAO_MEMBERS_CACHE_GOVERNORS_SHEET = 'Governors';
+// "Is Sentinel" = TRUE on this sheet → the "sentinel" role (autopilot persona).
+const DAO_MEMBERS_CACHE_CONTACT_SHEET = 'Contributors contact information';
 // Governor names live in column A starting at row 11 (rows 1–10 are header /
 // configuration / equinox-rotation copy). The cell list is auto-populated by
 // formulas elsewhere in the workbook based on the trailing contribution
@@ -196,6 +198,60 @@ function publishDaoMembersCacheToGithub_(opts) {
         'all contributors will be emitted with roles=["member"] only.');
   }
 
+  // ----- Sentinel flag — "Contributors contact information" sheet ----------
+  // A contributor with "Is Sentinel" = TRUE gets the "sentinel" role (autopilot
+  // persona). Columns are located by header (so layout shifts don't break it);
+  // join by name, with email as a fallback. Missing sheet/column → no sentinels,
+  // never breaks the cache.
+  const sentinelByName = {};
+  const sentinelByEmail = {};
+  const contactSheet = ss.getSheetByName(DAO_MEMBERS_CACHE_CONTACT_SHEET);
+  if (contactSheet && contactSheet.getLastRow() >= 2) {
+    const cVals = contactSheet.getDataRange().getValues();
+    // The header is NOT on row 1 (this sheet keeps config/legend rows up top —
+    // "Is Sentinel" lives on row 4). Auto-detect the header row by scanning the
+    // first few rows for the one that actually carries the "sentinel" column, so
+    // a future layout shift doesn't silently break the join.
+    var headerRowIdx = 0;
+    for (var hr = 0; hr < Math.min(cVals.length, 10); hr++) {
+      var hasSentinel = (cVals[hr] || []).some(function (h) {
+        return String(h || '').trim().toLowerCase().indexOf('sentinel') >= 0;
+      });
+      if (hasSentinel) { headerRowIdx = hr; break; }
+    }
+    const cHeader = (cVals[headerRowIdx] || []).map(function (h) { return String(h || '').trim().toLowerCase(); });
+    const findCol = function (preds) {
+      for (var pi = 0; pi < preds.length; pi++) {
+        for (var i = 0; i < cHeader.length; i++) { if (preds[pi](cHeader[i])) return i; }
+      }
+      return -1;
+    };
+    const sentinelCol = findCol([function (h) { return h.indexOf('sentinel') >= 0; }]);
+    const nameCol = findCol([
+      function (h) { return h === 'name' || h === 'contributor name' || h === 'full name'; },
+      function (h) { return h.indexOf('name') >= 0; },
+    ]);
+    const emailCol = findCol([function (h) { return h.indexOf('email') >= 0; }]);
+    if (sentinelCol < 0) {
+      Logger.log('dao_members_cache: no "Is Sentinel" column in ' + DAO_MEMBERS_CACHE_CONTACT_SHEET);
+    } else {
+      for (var r = headerRowIdx + 1; r < cVals.length; r++) {
+        var sv = cVals[r][sentinelCol];
+        if (sv !== true && String(sv).trim().toUpperCase() !== 'TRUE') continue;
+        if (nameCol >= 0) {
+          var nm = String(cVals[r][nameCol] || '').trim().toLowerCase();
+          if (nm) sentinelByName[nm] = true;
+        }
+        if (emailCol >= 0) {
+          var em = String(cVals[r][emailCol] || '').trim().toLowerCase();
+          if (em) sentinelByEmail[em] = true;
+        }
+      }
+    }
+  } else {
+    Logger.log('dao_members_cache: ' + DAO_MEMBERS_CACHE_CONTACT_SHEET + ' not found/empty; no sentinel roles.');
+  }
+
   // ----- Aggregate signatures by contributor name --------------------------
   // Email lives on col F (`Contributor Email Address`); per-key in the sheet
   // but we hoist the first non-empty email to the contributor record because
@@ -235,6 +291,7 @@ function publishDaoMembersCacheToGithub_(opts) {
     const voting = votingByName[k] || {};
     const roles = ['member'];
     if (governorsByName[k]) roles.unshift('governor');
+    if (sentinelByName[k] || (entry.email && sentinelByEmail[entry.email])) roles.push('sentinel');
     return {
       name: entry.name,
       email: entry.email,                                  // may be null

--- a/google_app_scripts/tdg_identity_management/manifest.json
+++ b/google_app_scripts/tdg_identity_management/manifest.json
@@ -32,7 +32,7 @@
       "notes": "Audit-derived from in-source header-comment scriptIds on 2026-05-28. Pre-flight checklist (TOKENOMICS_GAS_RESTRUCTURE_PLAN.md §4) must resolve: full deployments list, post-push cache-refresh hooks, confirmed owner_email, consumer callers."
     },
     {
-      "name": "TBC — confirm display name in GAS UI for 1m8IZPs1vFN9…",
+      "name": "TDG - Telegram Identity (scriptId 1m8IZPs1…)",
       "scriptId": "1m8IZPs1vFN99cuu-39kbC-OGXggRVtJtXq5rfSB0M1sCQjMdolEUDuGU",
       "owner_email": "admin@truesight.me",
       "deployments": {
@@ -53,9 +53,12 @@
       "source_files": [
         "edgar_send_email_verification.gs",
         "edgar_send_onboarding_invitation.gs",
-        "email_verification_from_edgar.gs"
+        "email_verification_from_edgar.gs",
+        "dao_members_cache_publisher.gs",
+        "dapp_permission_change_handler.gs",
+        "process_contributor_add_telegram_logs.gs"
       ],
-      "notes": "Audit-derived from in-source header-comment scriptIds on 2026-05-28. Pre-flight checklist (TOKENOMICS_GAS_RESTRUCTURE_PLAN.md §4) must resolve: full deployments list, post-push cache-refresh hooks, confirmed owner_email, consumer callers."
+      "notes": "Audit-derived from in-source header-comment scriptIds on 2026-05-28. Pre-flight checklist (TOKENOMICS_GAS_RESTRUCTURE_PLAN.md §4) must resolve: full deployments list, post-push cache-refresh hooks, confirmed owner_email, consumer callers. RESOLVED 2026-06-06: the three former files_without_scriptid (dao_members_cache_publisher.gs, dapp_permission_change_handler.gs, process_contributor_add_telegram_logs.gs) all live in THIS project (verified via clasp pull). IMPORTANT — the live project filenames DIFFER from the repo source filenames: DaoMembersCache.js=dao_members_cache_publisher.gs, DappPermissionChangeHandler.js=dapp_permission_change_handler.gs, ContributorAddHandler.js=process_contributor_add_telegram_logs.gs, Code.js=edgar_send_email_verification.gs. The dao_members cache refresh is served by web-app deployment AKfycbxvAi7DUCd1pv8GgSPazcNgNxhUsfEiBOBZBaB3CbqqY3kScTEau273dip1YHyRsEFY-w (action=refresh_dao_members_cache, secret=EMAIL_VERIFICATION_SECRET script property; caller dao_protocol holds it as DAO_PROTOCOL_EMAIL_VERIFICATION_GAS_SECRET). Redeploy that deployment id after any push or the webhook serves stale code."
     },
     {
       "name": "TBC — confirm display name in GAS UI for 1zKgMwd6KJFj…",
@@ -81,11 +84,7 @@
       "notes": "Audit-derived from in-source header-comment scriptIds on 2026-05-28. Pre-flight checklist (TOKENOMICS_GAS_RESTRUCTURE_PLAN.md §4) must resolve: full deployments list, post-push cache-refresh hooks, confirmed owner_email, consumer callers."
     }
   ],
-  "files_without_scriptid": [
-    "dao_members_cache_publisher.gs",
-    "dapp_permission_change_handler.gs",
-    "process_contributor_add_telegram_logs.gs"
-  ],
+  "files_without_scriptid": [],
   "exec_urls_seen_in_folder_sources": [
     "https://script.google.com/macros/s/AKfycbwbtBlxkK0TzwLGnwUNQ_INfvLFvTRli-31r-b51Tnx4c-xlwMoqwT5sKFmfZv5lN6sLQ/exec",
     "https://script.google.com/macros/s/AKfycbwlh2u-SktykzL6S_qamE2rQVd-G_3uSd3GhJ_8KI5b2e8oVuMYxXA5UfJ-NaigOk60/exec",


### PR DESCRIPTION
Adds a `sentinel` role to the DAO-wide `dao_members.json` cache (treasury-cache), driven by the **Is Sentinel** column on the *Contributors contact information* tab.

## What
- `dao_members_cache_publisher.gs`: reads the `Is Sentinel` column, adds `sentinel` to a contributor's roles (joined by name, email fallback). **Header row is auto-detected** — it lives on row 4, not row 1, which is why the first cut emitted zero sentinels.
- `manifest.json`: the three former `files_without_scriptid` all live in project `1m8IZPs1` (verified via `clasp pull`). Mapped them, cleared the list, and documented the **repo↔project filename divergence** (`DaoMembersCache.js` = `dao_members_cache_publisher.gs`, etc.) that made the script ID look 'missing'.

## Verified live
Deployed to project `1m8IZPs1` + redeployed the webhook deployment, then triggered `refresh_dao_members_cache`:
```
sentinels: Sophia Truesight ['member','sentinel'], truesight-autopilot ['member','sentinel']
```
(Also surfaced these on https://truesight.me/members.html via a companion truesight_me PR.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)