### PR TITLE
Review approve: persist reviewer-selected contributor to Col A (resolves RESOLVE FAILED rows)

### DIFF
--- a/google_app_scripts/1BHAGZd_T1I5mQnqnAFqUJKX2x_N8Uv05n1O2OohRA908Ja8wVwVxaR7K/telegram_webhook_listener.js
+++ b/google_app_scripts/1BHAGZd_T1I5mQnqnAFqUJKX2x_N8Uv05n1O2OohRA908Ja8wVwVxaR7K/telegram_webhook_listener.js
@@ -270,6 +270,13 @@ function processApprovalRejections() {
     const actionUpper = action.toUpperCase();
     
     if (actionUpper === 'APPROVE') {
+      // Correct the contributor (Col A, column 1) to the reviewed name when the event provides
+      // one. This is what resolves a RESOLVE FAILED / FALSE row: the reviewer-selected name is
+      // written back so the transfer script can validate it against Contributors. For an
+      // already-resolved row the provided name equals Col A, so this is a safe no-op.
+      if (reviewContributor) {
+        scoredSheet.getRange(scoredRowIndex + 1, 1).setValue(reviewContributor);
+      }
       // Update Status to Reviewed (Col F, index 5)
       scoredSheet.getRange(scoredRowIndex + 1, 6).setValue('Reviewed');
       // Update TDGs Issued (Col G, index 6)


### PR DESCRIPTION
RESOLVE FAILED / FALSE rows surface for review and the page offers a contributor dropdown, but the approve write-back only set Col F + Col G — the selected contributor was used to match the row but **never written to Col A**. So Col A stayed unresolved and the transfer script then errored with `Entry Error - Contributor Not Found`.

Fix: on Approve, when the event carries a `Contributor Name`, write it to **Col A**. Safe no-op for already-resolved rows (the provided name equals Col A).

Governance note: the contributor written here is who receives the TDG, so reviewers must select the correct contributor from evidence, not guess.