### PR TITLE
[autopilot] The `action=triggerSync` endpoint in the GAS web app (`doGet

### DIFF
--- a/google_app_scripts/1ZQjgSZvAXL2PB3e3YW289xY7Ork4S5wV4uKTXJyw83xQT4R0lh_hwNWn/tdg_wix_dashboard.js
+++ b/google_app_scripts/1ZQjgSZvAXL2PB3e3YW289xY7Ork4S5wV4uKTXJyw83xQT4R0lh_hwNWn/tdg_wix_dashboard.js
@@ -1996,6 +1996,37 @@ function doGet(e) {
         .setMimeType(ContentService.MimeType.JSON);
     }
 
+    if (type === 'sync_treasury' || type === 'sync-treasury') {
+      // Lightweight sync of just USD_TREASURY_BALANCE to the Performance
+      // Statistics sheet. Uses the same formula as syncAllPerformanceStatistics()
+      // (off-chain assets + USDT vault + AGL investment holdings) but skips
+      // all other stats — avoids the 30s GAS timeout that full sync hits
+      // when iterating all AGL ledgers for sales data.
+      //
+      // Returns the new value as JSON so the caller (e.g. landing page
+      // backend) can confirm the write succeeded.
+      var offChain = getOffChainAssetValue();
+      var usdtVault = getUSDTBalanceInVault();
+      var aglEquity = getInvestmentHoldingsInAGL();
+      var treasuryBalance = offChain + usdtVault + aglEquity;
+      updatePerformanceStatistic("USD_TREASURY_BALANCE", treasuryBalance, "USD");
+      // Also warm the treasury breakdown cache so /treasury stays fast
+      var breakdown = computeTreasuryBreakdown();
+      cacheTreasuryBreakdown(breakdown);
+      return ContentService.createTextOutput(JSON.stringify({
+        timestamp: new Date().toISOString(),
+        status: 'ok',
+        stat: 'USD_TREASURY_BALANCE',
+        value: treasuryBalance,
+        components: {
+          off_chain_assets_usd: offChain,
+          usdt_vault_usd: usdtVault,
+          agl_equity_usd: aglEquity
+        },
+        note: 'Only USD_TREASURY_BALANCE was synced (lightweight). Use action=triggerSync for a full sync of all stats.'
+      })).setMimeType(ContentService.MimeType.JSON);
+    }
+
     if (type === 'recalculate_aum') {
       // Operator escape hatch: trigger calculateAUM() out-of-band AND
       // overwrite the Performance Statistics 'AUM' cell (the same thing

--- a/google_app_scripts/1rLl94jQ9tDYdRvudnP0prPY5SEjvM07R4gPs6-vRyZEpSJhUqbiE3CZY/tdg_wix_dashboard.js
+++ b/google_app_scripts/1rLl94jQ9tDYdRvudnP0prPY5SEjvM07R4gPs6-vRyZEpSJhUqbiE3CZY/tdg_wix_dashboard.js
@@ -2294,6 +2294,37 @@ function doGet(e) {
         .setMimeType(ContentService.MimeType.JSON);
     }
 
+    if (type === 'sync_treasury' || type === 'sync-treasury') {
+      // Lightweight sync of just USD_TREASURY_BALANCE to the Performance
+      // Statistics sheet. Uses the same formula as syncAllPerformanceStatistics()
+      // (off-chain assets + USDT vault + AGL investment holdings) but skips
+      // all other stats — avoids the 30s GAS timeout that full sync hits
+      // when iterating all AGL ledgers for sales data.
+      //
+      // Returns the new value as JSON so the caller (e.g. landing page
+      // backend) can confirm the write succeeded.
+      var offChain = getOffChainAssetValue();
+      var usdtVault = getUSDTBalanceInVault();
+      var aglEquity = getInvestmentHoldingsInAGL();
+      var treasuryBalance = offChain + usdtVault + aglEquity;
+      updatePerformanceStatistic("USD_TREASURY_BALANCE", treasuryBalance, "USD");
+      // Also warm the treasury breakdown cache so /treasury stays fast
+      var breakdown = computeTreasuryBreakdown();
+      cacheTreasuryBreakdown(breakdown);
+      return ContentService.createTextOutput(JSON.stringify({
+        timestamp: new Date().toISOString(),
+        status: 'ok',
+        stat: 'USD_TREASURY_BALANCE',
+        value: treasuryBalance,
+        components: {
+          off_chain_assets_usd: offChain,
+          usdt_vault_usd: usdtVault,
+          agl_equity_usd: aglEquity
+        },
+        note: 'Only USD_TREASURY_BALANCE was synced (lightweight). Use action=triggerSync for a full sync of all stats.'
+      })).setMimeType(ContentService.MimeType.JSON);
+    }
+
     if (type === 'recalculate_aum') {
       // Operator escape hatch: trigger calculateAUM() out-of-band AND
       // overwrite the Performance Statistics 'AUM' cell (the same thing


### PR DESCRIPTION
## Autopilot Fix

**Issue:** The `action=triggerSync` endpoint in the GAS web app (`doGet`) calls `syncAllPerformanceStatistics()` which times out via HTTP (exceeds GAS 30s limit) because it iterates all AGL ledgers. 

The `USD_TREASURY_BALANCE` in the Performance Statistics sheet can't be refreshed remotely, causing the landing page (which reads from the sheet) to show stale data vs the `/treasury/` page (which computes live).

Fix: Add a `?type=sync_treasury` parameter to `doGet` that:
1. Calls `getOffChainAssetValue() + getUSDTBalanceInVault() + getInvestmentHoldingsInAGL()` (same formula as `syncAllPerformanceStatistics`)
2. Calls `updatePerformanceStatistic("USD_TREASURY_BALANCE", treasuryBalance, "USD")` to write it to the sheet
3. Returns the new value as JSON

This is much lighter than the full `syncAllPerformanceStatistics()` because it only updates one stat. If it still times out, we can further optimize by accepting the pre-computed value from the `?type=treasury_breakdown` response and just writing it to the sheet.

**Branch:** `autopilot/fix-1784142762`

---

This PR was generated by [truesight_autopilot](https://github.com/TrueSightDAO/truesight_autopilot). Please review before merging.