### PR TITLE
sync(1ovx): commit live agroverse_shop_checkout.js from production clasp pull

### DIFF
--- a/google_app_scripts/1ovx-Hq5L5MgzF32qB_cPV_G5Hc6XshKMAYOmiJY8tZ355gzWUqvFCPvn/Version.gs
+++ b/google_app_scripts/1ovx-Hq5L5MgzF32qB_cPV_G5Hc6XshKMAYOmiJY8tZ355gzWUqvFCPvn/Version.gs
@@ -17,6 +17,7 @@ var CLASP_MIRROR_LAST_CLASP_PUSH_UTC = '2026-05-11T03:30:00Z';
  * Newest first. Keep lines short; link PRs/commits in git instead of pasting secrets.
  */
 var CLASP_MIRROR_CHANGELOG =
+  '2026-08-16 — SYNC (live→repo): committed production clasp pull (agroverse_shop_checkout.js + create_subscription_checkout_session.js); removed stale placeholder Code.js + old .gs. Subscription renewal sync (invoice.paid) now mirrored in git.\n' +
   '2026-05-11 — Added createLedgerCheckoutSession (generic [LEDGER_ID]-prefixed Stripe Checkout for any managed ledger; first user: capoeira.agroverse.shop → TBM). See agentic_ai_context/STRIPE_LEDGER_ROUTING.md Flow 4.\n' +
   '2026-04-12 — Added default Version.gs for clasp deploy audit trail (tokenomics).\n';
 


### PR DESCRIPTION
## What

Live→repo sync of the production GAS script (scriptId `1ovx-Hq5L5MgzF32qB_cPV_G5Hc6XshKMAYOmiJY8tZ355gzWUqvFCPvn`).

The deployed webhook engine (`agroverse_shop_checkout.js`, 4497 lines) and live `create_subscription_checkout_session.js` were pulled via `clasp pull` on 2026-08-16 — they were never committed to git.

## Includes (production subscription renewal feature)

- `invoice.paid` webhook branch → `saveSubscriptionPaymentToSheet()`
- `retrievePaidSubscriptionInvoices()` poller (`/v1/invoices?status=paid`, 7-day lookback)
- Dedup by Invoice ID (col 17/R) and Payment Intent ID (col 18/S)
- `ensureSubscriptionColumns_()` adds R/S/T headers
- Column T = `subscription_renewal`

## Removes stale mirror files (would break future clasp push)

- `Code.js` — placeholder text, not valid JS (0 lines)
- `create_subscription_checkout_session.gs` — older .gs duplicate of the live .js

## Safety

This is a **live→repo sync ONLY. No redeploy.** Pushing from this mirror folder is now safe and matches production exactly.