### PR TITLE
feat: Sentinel authorization for inventory movement + column T schema

### DIFF
--- a/SCHEMA.md
+++ b/SCHEMA.md
@@ -8,7 +8,7 @@
 
 ### **Inventory Movement** / **Scored Expense Submissions** — signer vs manager authorization (GAS)
 
-- **`process_movement_telegram_logs.gs`:** Column **N** (`STATUS`) is **`NEW`** when **Telegram Chat Logs** column **S** (`Governor`) is **`YES`**, or when the **ACTIVE** signer (**Contributors Digital Signatures**) matches **`- Manager Name:`** from the movement payload; otherwise **`unauthorized`**. **`processInventoryMovementToLedgers`** only processes **`NEW`** (skips **`unauthorized`**).
+- **`process_movement_telegram_logs.gs`:** Column **N** (`STATUS`) is **`NEW`** when **Telegram Chat Logs** column **S** (`Governor`) is **`YES`** OR column **T** (`Is Sentinel`) is **`TRUE`**, or when the **ACTIVE** signer (**Contributors Digital Signatures**) matches **`- Manager Name:`** from the movement payload; otherwise **`unauthorized`**. **`processInventoryMovementToLedgers`** only processes **`NEW`** (skips **`unauthorized`**).
 - **`tdg_expenses_processing.gs`:** **Scored Expense Submissions** column **N** — **`Processing Status`**: **`authorized`** under the same governor rule or when **Reporter Name** (column **E**) matches **DAO Member Name** (column **H**); otherwise **`unauthorized`**. **`InsertExpenseRecords`** does not write to ledgers when column **N** is **`unauthorized`** (row is still appended for audit). Legacy scored rows with only columns **A–M** are treated as authorized when inserted into ledgers by older code paths.
 
 ---
@@ -21,7 +21,7 @@
 - **Column S header:** **`Governor`**
 - **Values (Edgar / `sentiment_importer`):** **`YES`** — signer verified and **ACTIVE** **Contributors Digital Signatures** **Contributor Name** matches a value in **Main Ledger** tab **`Governors`** column **A** (case-insensitive). **`NO`** — verified signer not on that list. **Blank** — signature not successful or signer could not be resolved to an **ACTIVE** contributor row.
 - **Operations meaning:** **`YES`** = **global override** for downstream Google Apps Script that processes sales, inventory movement, and expenses from this tab (governors may correct submissions when other members do not update records). **`NO`** / blank = downstream scripts should apply existing signer-vs-inventory scope rules and skip or flag ledger mutations when out of scope.
-- **Implementation:** Edgar appends **19 columns** (**A–S**) on `POST /dao/submit_contribution` and express contribution paths; values are cached server-side from **`Governors`!A2:A** for a short TTL.
+- **Implementation:** Edgar appends **20 columns** (**A–T**) on `POST /dao/submit_contribution` and express contribution paths; column S values are cached server-side from **`Governors`!A2:A** for a short TTL; column T reads **Contributors contact information** column W (`Is Sentinel`).
 
 ---
 
