### PR TITLE
Add HTS Code column (US customs) to Currencies sheet + document in SCHEMA.md

### DIFF
--- a/SCHEMA.md
+++ b/SCHEMA.md
@@ -1242,6 +1242,43 @@ See [`python_scripts/schema_validation/README.md`](./python_scripts/schema_valid
 
 ---
 
+##### Sheet: `Currencies`
+**Purpose:** Master catalog of all currencies (products, ingredients, packaging, and raw materials) tracked by the DAO. Each row is a distinct SKU / inventory item with its unit cost, physical properties, and customs codes.
+
+**Sheet URL:** https://docs.google.com/spreadsheets/d/1GE7PUq-UT6x2rBN-Q2ksogbWpgyuh2SaxJyG_uEK6PU/edit#gid=0
+
+**Header Row:** 1
+
+| Column | Name | Type | Description |
+|--------|------|------|-------------|
+| A | Currencies | String | Item / product name |
+| B | Price in USD | Number | Unit cost in USD |
+| C | Serializable | String | Whether the item is serialized (TRUE / blank) |
+| D | Product Image | String | URL to product image |
+| E | landing_page | String | Landing page URL |
+| F | ledger | String | Associated ledger URL |
+| G | farm name | String | Source farm name |
+| H | state | String | State/region of origin |
+| I | country | String | Country of origin |
+| J | Year | String | Harvest year |
+| K | Unit Weight (grams) | Number | Weight per unit in grams |
+| L | Unit Weight (ounces) | Number | Weight per unit in ounces |
+| M | SKU Product ID | String | Product SKU identifier |
+| N | Raw request text | String | Original repackaging / creation request |
+| O | Composition JSON | String | URL to composition breakdown JSON |
+| P | Inventory Type | String | Inventory category (e.g. "Cacao Nib", "Chocolate Bar", "Cacao Bean", "Bulk") |
+| Q | Sale Type | String | Sale type (e.g. "Retail Ready", "Bulk") |
+| R | GTIN | String | Global Trade Item Number (barcode) |
+| S | HS Code | String | International Harmonized System code (6-digit) |
+| T | HTS Code | String | US Harmonized Tariff Schedule code (8–10 digit, includes statistical suffix for US customs) |
+
+**Used by:**
+- Product and pricing management
+- [`tdg_inventory_management/web_app.gs`](https://github.com/TrueSightDAO/tokenomics/blob/main/google_app_scripts/tdg_inventory_management/web_app.gs) — `getCurrenciesUnitCostMap_()` reads column A + column B
+- Repackaging and inventory scripts
+
+---
+
 ##### Sheet: `Contributor Staking`
 **Purpose:** Tracks TDG staking by contributors
 


### PR DESCRIPTION
## What

1. **New column T — `HTS Code`** in the **Currencies** sheet: the US-specific Harmonized Tariff Schedule code (8–10 digits), distinct from the international HS Code in column S.
2. **Added the missing Currencies sheet section** to SCHEMA.md with full column documentation including the new HTS Code column.

## Why

The existing **HS Code** column (column S) holds the international 6-digit Harmonized System code. US customs requires the longer **HTS code** (Harmonized Tariff Schedule) with statistical suffixes for import declarations. We need both tracked separately.

## Existing HS codes on the sheet

- `1801` — cacao beans/nibs (row 10)
- `1806.32` — chocolate bars (rows 18–19)

The corresponding HTS codes would be `1801.00.0000` and `1806.32.0000` respectively, but these need to be filled in by the operator.

## Manual step needed

Add the **"HTS Code"** header to **Currencies!T1** in the main ledger spreadsheet (`1GE7PUq-...`). The SCHEMA.md now documents this column.