### PR TITLE
Replace hardcoded TRUSTED_AGENTS with dynamic sentinel role check in inventory movement auth

### DIFF
--- a/google_app_scripts/1wONDeDwZ_fXNapDKpstWrBION3aV3r7NXwq7PCdqbW1LvI5ceaykQNbR/process_movement_telegram_logs.js
+++ b/google_app_scripts/1wONDeDwZ_fXNapDKpstWrBION3aV3r7NXwq7PCdqbW1LvI5ceaykQNbR/process_movement_telegram_logs.js
@@ -109,13 +109,31 @@ function findContributorNameByDigitalSignature_(digitalSignature) {
   }
 }
 
-/** Trusted agent contributor names (autopilot, etc.) that can submit on behalf of governors. */
-const TRUSTED_AGENTS = ['autopilot@agroverse.shop'];
-
-function isTrustedAgent_(contributorName) {
-  return TRUSTED_AGENTS.some(function(agent) {
-    return agent.toLowerCase() === (contributorName || '').toLowerCase();
-  });
+/**
+ * Checks if a contributor name has the Sentinel role in Contributors contact information (Column W).
+ * Sentinels (AI agents) can submit governor-approved inventory movements.
+ */
+function isSentinelByName_(contributorName) {
+  if (!contributorName) return false;
+  try {
+    var spreadsheet = SpreadsheetApp.openById(OFFCHAIN_SPREADSHEET_ID);
+    var sheet = spreadsheet.getSheetByName(CONTRIBUTORS_SHEET_NAME);
+    if (!sheet) return false;
+    var lastRow = sheet.getLastRow();
+    if (lastRow < 5) return false;
+    var data = sheet.getRange(5, 1, lastRow - 4, 23).getValues(); // A5:W(lastRow)
+    var normalizedName = String(contributorName).trim().toLowerCase();
+    for (var i = 0; i < data.length; i++) {
+      var name = String(data[i][0] || '').trim().toLowerCase();
+      if (name === normalizedName) {
+        var isSentinel = String(data[i][22] || '').trim().toUpperCase(); // Column W = index 22
+        return isSentinel === 'TRUE' || isSentinel === 'YES' || isSentinel === '1';
+      }
+    }
+  } catch (e) {
+    Logger.log('Sentinel lookup failed: ' + e.message);
+  }
+  return false;
 }
 
 /**
@@ -193,8 +211,8 @@ function inventoryMovementStatusFromTelegramRow_(telegramRow, contribution, ware
 
   if (authNamesMatch_(res.contributorName, warehouseManagerName)) return 'NEW';
 
-  // Agentic trust path: trusted agent (autopilot) + governor-approved
-  if (isTrustedAgent_(res.contributorName)) {
+  // Sentinel trust path: sentinel (AI agent) + governor-approved
+  if (isSentinelByName_(res.contributorName)) {
     const approvedBy = extractApprovedBy_(contribution);
     if (approvedBy && isGovernorApproved_(approvedBy)) return 'NEW';
   }


### PR DESCRIPTION
## What

Replaces the hardcoded `TRUSTED_AGENTS = ['autopilot@agroverse.shop']` list with a **dynamic sentinel role check** in the inventory movement authorization flow.

## Why

The hardcoded list was brittle — it didn't match Sophia's actual contributor name (`"Sophia Truesight"` or `"truesight-autopilot"`), and it required code changes to add new sentinels. Now the auth reads `Contributors contact information` Column W (`Is Sentinel`) directly, so any contributor flagged as a sentinel can submit governor-approved inventory movements.

## Changes

1. **Removed** `TRUSTED_AGENTS` constant and `isTrustedAgent_()` function
2. **Added** `isSentinelByName_(contributorName)` — reads `Contributors contact information` sheet (rows 5+, columns A and W) and returns TRUE if the contributor has `Is Sentinel = TRUE/YES/1`
3. **Replaced** the trusted agent check in `inventoryMovementStatusFromTelegramRow_` with the sentinel check

## Testing

- [x] `isSentinelByName_` follows the same pattern as `isGovernorByName_` (reads from the same spreadsheet, same error handling)
- [x] Column W index (22) matches the `DaoMembersCache.js` publisher that was already deployed and verified
- [x] The 4 sentinels in `dao_members.json` (Sophia Truesight, truesight-autopilot, Claude Anthropic, Kimi Moon) all have `Is Sentinel = TRUE` in the sheet

## Related

- PR #362 (dao_members_cache_publisher — added sentinel role to JSON)
- Plan: SENTINEL_ROLE_IMPLEMENTATION_PLAN.md