### PR TITLE
fix(qr-gen): repoint serialized-QR PNG storage from archived qr_codes -> lineage-assets

### DIFF
--- a/.github/workflows/qr-code-batch-webhook.yml
+++ b/.github/workflows/qr-code-batch-webhook.yml
@@ -75,7 +75,7 @@ jobs:
     - name: Generate Batch QR Codes
       env:
         QR_CODE_REPOSITORY_TOKEN: ${{ secrets.QR_CODE_REPOSITORY_TOKEN }}
-        GITHUB_REPOSITORY: TrueSightDAO/qr_codes
+        GITHUB_REPOSITORY: TrueSightDAO/lineage-assets
         GDRIVE_KEY: ${{ secrets.GDRIVE_KEY }}
       run: |
         # Change to the agroverse_qr_code_web_service directory

--- a/agroverse_qr_code_web_service/github_webhook_handler.py
+++ b/agroverse_qr_code_web_service/github_webhook_handler.py
@@ -34,7 +34,7 @@ try:
 except ImportError:
     GITHUB_TOKEN = os.environ.get('QR_CODE_REPOSITORY_TOKEN')
 
-GITHUB_REPOSITORY = 'TrueSightDAO/qr_codes'
+GITHUB_REPOSITORY = 'TrueSightDAO/lineage-assets'  # qr_codes archived 2026-06-11; canonical PNG home is lineage-assets/pngs/ (fallback only — target repo+path are derived from column-K URL via parse_github_url)
 # Use to_upload directory for temporary file storage
 GITHUB_WORKSPACE = os.path.join(os.getcwd(), 'to_upload')
 

--- a/google_app_scripts/1N6o00N9VtRK_L3e0NQXEsmC6QME1KObZdmdbJgo0Tbgj_7P-ElNL5THn/process_qr_code_generation_telegram_logs.js
+++ b/google_app_scripts/1N6o00N9VtRK_L3e0NQXEsmC6QME1KObZdmdbJgo0Tbgj_7P-ElNL5THn/process_qr_code_generation_telegram_logs.js
@@ -29,11 +29,13 @@ const QR_GEN_TELEGRAM_MAIN_WORKBOOK_URL = 'https://docs.google.com/spreadsheets/
 const AGROVERSE_QR_SPREADSHEET_URL = 'https://docs.google.com/spreadsheets/d/1GE7PUq-UT6x2rBN-Q2ksogbWpgyuh2SaxJyG_uEK6PU/edit?gid=472328231#gid=472328231'; // Agroverse QR codes spreadsheet - PRODUCTION
 
 const CONTRIBUTORS_SIGNATURES_URL = 'https://docs.google.com/spreadsheets/d/1GE7PUq-UT6x2rBN-Q2ksogbWpgyuh2SaxJyG_uEK6PU/edit?gid=577022511#gid=577022511'; // Contributors Digital Signatures spreadsheet
-/** Public blob path for single-QR PNGs in qr_codes repo (unique name vs qr_code_generator.gs in multi-file deployments). */
-const QR_GEN_TELEGRAM_GITHUB_BLOB_BASE_URL = 'https://github.com/TrueSightDAO/qr_codes/blob/main/'; // GitHub repository URL
-const ZIP_FILE_DOWNLOAD_BASE_URL = 'https://raw.githubusercontent.com/TrueSightDAO/qr_codes/main/batch_files/'; // Base URL for zip file downloads
+/** Public blob path for serialized-QR PNGs. Canonical home is lineage-assets/pngs/ (qr_codes was
+ *  archived/read-only 2026-06-11; uploads there 403'd). The batch workflow derives the upload repo+path
+ *  from this column-K URL via parse_github_url, so this constant is the single source of truth. */
+const QR_GEN_TELEGRAM_GITHUB_BLOB_BASE_URL = 'https://github.com/TrueSightDAO/lineage-assets/blob/main/pngs/'; // GitHub repository URL
+const ZIP_FILE_DOWNLOAD_BASE_URL = 'https://raw.githubusercontent.com/TrueSightDAO/lineage-assets/main/batch_files/'; // Base URL for zip file downloads
 /** Commits that add batch zips land in this repo (not the tokenomics dispatch repo) */
-const QR_CODES_ZIP_GITHUB_REPO = 'TrueSightDAO/qr_codes';
+const QR_CODES_ZIP_GITHUB_REPO = 'TrueSightDAO/lineage-assets';
 const QR_CODES_ZIP_BATCH_PREFIX = 'batch_files/';
 
 // Tab names


### PR DESCRIPTION
## Goal
Fix QR PNG generation, silently failing since 2026-06-11. Surfaced while verifying the Edgar→GAS batch-QR hook end-to-end.

## Root cause
`TrueSightDAO/qr_codes` was **archived (read-only) 2026-06-11**, but the batch QR workflow still uploads compiled PNGs there → every run 403s (`Repository was archived so is read-only`). The QR row mints in the sheet (MINTED) but no PNG is produced. Canonical serialized-QR home is now `lineage-assets/pngs/` (per `QR_GENERATION_DAO_CLIENT_POSTMORTEM.md`; `truesight.me/physical-assets/serialized` reads `lineage-assets`).

## Changes
The workflow derives the upload repo+path from the **column-K URL** (`parse_github_url`), so the GAS constant is the single source of truth:
- **GAS `1N6o00`** — `QR_GEN_TELEGRAM_GITHUB_BLOB_BASE_URL` → `lineage-assets/blob/main/pngs/`; `ZIP_FILE_DOWNLOAD_BASE_URL` + `QR_CODES_ZIP_GITHUB_REPO` → `lineage-assets`.
- **`.github/workflows/qr-code-batch-webhook.yml`** — `GITHUB_REPOSITORY` default → `lineage-assets`.
- **`github_webhook_handler.py`** — `GITHUB_REPOSITORY` fallback → `lineage-assets`.

## Testing
`workflow_dispatch` on row 1611 (`2024_20260622_22`, minted through the live Edgar pipeline): target resolves to `TrueSightDAO/lineage-assets`, PNG renders correctly (59 KB, correct labels). `node --check` + `py_compile` pass.

## ⚠️ Remaining blocker (account-owner action — NOT in this PR)
Upload then fails with a different error: `403 "Resource not accessible by personal access token"`. `QR_CODE_REPOSITORY_TOKEN` is a fine-grained PAT scoped to `qr_codes` with no write on `lineage-assets`. **Fix:** grant that PAT `Contents: Read and write` on `TrueSightDAO/lineage-assets` (or replace the secret). Then re-running generation completes the PNG.

## Follow-up (separate)
Workflow emits only the PNG — not `qrs/<id>.json` + `qrs_index.json` rebuild — so workflow-generated QRs won't show on `truesight.me/physical-assets/serialized` until added (or unify on `batch_compiler.py`). Filed in `OPEN_FOLLOWUPS.md`.

## Rollout
After merge, deploy the GAS const via clasp (redeploy existing `AKfycbxn3siu…`). Until the token is granted lineage-assets write, new QR rows carry correct `lineage-assets` col-K URLs but PNGs won't upload.

Generated-by: Claude Code