### PR TITLE
Fix: write cache to current directory, not hardcoded path

### DIFF
--- a/python_scripts/tdg_asset_management/update_buy_back_reserve_cache.py
+++ b/python_scripts/tdg_asset_management/update_buy_back_reserve_cache.py
@@ -37,8 +37,9 @@ GAS_PERF_STATS_URL = (
     '?action=getPerformanceStatistics'
 )
 
-OUTPUT_DIR = os.path.expanduser('~/Applications/treasury-cache')
-REPO_DIR = os.path.expanduser('~/Applications/treasury-cache')
+# Write to current working directory (repo root when run from GitHub Action)
+OUTPUT_DIR = os.getcwd()
+REPO_DIR = os.getcwd()
 
 SERVICE_ACCOUNT_PATH = os.path.expanduser(
     '~/Applications/sentiment_importer/config/cypher_defense_gdrive_key.json'


### PR DESCRIPTION
The script was writing to `~/Applications/treasury-cache/` which doesn't exist in the GitHub Actions runner. Changed to write to the current working directory (which is the repo root when run from the GitHub Action workflow).