### PR TITLE
Fix review write-back: Scored Chatlogs lookup by Col K (hash key), not Col H

### DIFF
--- a/google_app_scripts/1BHAGZd_T1I5mQnqnAFqUJKX2x_N8Uv05n1O2OohRA908Ja8wVwVxaR7K/telegram_webhook_listener.js
+++ b/google_app_scripts/1BHAGZd_T1I5mQnqnAFqUJKX2x_N8Uv05n1O2OohRA908Ja8wVwVxaR7K/telegram_webhook_listener.js
@@ -177,16 +177,17 @@ function processApprovalRejections() {
   const data = sheet.getDataRange().getValues();
   
   // Get all data from Scored Chatlogs
-  // Columns: A=Timestamp, B=Contributor Name, C=Contribution Description, D=Contribution Type,
-  // E=TDGs Provisioned, F=Status, G=TDGs Issued, H=Hash Key, I=Found in Contributors,
+  // Scored Chatlogs real columns (header row 3): A=Contributor Name, B=Project Name,
+  // C=Contribution Made, D=Rubric classification, E=TDGs Provisioned, F=Status,
+  // G=TDGs Issued, H=Status date, I=Existing Contributor, J=Reporter Name, K=Scoring Hash Key (idx 10).
   // J=Contributor Email, K=Telegram Chat Logs Row ID, L-N=other, O=Rejection Reason
   const scoredData = scoredSheet.getDataRange().getValues();
   
   // Build a map of hash_key -> { row_index, row_data } for Scored Chatlogs
-  // Hash key is in column H (index 7)
+  // Scoring Hash Key is in column K (index 10) — matches generate_review_cache.py + the transfer script.
   const scoredMap = {};
   for (let i = 0; i < scoredData.length; i++) {
-    const hashKey = String(scoredData[i][7] || '').trim();
+    const hashKey = String(scoredData[i][10] || '').trim();
     if (hashKey) {
       scoredMap[hashKey] = { index: i, data: scoredData[i] };
     }


### PR DESCRIPTION
`processApprovalRejections` (#367) built its row map keyed on `scoredData[i][7]` (**Col H = Status date**) instead of **Col K (idx 10 = Scoring Hash Key)**. Verified against the live sheet (header row 3) and consistent with `generate_review_cache.py` (`COL_HASH_KEY=10`) + the transfer script. With the wrong column, an approval's hash key matched no row ⇒ the write-back was a **silent no-op**. Write targets (F/G/O) were already correct.