@@ -271,6 +271,7 @@ See [`python_scripts/schema_validation/README.md`](./python_scripts/schema_valid
 | Q | External API call status | String | Status of external API calls |
 | R | External API call response | String | Response from external API |
 | S | Governor | String | **`YES`** / **`NO`** / blank — signer matched **Main Ledger** tab **`Governors`** column **A** at ingest (`YES` = global ledger authority for downstream sales / inventory / expense parsers). See **Recent Changes (2026-04-21)**. |
+| T | Is Sentinel | String | **`TRUE`** / blank — signer's contributor row has `TRUE` in **Contributors contact information** column **W** (`Is Sentinel`). Sentinels (AI agents) get governor-equivalent operational privileges (inventory, sales, QR ops) without governance authority (proposals, votes). Populated by Edgar (`dao_protocol`) at ingest. |
 
 **Note (DApp / Edgar ingest):** For `POST /dao/submit_contribution`, column **P** is populated by Edgar as `success` / `failed` / `no_signature_format` / `error` (and similar). Downstream processors (for example Agroverse QR generation) treat `success` (case-insensitive) as cryptographically verified at ingest. Email onboarding events (`[EMAIL REGISTERED EVENT]`, `[EMAIL VERIFICATION EVENT]`) follow the same ingest path and column **P** semantics.
 

--- a/google_app_scripts/1wONDeDwZ_fXNapDKpstWrBION3aV3r7NXwq7PCdqbW1LvI5ceaykQNbR/Code.js
+++ b/google_app_scripts/1wONDeDwZ_fXNapDKpstWrBION3aV3r7NXwq7PCdqbW1LvI5ceaykQNbR/Code.js
@@ -41,6 +41,8 @@ const LEDGER_URL_COL = 11; // Column L - Ledger URL
 
 /** Telegram Chat Logs column S (Governor): YES = global ledger authority (Edgar). 0-based index 18. */
 const TELEGRAM_GOVERNOR_COL = 18;
+/** Telegram Chat Logs column T (Is Sentinel): TRUE = AI agent with governor-equivalent operational privileges (Edgar). 0-based index 19. */
+const TELEGRAM_SENTINEL_COL = 19;
 
 function normalizeAuthName_(name) {
   return (name == null ? '' : String(name))
@@ -59,6 +61,12 @@ function isTelegramGovernorYes_(telegramRow) {
   return String(telegramRow && telegramRow[TELEGRAM_GOVERNOR_COL] != null ? telegramRow[TELEGRAM_GOVERNOR_COL] : '')
     .trim()
     .toUpperCase() === 'YES';
+}
+
+function isTelegramSentinelTrue_(telegramRow) {
+  return String(telegramRow && telegramRow[TELEGRAM_SENTINEL_COL] != null ? telegramRow[TELEGRAM_SENTINEL_COL] : '')
+    .trim()
+    .toUpperCase() === 'TRUE';
 }
 
 /** PEM or raw SPKI between My Digital Signature and Request Transaction ID (DApp submit format). */
@@ -168,12 +176,13 @@ function isGovernorApproved_(approvedBy) {
 }
 
 /**
- * Inventory Movement column N (STATUS): NEW if governor or ACTIVE signer matches warehouse manager,
- * signer is a registered DAO governor, or trusted agent submission approved by a governor;
+ * Inventory Movement column N (STATUS): NEW if governor, sentinel, or ACTIVE signer matches warehouse manager,
+ * signer is a registered DAO governor/sentinel, or trusted agent submission approved by a governor;
  * unauthorized otherwise (Phase 2 skips non-NEW).
  */
 function inventoryMovementStatusFromTelegramRow_(telegramRow, contribution, warehouseManagerName) {
   if (isTelegramGovernorYes_(telegramRow)) return 'NEW';
+  if (isTelegramSentinelTrue_(telegramRow)) return 'NEW';
   const pk = extractPublicKeyFromSignedContribution_(contribution);
   if (!pk) return 'unauthorized';
   const res = findContributorNameByDigitalSignature_(pk);

--- a/google_app_scripts/1wONDeDwZ_fXNapDKpstWrBION3aV3r7NXwq7PCdqbW1LvI5ceaykQNbR/process_movement_telegram_logs.js
+++ b/google_app_scripts/1wONDeDwZ_fXNapDKpstWrBION3aV3r7NXwq7PCdqbW1LvI5ceaykQNbR/process_movement_telegram_logs.js
@@ -41,6 +41,8 @@ const LEDGER_URL_COL = 11; // Column L - Ledger URL
 
 /** Telegram Chat Logs column S (Governor): YES = global ledger authority (Edgar). 0-based index 18. */
 const TELEGRAM_GOVERNOR_COL = 18;
+/** Telegram Chat Logs column T (Is Sentinel): TRUE = AI agent with governor-equivalent operational privileges (Edgar). 0-based index 19. */
+const TELEGRAM_SENTINEL_COL = 19;
 
 function normalizeAuthName_(name) {
   return (name == null ? '' : String(name))
@@ -59,6 +61,12 @@ function isTelegramGovernorYes_(telegramRow) {
   return String(telegramRow && telegramRow[TELEGRAM_GOVERNOR_COL] != null ? telegramRow[TELEGRAM_GOVERNOR_COL] : '')
     .trim()
     .toUpperCase() === 'YES';
+}
+
+function isTelegramSentinelTrue_(telegramRow) {
+  return String(telegramRow && telegramRow[TELEGRAM_SENTINEL_COL] != null ? telegramRow[TELEGRAM_SENTINEL_COL] : '')
+    .trim()
+    .toUpperCase() === 'TRUE';
 }
 
 /** PEM or raw SPKI between My Digital Signature and Request Transaction ID (DApp submit format). */
@@ -168,12 +176,13 @@ function isGovernorApproved_(approvedBy) {
 }
 
 /**
- * Inventory Movement column N (STATUS): NEW if governor or ACTIVE signer matches warehouse manager,
+ * Inventory Movement column N (STATUS): NEW if governor, sentinel, or ACTIVE signer matches warehouse manager,
  * signer is a registered DAO governor, or trusted agent submission approved by a governor;
  * unauthorized otherwise (Phase 2 skips non-NEW).
  */
 function inventoryMovementStatusFromTelegramRow_(telegramRow, contribution, warehouseManagerName) {
   if (isTelegramGovernorYes_(telegramRow)) return 'NEW';
+  if (isTelegramSentinelTrue_(telegramRow)) return 'NEW';
   const pk = extractPublicKeyFromSignedContribution_(contribution);
   if (!pk) return 'unauthorized';
   const res = findContributorNameByDigitalSignature_(pk);


### PR DESCRIPTION
Updates the inventory movement processor to recognize the new Sentinel role:

**GAS changes:**
- Added `isTelegramSentinelTrue_()` — checks Telegram Chat Logs column T for 'TRUE'
- `inventoryMovementStatusFromTelegramRow_()` now returns 'NEW' if either column S='YES' (governor) OR column T='TRUE' (sentinel)
- Both Code.js and process_movement_telegram_logs.js updated

**SCHEMA.md:**
- Added column T (Is Sentinel) to Telegram Chat Logs schema
- Updated authorization rule: NEW if column S=YES OR column T=TRUE
- Updated implementation note: Edgar now appends 20 columns (A–T)

See also: dao_protocol PR #122 (columns S+T population)