### PR TITLE
Add clasp owner hint to Shopping Cart mirror

### DIFF
--- a/clasp_mirrors/1ovx-Hq5L5MgzF32qB_cPV_G5Hc6XshKMAYOmiJY8tZ355gzWUqvFCPvn/.clasp-owner
+++ b/clasp_mirrors/1ovx-Hq5L5MgzF32qB_cPV_G5Hc6XshKMAYOmiJY8tZ355gzWUqvFCPvn/.clasp-owner
@@ -1,0 +1,9 @@
+garyjob@agroverse.shop
+# This script is owned by garyjob@agroverse.shop.
+# To push/deploy, swap clasp credentials:
+#   cp /home/ubuntu/.clasprc-gary.json /home/ubuntu/.clasprc.json
+#   clasp push
+#   cp /home/ubuntu/.clasprc-admin.json /home/ubuntu/.clasprc.json
+#
+# The default .clasprc.json is admin@truesight.me and does NOT have access.
+# See clasp_mirrors/README.md for the full credential-switching protocol.


### PR DESCRIPTION
## Problem
Future Sophias (and LLMs) get stuck trying to `clasp push` the Shopping Cart mirror because the default `.clasprc.json` is `admin@truesight.me`, but the script is owned by `garyjob@agroverse.shop`.

## Fix
1. Added `@owner garyjob@agroverse.shop` JSDoc tag to `Version.js` with credential-swap instructions
2. Added `.clasp-owner` file in the mirror directory with the same info
3. Updated changelog to record the subscription checkout session deployment (version @2)
4. Added `owner` field to `getClaspMirrorDeployInfo()` return value

## Future pattern
Every clasp mirror should have a `.clasp-owner` file so any Sophia can check `cat clasp_mirrors/<scriptId>/.clasp-owner` before attempting a push.