### PR TITLE
[autopilot] Add BUY_BACK_RESERVE to Performance Statistics sync in tdg_w

### DIFF
--- a/google_app_scripts/tdg_asset_management/tdg_wix_dashboard.gs
+++ b/google_app_scripts/tdg_asset_management/tdg_wix_dashboard.gs
@@ -1111,6 +1111,32 @@ function getOffChainAssetValue() {
   return assets[0];
 }
 
+/**
+ * Reads the "USD - provisions for voting rights cash out" balance from the
+ * "off chain asset balance" sheet (column A = asset name, column B = balance).
+ * Returns the numeric value from column B, or 0 if the row is not found.
+ *
+ * @return {number} The buy-back reserve balance in USD.
+ */
+function getBuyBackReserveFromOffChainBalance() {
+  try {
+    var data = offChainAssetBalanceTab.getDataRange().getValues();
+    for (var i = 0; i < data.length; i++) {
+      var assetName = String(data[i][0] || '').trim();
+      if (assetName === "USD - provisions for voting rights cash out") {
+        var balance = parseFloat(data[i][1]) || 0;
+        Logger.log("Buy-back reserve (off-chain): " + balance);
+        return balance;
+      }
+    }
+    Logger.log("Buy-back reserve row not found in off chain asset balance sheet, returning 0");
+    return 0;
+  } catch (e) {
+    Logger.log("Error reading buy-back reserve from off chain asset balance: " + e.message);
+    return 0;
+  }
+}
+
 function getTdgTokensIssued() {
   var assets = tdgIssuedBalanceTab.getRange(1,5).getValues().map(function(valueArray) {
     return valueArray[0];

--- a/google_app_scripts/tdg_asset_management/tdg_wix_dashboard.gs
+++ b/google_app_scripts/tdg_asset_management/tdg_wix_dashboard.gs
@@ -3347,7 +3347,18 @@ function syncAllPerformanceStatistics() {
       Logger.log("❌ Error updating AUM: " + e.message);
     }
     
-    // 8. Update current month's statistics in Monthly Statistics sheet
+    // 8. BUY_BACK_RESERVE
+    try {
+      var buyBackReserve = getBuyBackReserveFromOffChainBalance();
+      updatePerformanceStatistic("BUY_BACK_RESERVE", buyBackReserve, "USD");
+      report.updated.push({ key: "BUY_BACK_RESERVE", value: buyBackReserve });
+      Logger.log("✅ Updated BUY_BACK_RESERVE: " + buyBackReserve);
+    } catch (e) {
+      report.errors.push({ key: "BUY_BACK_RESERVE", error: e.message });
+      Logger.log("❌ Error updating BUY_BACK_RESERVE: " + e.message);
+    }
+    
+    // 9. Update current month's statistics in Monthly Statistics sheet
     try {
       updateCurrentMonthStatistics();
       Logger.log("✅ Updated current month statistics in Monthly Statistics sheet");


### PR DESCRIPTION
## Autopilot Fix

**Issue:** Add BUY_BACK_RESERVE to Performance Statistics sync in tdg_wix_dashboard.gs

The file is at google_app_scripts/tdg_asset_management/tdg_wix_dashboard.gs

I need two changes:

1. Add a new function `getBuyBackReserveFromOffChainBalance()` that reads the "USD - provisions for voting rights cash out" row from the "off chain asset balance" sheet (column A = asset name, column B = balance). The sheet is already referenced as `offChainAssetBalanceTab`. Find the row where column A matches "USD - provisions for voting rights cash out" and return the numeric value from column B. Return 0 if not found.

2. In the `syncAllPerformanceStatistics()` function, add a new step (before the "Update current month's statistics" step) that calls `getBuyBackReserveFromOffChainBalance()` and writes it to Performance Statistics with key "BUY_BACK_RESERVE" and currency "USD", following the same pattern as the other steps (try/catch, updatePerformanceStatistic, report.updated.push, Logger.log).

The function should be placed near the other helper functions that read from the off chain asset balance sheet.

**Branch:** `autopilot/fix-1781617089`

---

This PR was generated by [truesight_autopilot](https://github.com/TrueSightDAO/truesight_autopilot). Please review before merging.