### PR TITLE
feat(1ovx): send email notification to garyjob@agroverse.shop for subscription renewal payments

### DIFF
--- a/google_app_scripts/1ovx-Hq5L5MgzF32qB_cPV_G5Hc6XshKMAYOmiJY8tZ355gzWUqvFCPvn/Version.gs
+++ b/google_app_scripts/1ovx-Hq5L5MgzF32qB_cPV_G5Hc6XshKMAYOmiJY8tZ355gzWUqvFCPvn/Version.gs
@@ -17,6 +17,7 @@ var CLASP_MIRROR_LAST_CLASP_PUSH_UTC = '2026-05-11T03:30:00Z';
  * Newest first. Keep lines short; link PRs/commits in git instead of pasting secrets.
  */
 var CLASP_MIRROR_CHANGELOG =
+  '2026-08-16 — ADD: sendSubscriptionRenewalNotificationEmail in saveSubscriptionPaymentToSheet; renewal payments now email garyjob@agroverse.shop (invoice.paid flow).\n' +
   '2026-08-16 — SYNC (live→repo): committed production clasp pull (agroverse_shop_checkout.js + create_subscription_checkout_session.js); removed stale placeholder Code.js + old .gs. Subscription renewal sync (invoice.paid) now mirrored in git.\n' +
   '2026-05-11 — Added createLedgerCheckoutSession (generic [LEDGER_ID]-prefixed Stripe Checkout for any managed ledger; first user: capoeira.agroverse.shop → TBM). See agentic_ai_context/STRIPE_LEDGER_ROUTING.md Flow 4.\n' +
   '2026-04-12 — Added default Version.gs for clasp deploy audit trail (tokenomics).\n';

--- a/google_app_scripts/1ovx-Hq5L5MgzF32qB_cPV_G5Hc6XshKMAYOmiJY8tZ355gzWUqvFCPvn/agroverse_shop_checkout.js
+++ b/google_app_scripts/1ovx-Hq5L5MgzF32qB_cPV_G5Hc6XshKMAYOmiJY8tZ355gzWUqvFCPvn/agroverse_shop_checkout.js
@@ -3082,8 +3082,66 @@ function saveSubscriptionPaymentToSheet(invoice, subscription, originalSessionId
 
     sheet.appendRow(row);
     Logger.log('Subscription renewal saved: invoice ' + invoice.id + ' for ' + customerName + ' $' + totalAmount.toFixed(2));
+
+    // Send notification email to admin (non-critical - order is already saved)
+    try {
+      sendSubscriptionRenewalNotificationEmail(invoice, customerName, customerEmail, itemsPurchased, totalQuantity, totalAmount, shippingCost, currency, originalSessionId);
+    } catch (emailError) {
+      Logger.log('Error sending subscription renewal notification email (non-critical): ' + emailError.toString());
+    }
   } catch (error) {
     Logger.log('Error saving subscription payment: ' + error.toString());
+    throw error;
+  }
+}
+
+/**
+ * Send email notification to admin for a subscription renewal payment.
+ */
+function sendSubscriptionRenewalNotificationEmail(invoice, customerName, customerEmail, itemsPurchased, totalQuantity, amountTotal, shippingCost, currency, originalSessionId) {
+  try {
+    var currencySymbol = currency === 'USD' ? '$' : (currency + ' ');
+    var paymentDate = new Date(invoice.created * 1000).toLocaleString();
+
+    var subject = 'Subscription Renewal: ' + customerName + ' - ' + currencySymbol + amountTotal.toFixed(2);
+
+    var body = 'Subscription renewal payment received!\n\n' +
+      '=== PAYMENT DETAILS ===\n' +
+      'Payment Date: ' + paymentDate + '\n' +
+      'Invoice ID: ' + invoice.id + '\n' +
+      'Payment Intent ID: ' + (invoice.payment_intent || 'N/A') + '\n' +
+      'Original Checkout Session: ' + (originalSessionId || 'N/A') + '\n' +
+      'Payment Status: ' + (invoice.status || 'N/A') + '\n\n' +
+
+      '=== CUSTOMER INFORMATION ===\n' +
+      'Name: ' + customerName + '\n' +
+      'Email: ' + customerEmail + '\n\n' +
+
+      '=== ORDER ITEMS ===\n' +
+      itemsPurchased + '\n' +
+      'Total Quantity: ' + totalQuantity + '\n\n' +
+
+      '=== PRICING BREAKDOWN ===\n' +
+      'Subtotal: ' + currencySymbol + (amountTotal - shippingCost).toFixed(2) + '\n' +
+      'Shipping: ' + currencySymbol + shippingCost.toFixed(2) + '\n' +
+      'Total: ' + currencySymbol + amountTotal.toFixed(2) + '\n\n' +
+
+      '=== LINKS ===\n' +
+      'Invoice: https://dashboard.stripe.com/invoices/' + invoice.id + '\n' +
+      'Payment: https://dashboard.stripe.com/payments/' + (invoice.payment_intent || '') + '\n\n' +
+
+      '---\n' +
+      'This is an automated notification from Agroverse Shop.';
+
+    MailApp.sendEmail({
+      to: 'garyjob@agroverse.shop',
+      subject: subject,
+      body: body
+    });
+
+    Logger.log('Subscription renewal notification email sent to garyjob@agroverse.shop');
+  } catch (error) {
+    Logger.log('Error sending subscription renewal notification email: ' + error.toString());
     throw error;
   }
 }


### PR DESCRIPTION
## What
Adds an admin email notification whenever a subscription renewal payment lands on the Stripe Social Media Checkout ID ledger tab (the `invoice.paid` flow).

## Why
One-time checkout orders already fire `sendOrderNotificationEmail` → `MailApp.sendEmail` to garyjob@agroverse.shop. Subscription renewals (e.g. Linda Ford's Aug 12 $70.80) were written to the ledger silently — no email. This closes that gap so future renewals notify the admin.

## Changes
- `agroverse_shop_checkout.js`:
  - `saveSubscriptionPaymentToSheet` now calls `sendSubscriptionRenewalNotificationEmail(...)` after `sheet.appendRow(row)` (non-critical, wrapped in try/catch so a mail failure never blocks the ledger write)
  - New `sendSubscriptionRenewalNotificationEmail(invoice, customerName, customerEmail, itemsPurchased, totalQuantity, amountTotal, shippingCost, currency, originalSessionId)` — sends to garyjob@agroverse.shop with payment date, invoice ID, payment intent ID, original checkout session, items, pricing breakdown, and Stripe dashboard links
- `Version.gs`: changelog entry added

## Testing
- `node --check` passes on the modified JS
- No deploy performed in this PR — deploy happens via clasp after merge (per Gary's approval)