### PR TITLE
Harden secret gitignore + add credential templates (Wix token leak follow-up)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,9 @@
 /venv/*
 /.env
 la_token_market_making_python/.env
+# Nested .env files anywhere (root /.env above is anchored and misses subdirectories,
+# e.g. python_scripts/schema_validation/.env which leaked once). Keep .env.example tracked.
+**/.env
 # Ignore Jupyter logs and checkpoints
 jupyter.log
 python_scripts/jupyter.log
@@ -20,6 +23,9 @@ token.json
 # Apps Script sources that embed API keys / secrets (basename contains "credential(s)")
 google_app_scripts/**/*redential*.gs
 google_app_scripts/**/Credentials.js
+# Defensive: the ".gs.js" double-extension variant slipped past the rule above once
+# (Credentials.gs.js leaked the Wix token). Catch any *Credential* .gs.js too.
+google_app_scripts/**/*redential*.gs.js
 !google_app_scripts/**/Credentials.sample.js
 
 # Schema validation output

--- a/google_app_scripts/1Y8sJ22lZuqQYS_kF_3ItMuyfiAzbJ4wRA1xGC_bGx7FPB7uLTvrUObly/Credentials.sample.js
+++ b/google_app_scripts/1Y8sJ22lZuqQYS_kF_3ItMuyfiAzbJ4wRA1xGC_bGx7FPB7uLTvrUObly/Credentials.sample.js
@@ -1,0 +1,30 @@
+/**
+ * Credentials.sample.js — Template for Credentials.js (project: agroverse_wix_site_updates)
+ * =========================================================================================
+ *
+ * Copy this file to Credentials.js and fill in the actual values.
+ * Credentials.js is gitignored (google_app_scripts/**​/Credentials.js) — never commit real secrets.
+ *
+ * This GAS project (scriptId 1Y8sJ22lZuqQYS_kF_3ItMuyfiAzbJ4wRA1xGC_bGx7FPB7uLTvrUObly,
+ * agroverse_wix_site_updates.js) pushes content updates to the Agroverse Wix site and reads
+ * on-chain data via QuickNode. It needs the two secrets below.
+ *
+ * Preferred: store the real values in Script Properties (Project Settings → Script Properties)
+ * so they never live in a source file at all; the getters below fall back to Script Properties.
+ *
+ * Usage in GAS code:
+ *   const creds = getCredentials();
+ *   const wix = creds.WIX_API_KEY;
+ */
+
+function getCredentials() {
+  return {
+    // Wix API key / access token (IST.<jwt>) — Wix headless app token for the Agroverse site.
+    // Source: Wix Dashboard → Settings → Headless / API Keys (account tenant 0e2cde5f-...).
+    WIX_API_KEY: PropertiesService.getScriptProperties().getProperty('WIX_API_KEY') || 'IST.REPLACE_ME',
+
+    // QuickNode API key — RPC endpoint auth for on-chain reads.
+    // Source: QuickNode dashboard → your endpoint → Security / API key.
+    QUICKNODE_API_KEY: PropertiesService.getScriptProperties().getProperty('QUICKNODE_API_KEY') || 'REPLACE_ME',
+  };
+}

--- a/python_scripts/schema_validation/.env.example
+++ b/python_scripts/schema_validation/.env.example
@@ -1,0 +1,6 @@
+# schema_validation — environment template
+# Copy to .env and fill in the real value. .env is gitignored (never commit secrets).
+
+# Wix API access token (IST.<jwt>) — Wix headless app token for the Agroverse account.
+# Source: Wix Dashboard → Settings → Headless / API Keys (account tenant 0e2cde5f-...).
+WIX_ACCESS_TOKEN=IST.REPLACE_ME


### PR DESCRIPTION
Follow-up to the stray-secret near-miss during the PR4 work: a `git add -A` swept two untracked secret files into a feature branch (force-removed before any merge/PR).

## Root causes
- The Apps Script secret used the `.gs.js` **double extension** (`Credentials.gs.js`), so the existing `google_app_scripts/**/Credentials.js` rule missed it.
- The root `/.env` rule is **anchored**, so nested `python_scripts/schema_validation/.env` was never ignored (the file even claimed it was).

## Changes
- Rename the stray `Credentials.gs.js` → conventional **`Credentials.js`** (now ignored by the existing rule; secrets preserved locally, untracked).
- `.gitignore`: add **`**/.env`** (nested) + defensive **`google_app_scripts/**/*redential*.gs.js`**.
- Add **`Credentials.sample.js`** for the `1Y8sJ22…` (agroverse_wix_site_updates) project — documents the `WIX_API_KEY` + `QUICKNODE_API_KEY` a fresh local setup must supply (matches the existing `Credentials.sample.js` convention).
- Add **`python_scripts/schema_validation/.env.example`** documenting `WIX_ACCESS_TOKEN`.

## Verified
- `git check-ignore`: real `Credentials.js` + `.env` are ignored; `git add -A` stages **only** `.gitignore` + the two templates.

## ⚠️ Rotation note
The leaked values (a Wix `IST.…` token + a QuickNode key) reached an unreferenced dangling commit on GitHub. Low exposure (branch never merged/PR'd, now deleted), but consider rotating the Wix token + QuickNode key to be safe.