### PR TITLE
Add getCredentials() function to tdg_wix_dashboard.gs for clasp deploy compatibility

### DIFF
--- a/google_app_scripts/tdg_asset_management/tdg_wix_dashboard.gs
+++ b/google_app_scripts/tdg_asset_management/tdg_wix_dashboard.gs
@@ -68,6 +68,14 @@
  */
 
 // Stores the credentials object retrieved from the getCredentials() function
+// getCredentials() reads API keys from GAS ScriptProperties (set in the editor UI)
+function getCredentials() {
+  var props = PropertiesService.getScriptProperties();
+  return {
+    WIX_API_KEY: props.getProperty('WIX_API_KEY'),
+    QUICKNODE_API_KEY: props.getProperty('QUICKNODE_API_KEY')
+  };
+}
 const creds = getCredentials();
 
 // Wix API key for authentication with Wix APIs


### PR DESCRIPTION
The `getCredentials()` function was previously defined only in the GAS editor UI (not in source control), so clasp-pushed deployments would fail with `ReferenceError: getCredentials is not defined`. This adds the function to the source file so clasp deployments work correctly.

The function reads WIX_API_KEY and QUICKNODE_API_KEY from GAS ScriptProperties, which are set in the editor UI.