### PR TITLE
feat: add sentinel role to dao_members_cache_publisher

### DIFF
--- a/google_app_scripts/1m8IZPs1vFN99cuu-39kbC-OGXggRVtJtXq5rfSB0M1sCQjMdolEUDuGU/DaoMembersCache.js
+++ b/google_app_scripts/1m8IZPs1vFN99cuu-39kbC-OGXggRVtJtXq5rfSB0M1sCQjMdolEUDuGU/DaoMembersCache.js
@@ -48,6 +48,7 @@ const DAO_MEMBERS_CACHE_SPREADSHEET_ID =
 const DAO_MEMBERS_CACHE_SIGS_SHEET = 'Contributors Digital Signatures';
 const DAO_MEMBERS_CACHE_VOTING_SHEET = 'Contributors voting weight';
 const DAO_MEMBERS_CACHE_GOVERNORS_SHEET = 'Governors';
+const DAO_MEMBERS_CACHE_CONTACT_SHEET = 'Contributors contact information';
 // Governor names live in column A starting at row 11 (rows 1–10 are header /
 // configuration / equinox-rotation copy). The cell list is auto-populated by
 // formulas elsewhere in the workbook based on the trailing contribution
@@ -170,6 +171,30 @@ function publishDaoMembersCacheToGithub_(opts) {
     });
   }
 
+  // ----- Contributors Contact Information — sentinel flag (col W) -----------
+  // Header is row 3 (Name=col A, Is Sentinel=col W). Data starts at row 4.
+  const contactSheet = ss.getSheetByName(DAO_MEMBERS_CACHE_CONTACT_SHEET);
+  const sentinelsByName = {};
+  if (contactSheet) {
+    const contactLastRow = contactSheet.getLastRow();
+    if (contactLastRow >= 4) {
+      // Columns A(1)..W(23): name, ..., Is Sentinel
+      const contactRows = contactSheet.getRange(4, 1, contactLastRow - 3, 23).getValues();
+      contactRows.forEach(function (row) {
+        const name = String(row[0] || '').trim();
+        if (!name) return;
+        const isSentinel = String(row[22] || '').trim().toUpperCase() === 'TRUE';
+        if (isSentinel) {
+          sentinelsByName[name.toLowerCase()] = true;
+        }
+      });
+    }
+  } else {
+    Logger.log(
+        'Warning: ' + DAO_MEMBERS_CACHE_CONTACT_SHEET + ' tab not found; ' +
+        'no contributors will be flagged as sentinel.');
+  }
+
   // ----- Governors tab — names of currently-elected governors --------------
   // Read column A from row 11 to last-row, lowercase, stash in a Set-like map.
   // The leaderboard is recomputed quarterly (equinoxes / solstices) by the
@@ -224,6 +249,7 @@ function publishDaoMembersCacheToGithub_(opts) {
     const voting = votingByName[k] || {};
     const roles = ['member'];
     if (governorsByName[k]) roles.unshift('governor');
+    if (sentinelsByName[k]) roles.push('sentinel');
     return {
       name: entry.name,
       email: entry.email,                                  // may be null


### PR DESCRIPTION
## What

Adds a fourth sheet read to `DaoMembersCache.js` — `Contributors Contact Information` — and checks Column W ("Is Sentinel") to include `'sentinel'` in the contributor's `roles` array.

## Why

- The members page (`truesight.me/members.html`) has a Sentinels section that filters for `roles: ['sentinel']`, but it's been hidden because the publisher never set that role
- The GAS inventory movement auth needs a dynamic sentinel check (replacing the hardcoded `TRUSTED_AGENTS` list) — this provides the data source

## Changes

1. Added `DAO_MEMBERS_CACHE_CONTACT_SHEET = 'Contributors contact information'` constant
2. Added a new sheet read block that reads columns A (name) and W (Is Sentinel) from rows 4+ (header at row 3)
3. Built a `sentinelsByName` lookup map
4. In the roles assembly, added `if (sentinelsByName[k]) roles.push('sentinel')` after the governor check
5. Updated the schema comment to document the `'sentinel'` role

## Testing

- Manual: run `publishDaoMembersCacheNow()` from Apps Script editor after deploy
- Verify `dao_members.json` includes `"roles": ["governor", "member", "sentinel"]` for Sophia Truesight
- Verify Sentinels section appears on `truesight.me/members.html`

Part of the Sentinel Role plan (SENTINEL_ROLE_DAO_MEMBERS_PLAN.md, Step 1).