### PR TITLE
Add BUY_BACK_RESERVE to Performance Statistics sync

### DIFF
--- a/google_app_scripts/tdg_asset_management/tdg_wix_dashboard.gs
+++ b/google_app_scripts/tdg_asset_management/tdg_wix_dashboard.gs
@@ -3321,7 +3321,18 @@ function syncAllPerformanceStatistics() {
       Logger.log("❌ Error updating AUM: " + e.message);
     }
     
-    // 8. Update current month's statistics in Monthly Statistics sheet
+    // 8. BUY_BACK_RESERVE (accumulated provisions for voting rights cash out)
+    try {
+      var buyBackReserve = getBuyBackReserveFromOffChainBalance();
+      updatePerformanceStatistic("BUY_BACK_RESERVE", buyBackReserve, "USD");
+      report.updated.push({ key: "BUY_BACK_RESERVE", value: buyBackReserve });
+      Logger.log("✅ Updated BUY_BACK_RESERVE: " + buyBackReserve);
+    } catch (e) {
+      report.errors.push({ key: "BUY_BACK_RESERVE", error: e.message });
+      Logger.log("❌ Error updating BUY_BACK_RESERVE: " + e.message);
+    }
+    
+    // 9. Update current month's statistics in Monthly Statistics sheet
     try {
       updateCurrentMonthStatistics();
       Logger.log("✅ Updated current month statistics in Monthly Statistics sheet");


### PR DESCRIPTION
Adds a new `BUY_BACK_RESERVE` key to the Performance Statistics sheet, read from the "USD - provisions for voting rights cash out" row in the off chain asset balance sheet. This allows the homepage to display the accumulated buy-back reserve as a stat card.

**Changes:**
- Added `getBuyBackReserveFromOffChainBalance()` function that reads the "USD - provisions for voting rights cash out" row from the off chain asset balance sheet
- Added step 8 in `syncAllPerformanceStatistics()` to sync the buy-back reserve value to Performance Statistics

The homepage will display this as "Accumulated Buy-Back Reserve" — the total USD provisions set aside for buy-back/voting rights cash out to date.