### PR TITLE
[autopilot] Add a `?action=triggerSync` handler to the `doGet` function 

### DIFF
--- a/google_app_scripts/tdg_asset_management/tdg_wix_dashboard.gs
+++ b/google_app_scripts/tdg_asset_management/tdg_wix_dashboard.gs
@@ -2377,6 +2377,20 @@ function doGet(e) {
         .setMimeType(ContentService.MimeType.JSON);
     }
     
+    // Check if action parameter is provided for remote trigger
+    var action = e.parameter.action;
+    
+    if (action === 'triggerSync') {
+      var result = syncAllPerformanceStatistics();
+      return ContentService.createTextOutput(JSON.stringify({
+        timestamp: new Date().toISOString(),
+        status: 'ok',
+        updated: result.updated.length,
+        errors: result.errors.length,
+        details: result
+      })).setMimeType(ContentService.MimeType.JSON);
+    }
+    
     // Default: return all performance statistics
     var data = readPerformanceStatistics();
     


### PR DESCRIPTION
## Autopilot Fix

**Issue:** Add a `?action=triggerSync` handler to the `doGet` function in `google_app_scripts/tdg_asset_management/tdg_wix_dashboard.gs` so the sync can be triggered remotely via HTTP GET.

The `doGet` function currently only handles `?action=getPerformanceStatistics`. Add a new case:

```
if (action === 'triggerSync') {
  var result = syncAllPerformanceStatistics();
  return ContentService.createTextOutput(JSON.stringify({
    timestamp: new Date().toISOString(),
    status: 'ok',
    updated: result.updated.length,
    errors: result.errors.length,
    details: result
  })).setMimeType(ContentService.MimeType.JSON);
}
```

This should be added in the `doGet` function, right after the existing `getPerformanceStatistics` action handler. The function `syncAllPerformanceStatistics()` already exists in the same file.

**Branch:** `autopilot/fix-1781617494`

---

This PR was generated by [truesight_autopilot](https://github.com/TrueSightDAO/truesight_autopilot). Please review before merging.