### PR TITLE
Fix: use absolute values for provision amounts

### DIFF
--- a/python_scripts/tdg_asset_management/update_buy_back_reserve_cache.py
+++ b/python_scripts/tdg_asset_management/update_buy_back_reserve_cache.py
@@ -150,7 +150,7 @@ def get_daily_provisions(gc):
             provisions.append({
                 'date': date_val,
                 'description': desc.split('\n')[0],  # first line only
-                'amount': round(amount, 2),
+                'amount': round(abs(amount), 2),  # use absolute value (ledger stores as debit)
             })
 
     # Sort by date ascending


### PR DESCRIPTION
The offchain transactions sheet stores buy-back provisions as negative debits. The cache should show positive amounts for display on the detail page.