### PR TITLE
fix(qr-gen): repoint batch-zip upload off archived qr_codes -> lineage-assets

### DIFF
--- a/agroverse_qr_code_web_service/batch_webhook_handler.py
+++ b/agroverse_qr_code_web_service/batch_webhook_handler.py
@@ -245,7 +245,7 @@ class BatchWebhookHandler:
                 qr_code_value=zip_file_name.replace('.zip', ''),
                 qr_image_path=zip_file_path,
                 commit_message=f"Add batch QR codes zip file: {zip_file_name} [skip ci]",
-                target_repo='TrueSightDAO/qr_codes',
+                target_repo='TrueSightDAO/lineage-assets',  # qr_codes archived 2026-06-11
                 target_path=f'batch_files/{zip_file_name}'
             )
             


### PR DESCRIPTION
Follow-up to #373. The per-PNG upload was repointed via the column-K URL, but `batch_webhook_handler.upload_zip_file()` had `target_repo='TrueSightDAO/qr_codes'` **hardcoded**, so the batch-zip step still 403'd ("Repository was archived"). 

Verified the PNG now lands at `lineage-assets/pngs/2024_20260622_22.png` (HTTP 200) after #373 + the CI token fix; this one-liner fixes the remaining zip step so the whole workflow run goes green.

Generated-by: Claude Code