### PR TITLE
docs(identity manifest): map 3 orphan files to scriptId 1m8IZPs1

### DIFF
--- a/google_app_scripts/tdg_identity_management/manifest.json
+++ b/google_app_scripts/tdg_identity_management/manifest.json
@@ -32,7 +32,7 @@
       "notes": "Audit-derived from in-source header-comment scriptIds on 2026-05-28. Pre-flight checklist (TOKENOMICS_GAS_RESTRUCTURE_PLAN.md §4) must resolve: full deployments list, post-push cache-refresh hooks, confirmed owner_email, consumer callers."
     },
     {
-      "name": "TBC — confirm display name in GAS UI for 1m8IZPs1vFN9…",
+      "name": "TDG - Telegram Identity (scriptId 1m8IZPs1…)",
       "scriptId": "1m8IZPs1vFN99cuu-39kbC-OGXggRVtJtXq5rfSB0M1sCQjMdolEUDuGU",
       "owner_email": "admin@truesight.me",
       "deployments": {
@@ -53,9 +53,12 @@
       "source_files": [
         "edgar_send_email_verification.gs",
         "edgar_send_onboarding_invitation.gs",
-        "email_verification_from_edgar.gs"
+        "email_verification_from_edgar.gs",
+        "dao_members_cache_publisher.gs",
+        "dapp_permission_change_handler.gs",
+        "process_contributor_add_telegram_logs.gs"
       ],
-      "notes": "Audit-derived from in-source header-comment scriptIds on 2026-05-28. Pre-flight checklist (TOKENOMICS_GAS_RESTRUCTURE_PLAN.md §4) must resolve: full deployments list, post-push cache-refresh hooks, confirmed owner_email, consumer callers."
+      "notes": "Audit-derived from in-source header-comment scriptIds on 2026-05-28. Pre-flight checklist (TOKENOMICS_GAS_RESTRUCTURE_PLAN.md §4) must resolve: full deployments list, post-push cache-refresh hooks, confirmed owner_email, consumer callers. RESOLVED 2026-06-06: the three former files_without_scriptid all live in THIS project (verified via clasp pull). Live project filenames DIFFER from repo source filenames: DaoMembersCache.js=dao_members_cache_publisher.gs, DappPermissionChangeHandler.js=dapp_permission_change_handler.gs, ContributorAddHandler.js=process_contributor_add_telegram_logs.gs, Code.js=edgar_send_email_verification.gs. dao_members cache refresh is served by web-app deployment AKfycbxvAi7DUCd1pv8GgSPazcNgNxhUsfEiBOBZBaB3CbqqY3kScTEau273dip1YHyRsEFY-w (action=refresh_dao_members_cache; secret=EMAIL_VERIFICATION_SECRET script property; caller dao_protocol holds it as DAO_PROTOCOL_EMAIL_VERIFICATION_GAS_SECRET). Redeploy that deployment id after any push or the webhook serves stale code."
     },
     {
       "name": "TBC — confirm display name in GAS UI for 1zKgMwd6KJFj…",
@@ -81,11 +84,7 @@
       "notes": "Audit-derived from in-source header-comment scriptIds on 2026-05-28. Pre-flight checklist (TOKENOMICS_GAS_RESTRUCTURE_PLAN.md §4) must resolve: full deployments list, post-push cache-refresh hooks, confirmed owner_email, consumer callers."
     }
   ],
-  "files_without_scriptid": [
-    "dao_members_cache_publisher.gs",
-    "dapp_permission_change_handler.gs",
-    "process_contributor_add_telegram_logs.gs"
-  ],
+  "files_without_scriptid": [],
   "exec_urls_seen_in_folder_sources": [
     "https://script.google.com/macros/s/AKfycbwbtBlxkK0TzwLGnwUNQ_INfvLFvTRli-31r-b51Tnx4c-xlwMoqwT5sKFmfZv5lN6sLQ/exec",
     "https://script.google.com/macros/s/AKfycbwlh2u-SktykzL6S_qamE2rQVd-G_3uSd3GhJ_8KI5b2e8oVuMYxXA5UfJ-NaigOk60/exec",


### PR DESCRIPTION
Companion cleanup to #335. Sophia's PR added the sentinel logic but left these three files in `files_without_scriptid`, which is why the script ID looked 'missing' during her deploy attempt.

All three actually live in project **`1m8IZPs1`** (verified via `clasp pull`). This records the mapping, clears `files_without_scriptid`, and documents:
- the **repo↔project filename divergence** (`DaoMembersCache.js` = `dao_members_cache_publisher.gs`, `DappPermissionChangeHandler.js` = `dapp_permission_change_handler.gs`, `ContributorAddHandler.js` = `process_contributor_add_telegram_logs.gs`, `Code.js` = `edgar_send_email_verification.gs`)
- the **webhook deployment id** to redeploy after any push (else the `/exec` serves stale code).

🤖 Generated with [Claude Code](https://claude.com/claude-code)