### PR TITLE
fix: read 20 columns (A–T) from Telegram Chat Logs, not 19 (A–S)

### DIFF
--- a/google_app_scripts/1wONDeDwZ_fXNapDKpstWrBION3aV3r7NXwq7PCdqbW1LvI5ceaykQNbR/Code.js
+++ b/google_app_scripts/1wONDeDwZ_fXNapDKpstWrBION3aV3r7NXwq7PCdqbW1LvI5ceaykQNbR/Code.js
@@ -935,8 +935,8 @@ function processTelegramChatLogsToInventoryMovement() {
       Logger.log('No data in Telegram Chat Logs');
       return;
     }
-    // Read through column S (19) for Edgar Governor flag (YES/NO) on Telegram Chat Logs
-    const telegramData = telegramSheet.getRange(1, 1, telegramLastRow, 19).getValues(); // Columns A–S
+    // Read through column T (20) for Edgar Governor (S) + Sentinel (T) flags on Telegram Chat Logs
+    const telegramData = telegramSheet.getRange(1, 1, telegramLastRow, 20).getValues(); // Columns A–T
 
     // Prepare array to collect new rows for batch insertion
     const newRows = [];

--- a/google_app_scripts/1wONDeDwZ_fXNapDKpstWrBION3aV3r7NXwq7PCdqbW1LvI5ceaykQNbR/process_movement_telegram_logs.js
+++ b/google_app_scripts/1wONDeDwZ_fXNapDKpstWrBION3aV3r7NXwq7PCdqbW1LvI5ceaykQNbR/process_movement_telegram_logs.js
@@ -935,8 +935,8 @@ function processTelegramChatLogsToInventoryMovement() {
       Logger.log('No data in Telegram Chat Logs');
       return;
     }
-    // Read through column S (19) for Edgar Governor flag (YES/NO) on Telegram Chat Logs
-    const telegramData = telegramSheet.getRange(1, 1, telegramLastRow, 19).getValues(); // Columns A–S
+    // Read through column T (20) for Edgar Governor (S) + Sentinel (T) flags on Telegram Chat Logs
+    const telegramData = telegramSheet.getRange(1, 1, telegramLastRow, 20).getValues(); // Columns A–T
 
     // Prepare array to collect new rows for batch insertion
     const newRows = [];


### PR DESCRIPTION
The getRange() was hardcoded to 19 columns, excluding column T (Is Sentinel). The isTelegramSentinelTrue_() check read telegramRow[19] which was always undefined. Changed to 20 columns.